### PR TITLE
feat: add blog section and publish Why Contract Coverage article

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,8 @@ GitHub Pages deployment via `.github/workflows/deploy-gh-pages.yml`:
 ## Active Technologies
 - Hugo (via npm/thulite) + Go 1.23 (module resolution) + Node.js >= 20.11.0 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1` (001-site-scaffold)
 - N/A (static site, no database) (001-site-scaffold)
+- Hugo (via npm/thulite) + Go 1.23 + Node.js >= 20.11.0 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1` (003-blog-why-gaze)
+- N/A (static site, Markdown files) (003-blog-why-gaze)
 
 ## Recent Changes
 - 001-site-scaffold: Added Hugo (via npm/thulite) + Go 1.23 (module resolution) + Node.js >= 20.11.0 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1`

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -54,6 +54,7 @@ copyRight = "Copyright (c) 2025-2026 Unbound Force"
 
 [permalinks]
   docs = "/docs/:sections[1:]/:slug/"
+  blog = "/blog/:slug/"
 
 [minify.tdewolff.html]
   keepWhitespace = false

--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -23,6 +23,11 @@
   url = "/docs/contributing/"
 
 [[main]]
+  name = "Blog"
+  url = "/blog/"
+  weight = 5
+
+[[main]]
   name = "GitHub"
   url = "https://github.com/unbound-force"
   weight = 10

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -4,7 +4,7 @@ description = "The AI Agent Swarm for Software Engineering. Purpose-built agent 
 images = ["favicon-512x512.png"]
 
 # mainSections
-mainSections = ["docs"]
+mainSections = ["docs", "blog"]
 
 [social]
   github = "unbound-force"

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Blog"
+description: "Technical articles and insights from the Unbound Force project."
+lead: ""
+date: 2026-02-27T00:00:00+00:00
+draft: false
+weight: 1
+toc: false
+---

--- a/content/blog/why-contract-coverage.md
+++ b/content/blog/why-contract-coverage.md
@@ -1,0 +1,182 @@
+---
+title: "Why Contract Coverage: How Gaze Redefines What It Means to Have Good Tests"
+description: "Line coverage tells you what code ran, not what was verified. Contract Coverage measures whether tests check what functions are actually responsible for."
+lead: "Line coverage tells you what code ran. Contract Coverage tells you what was verified."
+slug: "why-contract-coverage"
+date: 2026-02-27T00:00:00+00:00
+draft: false
+weight: 100
+toc: true
+categories: ["Engineering"]
+tags: ["gaze", "testing", "go", "static-analysis"]
+contributors: ["Unbound Force"]
+---
+
+## The Problem with Line Coverage
+
+Most teams gate their CI pipelines on line coverage. The metric is simple: what percentage of your code was executed during tests? But execution is not verification. A test suite can achieve 90% line coverage without containing a single meaningful assertion — every function runs, but nothing checks whether the results are correct.
+
+This is not a theoretical concern. Research by Zhang and Mesbah analyzing 6,700 test suites across major open-source Java projects found that assertion coverage — the fraction of code whose output is actually evaluated by an assertion — is the strongest predictor of fault-detection effectiveness, far more than line or branch coverage alone. Separate work on "checked coverage" (which traces backward from assertions to the code that influenced them) has shown that a codebase boasting 85% statement coverage can have as little as 20% checked coverage. The gap between "code that ran" and "code whose behavior was verified" is enormous.
+
+Line coverage creates two additional problems:
+
+**It punishes refactoring.** When you restructure internal logic — extract a helper, merge functions, optimize an algorithm — line coverage numbers shift even if external behavior is unchanged. Worse, tests that assert on implementation details (mock call counts, internal method invocations, intermediate state) break on every refactor, even when the function still does exactly what it is supposed to do.
+
+**It incentivizes the wrong behavior.** When teams are told to raise coverage by 10%, the easiest path is writing assertion-free tests that exercise code paths without checking outcomes. The coverage number goes up. Confidence in the test suite should not.
+
+## What Gaze Measures Instead
+
+Gaze introduces **Contract Coverage**: the ratio of a function's _design responsibilities_ that its tests actually verify.
+
+```
+Contract Coverage = contractual side effects asserted on / total contractual side effects
+```
+
+The key insight is that not every observable effect of a function matters equally. Some effects are the reason the function exists — its contractual obligations to the rest of the system. Others are implementation details that could change during a refactor without affecting correctness. Gaze distinguishes between them.
+
+### The Pipeline
+
+Gaze operates as a static analysis tool for Go. Its core side effect detection and contract classification require no test execution — they work entirely from source code. (The `crap` subcommand can optionally invoke `go test -coverprofile` to generate line coverage data for the traditional CRAP formula, but the contract analysis itself is purely static.)
+
+Gaze works in three stages:
+
+1. **Side Effect Detection.** Gaze analyzes a function's AST and SSA representation to enumerate every observable side effect: return values, error returns, pointer mutations, file I/O, database writes, channel operations, goroutine spawns, logging, and more — organized into a 5-tier taxonomy (P0 through P4) covering 38 distinct effect types.
+
+2. **Contract Classification.** Each detected side effect is classified as _contractual_ (part of the function's design responsibility), _incidental_ (implementation detail), or _ambiguous_. Classification uses deterministic mechanical signals — interface satisfaction, caller dependency analysis within the module, exported API surface visibility, naming conventions, and godoc comments — each contributing a weighted score to a 0-100 confidence value. Optionally, an external workflow using OpenCode agents can analyze project documentation (architecture docs, specs, READMEs) to refine classification confidence further — this is not a built-in feature of the Gaze binary, but a supplementary process that feeds refined classifications back into the analysis.
+
+3. **Assertion Mapping.** Gaze maps each test assertion back to the side effect it verifies, then computes the ratio. It also computes an **Over-Specification Score**: the count of _incidental_ side effects the test asserts on. These are the assertions that will break during a refactor even when the function's contract is preserved.
+
+### What This Gets You
+
+- **Contract Coverage** tells you whether the test verifies what the function is _supposed to do_. A score of 100% means every contractual obligation is checked. A score of 50% means half of the function's responsibilities are unguarded.
+
+- **Over-Specification Score** tells you how fragile the test is. A score of 0 means the test only asserts on contractual effects — it will survive any refactor that preserves behavior. A score of 3 means three assertions are tied to implementation details and will break when internals change.
+
+Neither metric cares how many lines of code were executed.
+
+## A Concrete Example
+
+Consider a Go function:
+
+```go
+func SaveUser(ctx context.Context, db *sql.DB, user *User) error {
+    log.Printf("saving user %s", user.ID)
+
+    _, err := db.ExecContext(ctx, "INSERT INTO users ...", user.Name, user.Email)
+    if err != nil {
+        return fmt.Errorf("save user: %w", err)
+    }
+
+    go invalidateCache(user.ID)
+
+    return nil
+}
+```
+
+Gaze detects four side effects:
+
+| Side Effect                     | Type          | Classification |
+| ------------------------------- | ------------- | -------------- |
+| Return `nil` on success         | ReturnValue   | Contractual    |
+| Return wrapped error on failure | ErrorReturn   | Contractual    |
+| Database INSERT                 | DatabaseWrite | Contractual    |
+| Log message                     | LogWrite      | Incidental     |
+
+The goroutine spawn and log write are implementation details — the system's callers depend on the database write happening and the error being returned, not on whether a log line was emitted or how cache invalidation is scheduled internally.
+
+**Scenario A:** The test checks the error return and queries the database to verify the row exists.
+
+- Contract Coverage: **100%** (3/3 contractual effects verified)
+- Over-Specification: **0**
+
+**Scenario B:** The test only checks `err == nil`.
+
+- Contract Coverage: **33%** (1/3 — the database write and success return are unverified)
+- Over-Specification: **0**
+
+**Scenario C:** The test checks `err == nil` and also asserts on the log output.
+
+- Contract Coverage: **33%** (still 1/3 contractual)
+- Over-Specification: **1** (the log assertion will break if you change the log format or remove logging)
+
+Line coverage would report the same number for all three scenarios. Contract Coverage reveals that Scenario B and C are dangerously undertested, and that Scenario C is also brittle.
+
+### CRAP vs GazeCRAP
+
+Gaze also computes composite risk scores. The industry-standard CRAP formula combines cyclomatic complexity with line coverage:
+
+```
+CRAP(m) = complexity^2 * (1 - lineCoverage/100)^3 + complexity
+```
+
+Gaze introduces **GazeCRAP**, which substitutes contract coverage for line coverage:
+
+```
+GazeCRAP(m) = complexity^2 * (1 - contractCoverage/100)^3 + complexity
+```
+
+For `SaveUser` with complexity 5:
+
+| Metric   | Scenario A (100% contract cov, 90% line cov) | Scenario B (33% contract cov, 90% line cov) |
+| -------- | -------------------------------------------- | ------------------------------------------- |
+| CRAP     | 5.0                                          | 5.0                                         |
+| GazeCRAP | 5.0                                          | 12.5                                        |
+
+Traditional CRAP says both scenarios look safe. GazeCRAP reveals that Scenario B carries real risk — the function is complex enough to matter, and its contractual obligations are mostly unverified.
+
+Gaze classifies functions into four quadrants based on both scores:
+
+- **Q1 — Safe:** Low CRAP, low GazeCRAP. Simple and well-tested.
+- **Q2 — Complex but contract-tested:** High CRAP, low GazeCRAP. May benefit from refactoring, but tests are solid.
+- **Q3 — Simple but under-specified:** Low CRAP, high GazeCRAP. Easy to fix — just add the missing contractual assertions.
+- **Q4 — Dangerous:** High CRAP _and_ high GazeCRAP. Complex code with tests that don't verify its responsibilities. Highest priority.
+
+## How Gaze Differs from Existing Approaches
+
+| Approach                        | What It Measures                       | Refactoring Resilience                | Runtime Cost                                                         | Scope                   |
+| ------------------------------- | -------------------------------------- | ------------------------------------- | -------------------------------------------------------------------- | ----------------------- |
+| **Line/Branch Coverage**        | Code execution paths                   | Low — shifts on any structural change | Low (instrumentation)                                                | Unit level              |
+| **Mutation Testing**            | Assertion strength via fault injection | Moderate-High — validates post-facto  | High (recompile per mutant)                                          | Unit level              |
+| **Checked Coverage**            | Dynamic backward slice from assertions | Moderate — traces data flow           | High (execution tracing)                                             | Unit level              |
+| **API Contract Testing (Pact)** | Network boundary agreements            | High — decoupled from internals       | Low                                                                  | Service boundaries only |
+| **Gaze Contract Coverage**      | Design responsibility verification     | High — anchored to role, not code     | None for contract analysis; optional test execution for CRAP scoring | Unit level              |
+
+Key differentiators:
+
+- **Static at its core.** Gaze's side effect detection and contract classification analyze source code without running tests — no runtime overhead, no instrumentation, no recompilation. The `crap` subcommand can optionally run `go test` to collect line coverage data for the traditional CRAP formula, but the contract analysis pipeline itself is purely static. Gaze works alongside your existing test runner.
+
+- **Proactive, not reactive.** Mutation testing validates assertion strength by injecting faults _after_ tests exist. Gaze establishes what the assertions _should_ cover based on the function's design role, identifying gaps before they become escaped defects.
+
+- **Unit-level contracts.** Tools like Pact enforce contracts at API boundaries between services. Gaze pushes the contract paradigm down to individual functions and methods within a codebase.
+
+- **Refactoring-resilient by design.** Because the metric is anchored to the function's _role_ (what it is responsible for) rather than its _code lines_ (how it does it), Contract Coverage remains stable across refactors that preserve behavior. Rewrite the internals of `SaveUser` entirely — as long as it still writes to the database and returns errors correctly, the score does not change and the tests do not break.
+
+## CI Gating on What Matters
+
+Gaze provides threshold flags for pipeline enforcement:
+
+```bash
+# Fail the build if any test covers less than 80% of its target's contract
+gaze quality ./internal/analysis --min-contract-coverage=80
+
+# Fail if any test asserts on more than 2 incidental side effects
+gaze quality ./internal/analysis --max-over-specification=2
+
+# Fail if more than 5 functions are in the CRAP danger zone
+gaze crap ./... --max-crapload=5
+
+# Same threshold, but using contract coverage instead of line coverage
+gaze crap ./... --max-gaze-crapload=3
+```
+
+Without threshold flags, Gaze runs in report-only mode (exit code 0) — useful for initial adoption and exploration before enforcing gates.
+
+Gaze also includes a `self-check` command that runs its entire analysis pipeline against its own codebase, serving as both a dogfooding mechanism and a project health dashboard.
+
+### What These Gates Actually Mean
+
+A `--min-contract-coverage=80` gate answers a fundamentally different question than a `--min-coverage=80` gate. The traditional gate asks: "Did the tests touch 80% of the code?" Gaze's gate asks: "Do the tests verify at least 80% of what each function is _responsible for_?"
+
+The first question can be satisfied by assertion-free tests that game the metric. The second cannot. Contract Coverage requires that test assertions exist and that they map to the function's actual design obligations — the side effects that the rest of the system depends on. There is no way to inflate the number without writing tests that genuinely verify behavior.
+
+Combined with the Over-Specification gate, teams get a two-sided quality signal: tests must verify enough of the contract (coverage floor) while avoiding assertions on implementation details (brittleness ceiling). Functions that satisfy both constraints produce tests that are simultaneously thorough and refactoring-resilient — the precise outcome that line coverage was always supposed to deliver but structurally cannot.

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -2,8 +2,24 @@
 <section class="section section-hero container-fluid mt-n3 pb-3">
   <div class="row justify-content-center">
     <div class="col-lg-12 text-center">
-      <span class="badge bg-accent-subtle text-accent-emphasis rounded-pill px-3 py-2 mb-4">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="me-1" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+      <span
+        class="badge bg-accent-subtle text-accent-emphasis rounded-pill px-3 py-2 mb-4"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="me-1"
+          aria-hidden="true"
+        >
+          <path d="M13 10V3L4 14h7v7l9-11h-7z" />
+        </svg>
         Open Source AI Agent Swarm
       </span>
       <h1 class="display-4 fw-bold">{{ .Title }}</h1>
@@ -13,130 +29,314 @@
       <p class="lead fs-4 text-body-secondary mb-4">{{ . | safeHTML }}</p>
       {{ end }}
       <div class="d-flex justify-content-center gap-3 flex-wrap mb-4">
-        <a class="btn btn-primary rounded-pill btn-lg px-4" href="https://github.com/unbound-force" role="button" target="_blank" rel="noopener">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="me-2" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+        <a
+          class="btn btn-primary rounded-pill btn-lg px-4"
+          href="https://github.com/unbound-force"
+          role="button"
+          target="_blank"
+          rel="noopener"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="me-2"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14" />
+            <path d="m12 5 7 7-7 7" />
+          </svg>
           Explore on GitHub
         </a>
-        <a class="btn btn-outline-secondary rounded-pill btn-lg px-4" href="https://github.com/unbound-force/gaze" role="button" target="_blank" rel="noopener">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" class="me-2" aria-hidden="true"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        <a
+          class="btn btn-outline-secondary rounded-pill btn-lg px-4"
+          href="https://github.com/unbound-force/gaze"
+          role="button"
+          target="_blank"
+          rel="noopener"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            class="me-2"
+            aria-hidden="true"
+          >
+            <path
+              d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+            />
+          </svg>
           View Gaze
         </a>
       </div>
     </div>
   </div>
 </section>
-{{ end }}
-
-{{ define "sidebar-prefooter" }}
-  {{ if site.Params.doks.backgroundDots -}}
-  <div class="d-flex justify-content-start">
-    <div class="bg-dots"></div>
+{{ end }} {{ define "sidebar-prefooter" }} {{ if site.Params.doks.backgroundDots
+-}}
+<div class="d-flex justify-content-start">
+  <div class="bg-dots"></div>
+</div>
+{{ end -}} {{/* Features Section */}}
+<section class="section section-md section-features" aria-label="Key features">
+  <div class="container">
+    <div class="row justify-content-center text-center mb-5">
+      <div class="col-lg-8">
+        <h2 class="h2 fw-bold">Why Unbound Force?</h2>
+        <p class="lead text-body-secondary">
+          Purpose-built AI agent personas working through structured workflows
+          to ship quality software.
+        </p>
+      </div>
+    </div>
+    <div class="row justify-content-center text-center g-4">
+      <div class="col-lg-3 col-md-6">
+        <div class="feature-card p-4 rounded-4 h-100">
+          <div class="feature-icon mb-3">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0" />
+              <path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
+            </svg>
+          </div>
+          <h3 class="h5 fw-semibold">Agent Personas</h3>
+          <p class="text-body-secondary mb-0">
+            Purpose-built AI roles: Product Owner, Developer, Tester, Reviewer,
+            and Manager. Each persona brings domain expertise to every stage of
+            development.
+          </p>
+        </div>
+      </div>
+      <div class="col-lg-3 col-md-6">
+        <div class="feature-card p-4 rounded-4 h-100">
+          <div class="feature-icon mb-3">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 12h4l3 8l4 -16l3 8h4" />
+            </svg>
+          </div>
+          <h3 class="h5 fw-semibold">Speckit Workflow</h3>
+          <p class="text-body-secondary mb-0">
+            A structured spec-to-implementation pipeline. From specification
+            through planning, task generation, and implementation with quality
+            gates at every step.
+          </p>
+        </div>
+      </div>
+      <div class="col-lg-3 col-md-6">
+        <div class="feature-card p-4 rounded-4 h-100">
+          <div class="feature-icon mb-3">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10" />
+              <path d="m9 12 2 2 4-4" />
+            </svg>
+          </div>
+          <h3 class="h5 fw-semibold">Quality-First</h3>
+          <p class="text-body-secondary mb-0">
+            Integrated testing, review, and validation at every stage. Tools
+            like Gaze bring side effect detection and CRAP scoring to catch
+            risky code before it ships.
+          </p>
+        </div>
+      </div>
+      <div class="col-lg-3 col-md-6">
+        <div class="feature-card p-4 rounded-4 h-100">
+          <div class="feature-icon mb-3">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path
+                d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"
+              />
+              <path d="M9 18c-4.51 2-5-2-7-2" />
+            </svg>
+          </div>
+          <h3 class="h5 fw-semibold">Open Source</h3>
+          <p class="text-body-secondary mb-0">
+            Fully open source under Apache 2.0 license. Contribute, customize,
+            and build with the community.
+          </p>
+        </div>
+      </div>
+    </div>
   </div>
-  {{ end -}}
+</section>
 
-  {{/* Features Section */}}
-  <section class="section section-md section-features" aria-label="Key features">
-    <div class="container">
-      <div class="row justify-content-center text-center mb-5">
-        <div class="col-lg-8">
-          <h2 class="h2 fw-bold">Why Unbound Force?</h2>
-          <p class="lead text-body-secondary">Purpose-built AI agent personas working through structured workflows to ship quality software.</p>
-        </div>
+{{/* Projects Section */}}
+<section
+  class="section section-md section-projects bg-body-tertiary"
+  aria-label="Projects"
+>
+  <div class="container">
+    <div class="row justify-content-center text-center mb-5">
+      <div class="col-lg-8">
+        <h2 class="h2 fw-bold">Projects</h2>
+        <p class="lead text-body-secondary">
+          Tools built by the swarm, for the community.
+        </p>
       </div>
-      <div class="row justify-content-center text-center g-4">
-        <div class="col-lg-3 col-md-6">
-          <div class="feature-card p-4 rounded-4 h-100">
-            <div class="feature-icon mb-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0"/><path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2"/></svg>
+    </div>
+    <div class="row g-4 justify-content-center">
+      <div class="col-lg-6">
+        <a
+          href="https://github.com/unbound-force/gaze"
+          class="text-decoration-none"
+          target="_blank"
+          rel="noopener"
+        >
+          <div class="project-card p-4 rounded-4 h-100">
+            <div class="d-flex align-items-center mb-3">
+              <span
+                class="badge bg-primary-subtle text-primary-emphasis rounded-pill me-2"
+                >Go</span
+              >
+              <span class="text-body-secondary small">CLI Tool</span>
             </div>
-            <h3 class="h5 fw-semibold">Agent Personas</h3>
-            <p class="text-body-secondary mb-0">Purpose-built AI roles: Product Owner, Developer, Tester, Reviewer, and Manager. Each persona brings domain expertise to every stage of development.</p>
+            <h3 class="h5 fw-semibold text-body">Gaze</h3>
+            <p class="text-body-secondary mb-0">
+              Static analysis for Go that detects observable side effects in
+              functions and computes CRAP scores combining cyclomatic complexity
+              with test coverage.
+            </p>
           </div>
-        </div>
-        <div class="col-lg-3 col-md-6">
-          <div class="feature-card p-4 rounded-4 h-100">
-            <div class="feature-icon mb-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12h4l3 8l4 -16l3 8h4"/></svg>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{{/* Latest Articles Section */}} {{ with site.GetPage "/blog" }} {{ $posts :=
+where .Pages "Params.draft" "ne" true }} {{ with (first 1
+($posts.ByDate.Reverse)) }}
+<section
+  class="section section-md section-articles"
+  aria-label="Latest articles"
+>
+  <div class="container">
+    <div class="row justify-content-center text-center mb-5">
+      <div class="col-lg-8">
+        <h2 class="h2 fw-bold">Latest Articles</h2>
+        <p class="lead text-body-secondary">
+          Technical insights from the Unbound Force project.
+        </p>
+      </div>
+    </div>
+    <div class="row g-4 justify-content-center">
+      {{ range . }}
+      <div class="col-lg-6">
+        <a href="{{ .Permalink }}" class="text-decoration-none">
+          <div class="project-card p-4 rounded-4 h-100">
+            <div class="d-flex align-items-center mb-3">
+              <span class="text-body-secondary small"
+                >{{ .Date.Format "January 2, 2006" }}</span
+              >
             </div>
-            <h3 class="h5 fw-semibold">Speckit Workflow</h3>
-            <p class="text-body-secondary mb-0">A structured spec-to-implementation pipeline. From specification through planning, task generation, and implementation with quality gates at every step.</p>
+            <h3 class="h5 fw-semibold text-body">{{ .Title }}</h3>
+            <p class="text-body-secondary mb-0">{{ .Params.description }}</p>
           </div>
-        </div>
-        <div class="col-lg-3 col-md-6">
-          <div class="feature-card p-4 rounded-4 h-100">
-            <div class="feature-icon mb-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10"/><path d="m9 12 2 2 4-4"/></svg>
-            </div>
-            <h3 class="h5 fw-semibold">Quality-First</h3>
-            <p class="text-body-secondary mb-0">Integrated testing, review, and validation at every stage. Tools like Gaze bring side effect detection and CRAP scoring to catch risky code before it ships.</p>
-          </div>
-        </div>
-        <div class="col-lg-3 col-md-6">
-          <div class="feature-card p-4 rounded-4 h-100">
-            <div class="feature-icon mb-3">
-              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
-            </div>
-            <h3 class="h5 fw-semibold">Open Source</h3>
-            <p class="text-body-secondary mb-0">Fully open source under Apache 2.0 license. Contribute, customize, and build with the community.</p>
-          </div>
+        </a>
+      </div>
+      {{ end }}
+    </div>
+  </div>
+</section>
+{{ end }} {{ end }} {{/* CTA Section */}}
+<section class="section section-md section-cta" aria-label="Call to action">
+  <div class="container">
+    <div class="row justify-content-center text-center">
+      <div class="col-lg-8">
+        <h2 class="h2 fw-bold mb-3">Ready to Try Unbound Force?</h2>
+        <p class="lead text-body-secondary mb-4">
+          Explore the projects, meet the team, and start building with the
+          swarm.
+        </p>
+        <div class="d-flex justify-content-center gap-3 flex-wrap">
+          <a
+            class="btn btn-primary rounded-pill px-4"
+            href="https://github.com/unbound-force"
+            role="button"
+            target="_blank"
+            rel="noopener"
+            >Explore on GitHub</a
+          >
+          <a
+            class="btn btn-outline-secondary rounded-pill px-4"
+            href="https://github.com/unbound-force/gaze"
+            role="button"
+            target="_blank"
+            rel="noopener"
+            >View Gaze</a
+          >
         </div>
       </div>
     </div>
-  </section>
-
-  {{/* Projects Section */}}
-  <section class="section section-md section-projects bg-body-tertiary" aria-label="Projects">
-    <div class="container">
-      <div class="row justify-content-center text-center mb-5">
-        <div class="col-lg-8">
-          <h2 class="h2 fw-bold">Projects</h2>
-          <p class="lead text-body-secondary">Tools built by the swarm, for the community.</p>
-        </div>
-      </div>
-      <div class="row g-4 justify-content-center">
-        <div class="col-lg-6">
-          <a href="https://github.com/unbound-force/gaze" class="text-decoration-none" target="_blank" rel="noopener">
-            <div class="project-card p-4 rounded-4 h-100">
-              <div class="d-flex align-items-center mb-3">
-                <span class="badge bg-primary-subtle text-primary-emphasis rounded-pill me-2">Go</span>
-                <span class="text-body-secondary small">CLI Tool</span>
-              </div>
-              <h3 class="h5 fw-semibold text-body">Gaze</h3>
-              <p class="text-body-secondary mb-0">Static analysis for Go that detects observable side effects in functions and computes CRAP scores combining cyclomatic complexity with test coverage.</p>
-            </div>
-          </a>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  {{/* CTA Section */}}
-  <section class="section section-md section-cta" aria-label="Call to action">
-    <div class="container">
-      <div class="row justify-content-center text-center">
-        <div class="col-lg-8">
-          <h2 class="h2 fw-bold mb-3">Ready to Try Unbound Force?</h2>
-          <p class="lead text-body-secondary mb-4">Explore the projects, meet the team, and start building with the swarm.</p>
-          <div class="d-flex justify-content-center gap-3 flex-wrap">
-            <a class="btn btn-primary rounded-pill px-4" href="https://github.com/unbound-force" role="button" target="_blank" rel="noopener">Explore on GitHub</a>
-            <a class="btn btn-outline-secondary rounded-pill px-4" href="https://github.com/unbound-force/gaze" role="button" target="_blank" rel="noopener">View Gaze</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-{{ end }}
-
-{{ define "sidebar-footer" }}
-{{ if site.Params.doks.sectionFooter -}}
+  </div>
+</section>
+{{ end }} {{ define "sidebar-footer" }} {{ if site.Params.doks.sectionFooter -}}
 <section class="section section-md container-fluid bg-body-tertiary">
   <div class="row justify-content-center text-center">
     <div class="col-lg-7">
       <h2 class="mt-2 fw-bold">Start building with Unbound Force today</h2>
-      <p class="text-body-secondary">Explore the AI agent swarm for software engineering.</p>
-      <a class="btn btn-primary rounded-pill px-4 my-2" href="https://github.com/unbound-force" role="button" target="_blank" rel="noopener">Explore on GitHub</a>
+      <p class="text-body-secondary">
+        Explore the AI agent swarm for software engineering.
+      </p>
+      <a
+        class="btn btn-primary rounded-pill px-4 my-2"
+        href="https://github.com/unbound-force"
+        role="button"
+        target="_blank"
+        rel="noopener"
+        >Explore on GitHub</a
+      >
     </div>
   </div>
 </section>
-{{ end -}}
-{{ end }}
+{{ end -}} {{ end }}

--- a/specs/003-blog-why-gaze/checklists/requirements.md
+++ b/specs/003-blog-why-gaze/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Blog Section and "Why Contract Coverage" Article
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- FR-002 and FR-003 were revised during validation to remove configuration-level implementation references (`mainSections`, `sectionNav`) in favor of outcome-focused language.
+- The Assumptions section contains implementation context (source file paths, template expectations) which is appropriate for planning context but does not leak into the requirements themselves.
+- Article accuracy corrections (FR-009 through FR-012) are based on a thorough verification of 15 claims against the Gaze repository source code conducted before spec creation.

--- a/specs/003-blog-why-gaze/data-model.md
+++ b/specs/003-blog-why-gaze/data-model.md
@@ -1,0 +1,80 @@
+# Data Model: Blog Section and "Why Contract Coverage" Article
+
+**Branch**: `003-blog-why-gaze` | **Date**: 2026-02-27
+
+## Entities
+
+### Blog Section Index (`content/blog/_index.md`)
+
+| Field         | Type     | Required | Description                                        |
+| ------------- | -------- | -------- | -------------------------------------------------- |
+| `title`       | string   | Yes      | Section title displayed as page heading ("Blog")   |
+| `description` | string   | Yes      | SEO meta description for the blog index page       |
+| `lead`        | string   | No       | Subtitle/lead text below the section title         |
+| `date`        | datetime | Yes      | Creation date (ISO 8601 format)                    |
+| `draft`       | boolean  | Yes      | Must be `false` for published sections             |
+| `weight`      | integer  | Yes      | Ordering weight (1 for top-level section)          |
+| `toc`         | boolean  | Yes      | Table of contents toggle (`false` for index pages) |
+
+### Blog Post (`content/blog/*.md`)
+
+| Field          | Type     | Required | Description                                                 |
+| -------------- | -------- | -------- | ----------------------------------------------------------- |
+| `title`        | string   | Yes      | Post title displayed as H1                                  |
+| `description`  | string   | Yes      | SEO meta description; used in blog list cards               |
+| `lead`         | string   | No       | Brief summary displayed at top of post and in list excerpts |
+| `date`         | datetime | Yes      | Publication date (ISO 8601); controls sort order            |
+| `draft`        | boolean  | Yes      | Must be `false` for published posts                         |
+| `weight`       | integer  | Yes      | Manual ordering override within the blog section            |
+| `toc`          | boolean  | Yes      | Table of contents toggle (`true` for long-form articles)    |
+| `categories`   | string[] | No       | Taxonomy categories (e.g., ["Engineering"])                 |
+| `tags`         | string[] | No       | Taxonomy tags (e.g., ["gaze", "testing"])                   |
+| `contributors` | string[] | No       | Author/contributor names for metadata display               |
+
+### Homepage Article Card (rendered in `layouts/home.html`)
+
+Not a stored entity — dynamically rendered from Blog Post data. Displays:
+
+| Rendered Field | Source                                        | Description                        |
+| -------------- | --------------------------------------------- | ---------------------------------- |
+| Title          | Blog Post `.Title`                            | Linked heading to the full article |
+| Date           | Blog Post `.Date`                             | Formatted publication date         |
+| Description    | Blog Post `.Params.description` or `.Summary` | Brief excerpt                      |
+| URL            | Blog Post `.Permalink`                        | Link target for the card           |
+
+### Navigation Menu Entry (`menus.en.toml`)
+
+| Field    | Type    | Value    | Description                                |
+| -------- | ------- | -------- | ------------------------------------------ |
+| `name`   | string  | "Blog"   | Display text in the navbar                 |
+| `url`    | string  | "/blog/" | Target URL                                 |
+| `weight` | integer | 5        | Ordering (before GitHub link at weight 10) |
+
+## Relationships
+
+```
+Blog Section (1) ──contains──▶ Blog Post (many)
+Homepage ──queries──▶ Blog Section ──selects 1 most recent──▶ Blog Post
+Navigation Menu ──links to──▶ Blog Section index
+Blog Post ──classified by──▶ Categories (taxonomy)
+Blog Post ──tagged with──▶ Tags (taxonomy)
+```
+
+## Configuration Changes
+
+| File            | Field          | Current Value       | New Value                   |
+| --------------- | -------------- | ------------------- | --------------------------- |
+| `params.toml:7` | `mainSections` | `["docs"]`          | `["docs", "blog"]`          |
+| `hugo.toml:56`  | `[permalinks]` | `docs = "..."` only | Add `blog = "/blog/:slug/"` |
+| `menus.en.toml` | `[[main]]`     | GitHub only         | Add Blog entry (weight 5)   |
+
+## File Inventory
+
+| File                                    | Operation | Purpose                         |
+| --------------------------------------- | --------- | ------------------------------- |
+| `content/blog/_index.md`                | Create    | Blog section index page         |
+| `content/blog/why-contract-coverage.md` | Create    | "Why Contract Coverage" article |
+| `config/_default/params.toml`           | Edit      | Add `"blog"` to `mainSections`  |
+| `config/_default/hugo.toml`             | Edit      | Add blog permalink pattern      |
+| `config/_default/menus/menus.en.toml`   | Edit      | Add Blog navbar entry           |
+| `layouts/home.html`                     | Edit      | Add "Latest Articles" section   |

--- a/specs/003-blog-why-gaze/plan.md
+++ b/specs/003-blog-why-gaze/plan.md
@@ -1,0 +1,155 @@
+# Implementation Plan: Blog Section and "Why Contract Coverage" Article
+
+**Branch**: `003-blog-why-gaze` | **Date**: 2026-02-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-blog-why-gaze/spec.md`
+
+## Summary
+
+Add a Blog section to the Unbound Force website and publish the "Why Contract Coverage" article as its first post. The blog uses the Doks theme's built-in blog templates (no custom layouts needed for the blog itself). Configuration changes register the section in Hugo's content pipeline, navigation, and RSS. The homepage gains a "Latest Articles" section (showing the 1 most recent post) between the existing Projects and CTA sections. The article content is adapted from `temp/why-gaze.md` with 4 accuracy corrections verified against the Gaze repository source code.
+
+## Technical Context
+
+**Language/Version**: Hugo (via npm/thulite) + Go 1.23 + Node.js >= 20.11.0
+**Primary Dependencies**: `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1`
+**Storage**: N/A (static site, Markdown files)
+**Testing**: Manual — `npm run build` (zero errors) + visual verification via `npm run dev`
+**Target Platform**: GitHub Pages (static HTML/CSS/JS)
+**Project Type**: Static website (Hugo SSG)
+**Performance Goals**: N/A (static site, no runtime)
+**Constraints**: Constitution compliance (Content Accuracy, Minimal Footprint, Visitor Clarity)
+**Scale/Scope**: 2 new content files, 3 config edits, 1 template edit
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### Pre-Research Gate
+
+| Principle                 | Status | Evidence                                                                                                                                                                                                                                                   |
+| ------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **I. Content Accuracy**   | PASS   | Article content verified against Gaze repository source code (15 claims checked). 4 accuracy corrections documented in FR-009 through FR-012 will be applied during implementation. No placeholder content — the article is fully written.                 |
+| **II. Minimal Footprint** | PASS   | Blog section uses Doks built-in templates (`blog/list.html`, `blog/single.html`) — no custom layouts needed. Blog was explicitly requested by the user, satisfying the constitution's condition. Only 3 config edits and 1 template modification required. |
+| **III. Visitor Clarity**  | PASS   | Article uses "why should I care" framing (Constitution Principle III). Blog accessible within 2 clicks from homepage (navbar -> blog -> article, or homepage card -> article). Blog entry added to main navbar for discoverability.                        |
+
+**Gate result: PASS — all principles satisfied. Proceeding to Phase 0.**
+
+### Post-Design Gate
+
+| Principle                 | Status | Evidence                                                                                                                                                                                                                                |
+| ------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **I. Content Accuracy**   | PASS   | Research confirmed all Gaze claims are verifiable. Correction plan documented in research.md (R4). Frontmatter schema includes publication date for temporal context.                                                                   |
+| **II. Minimal Footprint** | PASS   | Research confirmed Doks ships blog templates natively (R1). Zero custom layouts needed for the blog section. Homepage modification is minimal — a single new section block using existing CSS patterns. No new npm dependencies.        |
+| **III. Visitor Clarity**  | PASS   | Data model confirms 2-click navigation paths. Blog menu entry at weight 5 positions it visibly in navbar. Homepage "Latest Articles" section provides alternative discovery path. Article title clearly communicates value proposition. |
+
+**Gate result: PASS — all principles satisfied post-design.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-blog-why-gaze/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0: technology decisions
+├── data-model.md        # Phase 1: entity definitions and file inventory
+├── quickstart.md        # Phase 1: implementation quick reference
+├── checklists/
+│   └── requirements.md  # Specification quality checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+content/
+├── _index.md                              # Homepage (existing, unchanged)
+└── blog/
+    ├── _index.md                          # Blog section index (NEW)
+    └── why-contract-coverage.md           # "Why Contract Coverage" article (NEW)
+
+config/_default/
+├── hugo.toml                              # Add blog permalink pattern (EDIT)
+├── params.toml                            # Add "blog" to mainSections (EDIT)
+└── menus/
+    └── menus.en.toml                      # Add Blog navbar entry (EDIT)
+
+layouts/
+└── home.html                              # Add "Latest Articles" section (EDIT)
+```
+
+**Structure Decision**: This feature adds content files and modifies configuration — no new source code directories. The blog section lives under `content/blog/` following Hugo's convention for top-level content sections. The Doks theme's built-in `blog/list.html` and `blog/single.html` templates handle rendering without custom overrides.
+
+## Implementation Phases
+
+### Phase 1: Blog Infrastructure (FR-001 through FR-005)
+
+**Goal**: Register the blog section in Hugo so it builds, appears in navigation, generates correct URLs, and feeds into RSS/search.
+
+**Steps**:
+
+1. Edit `config/_default/params.toml` — change `mainSections = ["docs"]` to `mainSections = ["docs", "blog"]`
+2. Edit `config/_default/hugo.toml` — add `blog = "/blog/:slug/"` under `[permalinks]`
+3. Edit `config/_default/menus/menus.en.toml` — add `[[main]]` entry: name="Blog", url="/blog/", weight=5
+4. Create `content/blog/_index.md` with frontmatter (title, description, date, draft: false, weight: 1, toc: false)
+5. Run `npm run build` to verify the blog section builds without errors
+
+**Verification**: Blog index page renders at `/blog/`. "Blog" link appears in the navbar. No build errors.
+
+### Phase 2: Article Content (FR-006 through FR-014)
+
+**Goal**: Publish the "Why Contract Coverage" article with all accuracy corrections applied.
+
+**Steps**:
+
+1. Create `content/blog/why-contract-coverage.md` by adapting `temp/why-gaze.md`:
+   - Add YAML frontmatter (title, description, lead, date, draft: false, weight: 100, toc: true, categories, tags, contributors)
+   - Remove the H1 title from body (frontmatter generates it)
+   - Ensure all code blocks use fenced syntax with language identifiers (`go`, `bash`)
+2. Apply accuracy correction FR-009: Reword AI agent claim to describe external OpenCode workflow
+3. Apply accuracy correction FR-010: Add `/100` divisor to GazeCRAP formula for consistent notation
+4. Apply accuracy correction FR-011: Fix CLI command examples — single package for `gaze quality`, correct flag names
+5. Apply accuracy correction FR-012: Add caveat about optional test execution in CRAP scoring
+6. Run `npm run build` to verify article renders without errors
+
+**Verification**: Article renders at `/blog/why-contract-coverage/` with all sections, code blocks with syntax highlighting, and tables. All 4 corrections applied and verifiable against Gaze source.
+
+### Phase 3: Homepage Integration (FR-015 through FR-018, FR-022)
+
+**Goal**: Add a "Latest Articles" section to the homepage that dynamically shows the most recent blog post.
+
+**Steps**:
+
+1. Edit `layouts/home.html` — add a new section block between the Projects section (ending line 111) and the CTA section (starting line 113)
+2. Use Hugo template logic: `{{ with site.GetPage "/blog" }}` to access the blog section, then `{{ range first 1 .Pages.ByDate.Reverse }}` to get the most recent post
+3. Render an article card with title (`.Title`), date (`.Date`), description (`.Params.description`), and link (`.Permalink`)
+4. Style the section consistently with the existing Projects section (same container, spacing, responsive grid)
+5. Use Bootstrap CSS variables (`var(--bs-*)`) for dark mode compatibility
+
+**Verification**: Homepage shows "Latest Articles" section between Projects and CTA. Card displays title, date, description. Clicking links to the full article. Dark mode renders correctly. Existing sections unchanged.
+
+### Phase 4: Final Verification (FR-019 through FR-022)
+
+**Goal**: Confirm all success criteria are met.
+
+**Steps**:
+
+1. `npm run build` — zero errors
+2. `npm run dev` — visual verification:
+   - Blog navbar link present on all pages
+   - Blog index lists the article with title, date, description
+   - Article renders fully with code blocks, tables, syntax highlighting
+   - Homepage "Latest Articles" shows the article
+   - Dark mode correct on all new/modified pages
+   - Existing pages (homepage hero, features, projects, CTA) unchanged
+3. Verify article appears in RSS feed output
+4. Verify article appears in search index
+
+## Risk Assessment
+
+| Risk                                                                | Impact | Likelihood | Mitigation                                                                                                         |
+| ------------------------------------------------------------------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------ |
+| Doks blog templates render unexpectedly                             | Medium | Low        | Templates are well-documented; fallback to root-level `list.html`/`single.html` if needed                          |
+| Homepage template change breaks existing sections                   | High   | Low        | Add new section as an independent block between existing sections; FR-022 requires regression check                |
+| Blog search integration doesn't work                                | Low    | Low        | Adding `"blog"` to `mainSections` should handle this; FlexSearch indexes all mainSections                          |
+| Article content has additional inaccuracies beyond the 4 identified | Medium | Low        | 15 claims were systematically verified; remaining content is descriptive prose without verifiable technical claims |

--- a/specs/003-blog-why-gaze/quickstart.md
+++ b/specs/003-blog-why-gaze/quickstart.md
@@ -1,0 +1,80 @@
+# Quick Start: Blog Section and "Why Contract Coverage" Article
+
+**Branch**: `003-blog-why-gaze` | **Date**: 2026-02-27
+
+## Prerequisites
+
+- Node.js >= 20.11.0
+- Go >= 1.23 (for Hugo module resolution)
+- Dependencies installed: `npm install`
+
+## Implementation Order
+
+### 1. Configuration Changes
+
+Edit three config files to register the blog section:
+
+**`config/_default/params.toml`** — Add `"blog"` to `mainSections`:
+
+```toml
+mainSections = ["docs", "blog"]
+```
+
+**`config/_default/hugo.toml`** — Add blog permalink under `[permalinks]`:
+
+```toml
+[permalinks]
+  docs = "/docs/:sections[1:]/:slug/"
+  blog = "/blog/:slug/"
+```
+
+**`config/_default/menus/menus.en.toml`** — Add Blog to navbar:
+
+```toml
+[[main]]
+  name = "Blog"
+  url = "/blog/"
+  weight = 5
+```
+
+### 2. Blog Section Index
+
+Create `content/blog/_index.md`:
+
+```yaml
+---
+title: "Blog"
+description: "Technical articles and insights from the Unbound Force project."
+lead: ""
+date: 2026-02-27T00:00:00+00:00
+draft: false
+weight: 1
+toc: false
+---
+```
+
+### 3. Article Content
+
+Create `content/blog/why-contract-coverage.md` adapted from `temp/why-gaze.md` with:
+
+- Proper YAML frontmatter (title, description, lead, date, categories, tags, contributors)
+- Body starting with `##` (H2)
+- All 4 accuracy corrections applied (FR-009 through FR-012)
+- Fenced code blocks with language identifiers
+
+### 4. Homepage Integration
+
+Edit `layouts/home.html` — add a "Latest Articles" section between the Projects section and the CTA section. Use Hugo's `site.GetPage "/blog"` to dynamically query the most recent blog post.
+
+### 5. Verification
+
+```bash
+npm run build              # Must succeed with zero errors
+npm run dev                # Visually verify:
+                           #   - Blog link in navbar
+                           #   - Blog index page lists the article
+                           #   - Article renders with code blocks, tables
+                           #   - Homepage shows "Latest Articles" section
+                           #   - Dark mode renders correctly on all pages
+                           #   - Existing pages unchanged
+```

--- a/specs/003-blog-why-gaze/research.md
+++ b/specs/003-blog-why-gaze/research.md
@@ -1,0 +1,115 @@
+# Research: Blog Section and "Why Contract Coverage" Article
+
+**Branch**: `003-blog-why-gaze` | **Date**: 2026-02-27
+
+## R1: Doks Built-in Blog Support
+
+**Decision**: Use the Doks theme's built-in blog templates (`blog/list.html`, `blog/single.html`) without custom overrides.
+
+**Rationale**: Doks ships with first-class blog section support:
+
+- `node_modules/@thulite/doks-core/layouts/blog/list.html` — paginated card-based post listing with metadata (date, categories, reading time)
+- `node_modules/@thulite/doks-core/layouts/blog/single.html` — individual post rendering with title, metadata, summary, tags, and optional related posts
+- `node_modules/@thulite/doks-core/layouts/_partials/main/blog-meta.html` — shared partial for date, categories, contributors, reading time
+- These templates are already mounted via `config/_default/module.toml` (lines 29-33)
+
+No custom layouts are needed for the blog section itself. This satisfies Constitution Principle II (Minimal Footprint) by using built-in features.
+
+**Alternatives considered**:
+
+- Custom blog list/single templates: Rejected — unnecessary when Doks provides them natively
+- Using the default `list.html`/`single.html` (docs-oriented): Rejected — the blog-specific templates are better suited and avoid sidebar navigation leaking into blog pages
+
+## R2: Hugo Configuration for Blog Section
+
+**Decision**: Three configuration changes are required:
+
+1. **`params.toml`**: Add `"blog"` to `mainSections` (line 7) — changes `["docs"]` to `["docs", "blog"]`. This ensures blog posts appear in RSS feeds and the search index.
+
+2. **`hugo.toml`**: Add a permalink pattern for blog — `blog = "/blog/:slug/"` under `[permalinks]` (line 56). This produces clean URLs like `/blog/why-contract-coverage/`.
+
+3. **`menus.en.toml`**: Add a `[[main]]` entry for Blog with `url = "/blog/"` and a weight that positions it before the GitHub external link.
+
+**Rationale**: These are the minimum config changes to integrate a new top-level content section. The blog section does NOT need to be added to `sectionNav` (FR-003 prohibits sidebar nav for blog).
+
+**Alternatives considered**:
+
+- Adding blog to `sectionNav`: Rejected — spec explicitly prohibits sidebar navigation for the blog section
+- Custom permalink pattern with date (e.g., `/blog/:year/:month/:slug/`): Rejected — unnecessary complexity for a project blog with low publishing frequency
+
+## R3: Homepage "Latest Articles" Integration
+
+**Decision**: Add a new section to `layouts/home.html` between the Projects section and the CTA section. Use Hugo's `site.GetPage "/blog"` to access the blog section, then query its pages sorted by date (descending), limited to 1 post.
+
+**Rationale**: Hugo's `site.GetPage` + `.Pages.ByDate.Reverse` is the idiomatic way to dynamically pull content from another section. Limiting to 1 post matches the clarification decision. The section should be visually consistent with the existing Projects section (same spacing, card style, responsive grid).
+
+**Alternatives considered**:
+
+- Hugo's `where` function on `site.RegularPages`: Works but `site.GetPage` is more explicit about sourcing from the blog section specifically
+- Hardcoding article references: Rejected — FR-016 requires dynamic sourcing
+
+## R4: Article Content Adaptation
+
+**Decision**: Adapt `temp/why-gaze.md` into `content/blog/why-contract-coverage.md` with 4 accuracy corrections applied:
+
+1. **AI agent claim (FR-009)**: Reword "Optionally, project documentation... can be fed through an AI agent to refine confidence further" to clarify this is an external OpenCode agent workflow, not built into the Gaze binary.
+
+2. **GazeCRAP formula (FR-010)**: Add `/100` divisor to make notation consistent with the CRAP formula. Both should read `(1 - coverage/100)^3`.
+
+3. **CLI commands (FR-011)**: Change `gaze quality ./...` to `gaze quality ./internal/analysis` (single package). Remove the nonexistent `gaze crap --gaze ./...` example or replace with `--max-gaze-crapload`.
+
+4. **Static analysis caveat (FR-012)**: Add a note that the `crap` subcommand can optionally run `go test` for coverage data.
+
+**Rationale**: These corrections are based on verification of 15 claims against the Gaze repository source code. 11 claims were fully accurate; 4 were partially true and require specific corrections.
+
+**Alternatives considered**:
+
+- Publishing the article as-is: Rejected — Constitution Principle I (Content Accuracy) requires all claims to be verifiable
+
+## R5: Blog Post Frontmatter Schema
+
+**Decision**: Use the Doks blog frontmatter convention:
+
+```yaml
+---
+title: "Why Contract Coverage: How Gaze Redefines What It Means to Have Good Tests"
+description: "Line coverage tells you what code ran, not what was verified. Contract Coverage measures whether tests check what functions are actually responsible for."
+lead: "Line coverage tells you what code ran. Contract Coverage tells you what was verified."
+date: 2026-02-27T00:00:00+00:00
+draft: false
+weight: 100
+toc: true
+categories: ["Engineering"]
+tags: ["gaze", "testing", "go", "static-analysis"]
+contributors: ["Unbound Force"]
+---
+```
+
+**Rationale**: The Doks blog templates expect `title`, `date`, and `summary` or `description`. Adding `categories`, `tags`, and `contributors` enables the Doks blog metadata partial to render rich metadata (reading time, category links, contributor display). The `lead` field is used by the Doks template for a summary/excerpt.
+
+**Alternatives considered**:
+
+- Minimal frontmatter (title, date, draft only): Rejected — would result in sparse metadata rendering in the blog list and single templates
+- Adding `authors` instead of `contributors`: Rejected — Doks uses `contributors` taxonomy, not `authors`
+
+## R6: Blog Section Index Page
+
+**Decision**: Create `content/blog/_index.md` with minimal frontmatter and no body content. The Doks `blog/list.html` template renders the list of posts automatically.
+
+```yaml
+---
+title: "Blog"
+description: "Technical articles and insights from the Unbound Force project."
+lead: ""
+date: 2026-02-27T00:00:00+00:00
+draft: false
+weight: 1
+toc: false
+---
+```
+
+**Rationale**: The blog index is a listing page. Body content is unnecessary — the Doks template handles rendering the post list. This follows the pattern established by the existing `content/_index.md` (homepage), which also has frontmatter-only content.
+
+**Alternatives considered**:
+
+- Adding body content to the index: Rejected — the Doks blog list template already provides the section header from frontmatter fields

--- a/specs/003-blog-why-gaze/spec.md
+++ b/specs/003-blog-why-gaze/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: Blog Section and "Why Contract Coverage" Article
+
+**Feature Branch**: `003-blog-why-gaze`
+**Created**: 2026-02-27
+**Status**: Draft
+**Input**: User description: "Blog Section and Why Contract Coverage Article"
+
+## Clarifications
+
+### Session 2026-02-27
+
+- Q: How many blog posts should the homepage "Latest Articles" section display at maximum? → A: Show the 1 most recent post.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Reading the "Why Contract Coverage" Article (Priority: P1)
+
+As a developer evaluating test quality tools, I want to read an article explaining why Contract Coverage matters and how Gaze implements it, so that I understand the value proposition before exploring the project further.
+
+**Why this priority**: This is the core deliverable. The article is the reason the blog section exists. Without it, the blog section has no content and violates the zero-waste mandate.
+
+**Independent Test**: Navigate to the blog from the navbar. Click on the "Why Contract Coverage" article. The full article renders with correct formatting, accurate technical content, and working code examples.
+
+**Acceptance Scenarios**:
+
+1. **Given** I click "Blog" in the main navbar, **When** the blog index page loads, **Then** I see a list of articles with the "Why Contract Coverage" post displayed with its title, description, and date.
+2. **Given** I click on the "Why Contract Coverage" article, **When** the page loads, **Then** I see the full article with all sections: The Problem with Line Coverage, What Gaze Measures Instead (pipeline, metrics), A Concrete Example (code blocks, comparison tables), How Gaze Differs from Existing Approaches, and CI Gating on What Matters.
+3. **Given** the article content, **When** I cross-reference technical claims against the Gaze repository source code, **Then** all facts are accurate: the 5-tier taxonomy (P0-P4) with 38 effect types, the 5 classification signals, the GazeCRAP formula, the four quadrants, and CLI flag names all match the implementation.
+4. **Given** the article mentions classification refinement using project documentation, **When** I read the description, **Then** it clearly states this is an optional external workflow via OpenCode agents, not a built-in Gaze feature.
+5. **Given** the article includes CLI command examples, **When** I check the commands, **Then** `gaze quality` uses a single package argument (not `./...`), and threshold flags use their actual names (`--min-contract-coverage`, `--max-over-specification`, `--max-crapload`, `--max-gaze-crapload`).
+6. **Given** the article, **When** I check code blocks, **Then** all Go code blocks have the `go` language identifier and all bash code blocks have the `bash` identifier, and both render with syntax highlighting.
+
+---
+
+### User Story 2 - Blog Section Infrastructure (Priority: P1)
+
+As a site visitor, I want a blog section accessible from the main navigation so that I can discover and browse articles published by the Unbound Force project.
+
+**Why this priority**: The blog section is the container for the article. Without it, the article has nowhere to live. This is co-priority with the article itself since both are required for delivery.
+
+**Independent Test**: Click "Blog" in the main navbar. The blog index page loads showing available articles.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am on any page, **When** I look at the main navigation bar, **Then** I see a "Blog" link.
+2. **Given** I click "Blog" in the navbar, **When** the page loads, **Then** I see a blog index page with a title, description, and a list of published articles.
+3. **Given** the blog index page, **When** I look at the article listings, **Then** each article shows its title, date, and description.
+4. **Given** the blog section, **When** I check the site RSS feed, **Then** blog posts are included.
+5. **Given** the blog section, **When** I search using the site search, **Then** blog articles appear in search results.
+
+---
+
+### User Story 3 - Homepage "Latest Articles" Section (Priority: P2)
+
+As a first-time visitor on the homepage, I want to see featured articles so that I discover the project publishes technical content and can click through to read it.
+
+**Why this priority**: Homepage integration increases article discoverability but is not required for the article to be accessible. The navbar link alone satisfies the two-click navigation rule.
+
+**Independent Test**: Load the homepage. Scroll to find the "Latest Articles" section. Click through to the article.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am on the homepage, **When** I scroll past the Projects section, **Then** I see a "Latest Articles" section showcasing the single most recent blog post.
+2. **Given** the "Latest Articles" section, **When** I see an article card, **Then** it displays the article title, publication date, a brief description, and a link to read it.
+3. **Given** I click on an article card, **When** the page loads, **Then** I am taken to the full article in the blog section.
+4. **Given** the homepage, **When** I view it in dark mode, **Then** the "Latest Articles" section renders correctly with proper contrast and styling.
+
+---
+
+### Edge Cases
+
+- What happens when only one blog post exists? The blog index page MUST display it as a single-item list without looking broken or empty.
+- What happens when a blog post has `draft: true`? It MUST be excluded from the blog index, homepage section, and RSS feed in production builds but visible during `npm run dev`.
+- What if a future blog post is added without updating the homepage? The homepage "Latest Articles" section MUST dynamically pull from the blog section so new posts appear automatically without template changes.
+- What if the blog section is empty (all posts are drafts)? The "Blog" navbar link still works; the index page displays an empty state gracefully.
+- What if technical claims in the article become outdated as Gaze evolves? The article includes a publication date to signal when it was written. Content is treated as a point-in-time snapshot that may require updates when Gaze changes significantly.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+#### Blog Section Infrastructure
+
+- **FR-001**: A blog content section MUST exist at `content/blog/` with a section index page (`content/blog/_index.md`) containing required YAML frontmatter (`title`, `description`, `lead`, `date`, `draft: false`, `weight`, `toc: false`).
+- **FR-002**: Blog posts MUST appear in the site's RSS feed and site search results alongside documentation content.
+- **FR-003**: The blog section MUST NOT display sidebar navigation. Blog posts are discoverable via the blog index page, site search, and the homepage.
+- **FR-004**: A main navigation menu entry for "Blog" MUST be added to the site navigation configuration so it appears in the persistent navbar.
+- **FR-005**: Blog post URLs MUST follow the pattern `/blog/<slug>/`.
+
+#### "Why Contract Coverage" Article
+
+- **FR-006**: The article MUST be published as a Markdown file in the blog section with complete YAML frontmatter including `title`, `description`, `lead`, `date`, `draft: false`, `weight`, and `toc: true`.
+- **FR-007**: The article body MUST start with `##` (H2). The `title` frontmatter generates H1.
+- **FR-008**: All code blocks MUST use fenced syntax with appropriate language identifiers (`go` for Go, `bash` for shell commands).
+- **FR-009**: The article MUST NOT claim that Gaze has a built-in AI agent for classification. The reference to AI-assisted classification MUST clearly describe it as an optional external workflow via OpenCode agents that uses project documentation to refine classification confidence.
+- **FR-010**: The GazeCRAP formula MUST use consistent notation with the CRAP formula. Both MUST use percentage notation with the `/100` divisor, matching the actual implementation: `GazeCRAP(m) = complexity^2 * (1 - contractCoverage/100)^3 + complexity`.
+- **FR-011**: CLI command examples MUST match the actual Gaze CLI interface. Specifically: `gaze quality` MUST use a single package argument (not the multi-package `./...` wildcard), and all threshold flags MUST use their actual names (`--min-contract-coverage`, `--max-over-specification`, `--max-crapload`, `--max-gaze-crapload`).
+- **FR-012**: The description of Gaze as a "static analysis tool" MUST include a note that the CRAP scoring feature can optionally invoke test execution to generate line coverage data.
+- **FR-013**: All technical claims MUST be verifiable against the Gaze repository source code. This includes: the 5-tier taxonomy (P0-P4) with 38 effect types, the 5 classification signals with weighted 0-100 confidence scoring, the Over-Specification Score, assertion mapping, the four risk quadrants (Q1-Q4), and all CLI flags.
+- **FR-014**: The article MUST retain its "why should I care" framing, adapted for a website audience rather than raw technical documentation.
+
+#### Homepage Integration
+
+- **FR-015**: The homepage template MUST include a "Latest Articles" section positioned between the existing Projects section and the Call to Action section.
+- **FR-016**: The "Latest Articles" homepage section MUST dynamically source content from the blog section rather than hardcoding specific article references. It MUST display only the 1 most recent published post. Future blog posts replace the displayed post automatically without template changes.
+- **FR-017**: The "Latest Articles" section MUST render correctly in both light and dark mode, using theme-compatible styling for colors and spacing.
+- **FR-018**: The "Latest Articles" section MUST display at minimum: article title, publication date, and a brief description for each featured post.
+
+#### Build and Navigation Integrity
+
+- **FR-019**: The site MUST build successfully with zero errors after all changes.
+- **FR-020**: The blog article MUST be reachable from the homepage within two clicks: either homepage -> Blog (navbar) -> article, or homepage -> "Latest Articles" card -> article.
+- **FR-021**: All internal links MUST be valid. No broken links or references to non-existent pages.
+- **FR-022**: The existing homepage sections (hero, features, projects, CTA) MUST NOT be visually or functionally altered by the addition of the "Latest Articles" section.
+
+### Key Entities
+
+- **Blog Section**: A top-level content section at `content/blog/` that hosts articles. Unlike the `docs` section, it does not use sidebar navigation. Posts are listed on the index page.
+- **Blog Post**: A Markdown file in `content/blog/` with YAML frontmatter. Each post has a title, description, date, and body content. Posts appear on the blog index, in search results, and in the RSS feed.
+- **Homepage Article Card**: A UI component in the homepage template that displays a blog post summary (title, date, description) with a link to the full article. Dynamically sourced from the blog section content.
+
+### Assumptions
+
+- The article content is adapted from the existing source file at `temp/why-gaze.md`. The source has been verified against the Gaze repository, and 4 accuracy corrections are required (documented in FR-009 through FR-012).
+- The blog section is explicitly requested by the user, satisfying the constitution's condition that a blog should only be added "when explicitly requested and justified."
+- No custom template is needed for individual blog posts; the default theme single-page template is expected to handle blog post rendering. A custom template SHOULD only be created if the default rendering is insufficient.
+- The "Latest Articles" homepage section requires a modification to the existing custom homepage template.
+- Blog posts do not use sidebar navigation (FR-003), relying instead on the blog index page and site search for discoverability.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: The blog section is accessible via a "Blog" link in the main navigation bar on every page of the site.
+- **SC-002**: The "Why Contract Coverage" article renders at its blog URL with all sections, code blocks with syntax highlighting, and comparison tables displaying correctly.
+- **SC-003**: The site builds successfully with zero errors after all changes are applied.
+- **SC-004**: Cross-referencing the published article against the Gaze repository confirms all 4 accuracy corrections have been applied: (1) AI agent claim clarified as external workflow, (2) GazeCRAP formula uses consistent `/100` notation, (3) CLI commands use correct arguments and flag names, (4) "static analysis" description notes the optional test execution for CRAP scoring.
+- **SC-005**: The homepage displays a "Latest Articles" section that shows the single most recent blog post with title, date, and description, linking to the full article.
+- **SC-006**: The article is discoverable via the site's search functionality.
+- **SC-007**: The article appears in the site's RSS feed.
+- **SC-008**: All pages (homepage, blog index, article) render correctly in both light and dark mode.
+- **SC-009**: No existing pages or navigation items are broken or visually altered by the changes.
+- **SC-010**: Every new page has complete YAML frontmatter with all required fields populated.

--- a/specs/003-blog-why-gaze/tasks.md
+++ b/specs/003-blog-why-gaze/tasks.md
@@ -1,0 +1,150 @@
+# Tasks: Blog Section and "Why Contract Coverage" Article
+
+**Input**: Design documents from `/specs/003-blog-why-gaze/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, quickstart.md
+
+**Tests**: No automated test suite exists for this project. Validation is manual via `npm run build` (zero errors) and visual verification via `npm run dev`.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Foundational (Hugo Configuration)
+
+**Purpose**: Register the blog section in Hugo's content pipeline, navigation, and permalink system. These changes MUST be complete before any blog content can be created.
+
+**Why blocking**: Without these config changes, Hugo won't recognize `content/blog/` as a content section, won't generate correct URLs, and won't include blog content in RSS or search.
+
+- [x] T001 [P] Add `"blog"` to `mainSections` in `config/_default/params.toml` — change line 7 from `mainSections = ["docs"]` to `mainSections = ["docs", "blog"]`
+- [x] T002 [P] Add blog permalink pattern in `config/_default/hugo.toml` — add `blog = "/blog/:slug/"` under the existing `[permalinks]` section (after line 56)
+- [x] T003 [P] Add Blog navbar entry in `config/_default/menus/menus.en.toml` — add a `[[main]]` entry with name="Blog", url="/blog/", weight=5 (before the existing GitHub link at weight 10)
+
+**Checkpoint**: Configuration complete. Hugo will recognize blog content, generate correct URLs, and show "Blog" in the navbar.
+
+---
+
+## Phase 2: User Story 2 - Blog Section Infrastructure (Priority: P1)
+
+**Goal**: Create the blog section so it builds, renders an index page, and is navigable via the navbar.
+
+**Independent Test**: Run `npm run build` (zero errors). Run `npm run dev` and click "Blog" in the navbar — the blog index page loads with a title and description. Verify the blog section appears in the RSS feed.
+
+- [x] T004 [US2] Create blog section index page at `content/blog/_index.md` with frontmatter: title="Blog", description="Technical articles and insights from the Unbound Force project.", lead="", date=2026-02-27T00:00:00+00:00, draft=false, weight=1, toc=false. No body content — the Doks `blog/list.html` template handles the post listing.
+- [x] T005 [US2] Run `npm run build` and verify zero errors. Confirm the blog index page is generated in the build output.
+
+**Checkpoint**: Blog section exists and builds successfully. "Blog" link in navbar navigates to the index page. No blog posts are listed yet (empty section). FR-001 through FR-005 satisfied.
+
+---
+
+## Phase 3: User Story 1 - "Why Contract Coverage" Article (Priority: P1) MVP
+
+**Goal**: Publish the "Why Contract Coverage" article as the first blog post with all 4 accuracy corrections applied.
+
+**Independent Test**: Navigate to `/blog/why-contract-coverage/`. The full article renders with all sections, code blocks with syntax highlighting, and comparison tables. Cross-reference technical claims against the Gaze repository.
+
+- [x] T006 [US1] Create the article file at `content/blog/why-contract-coverage.md` by adapting `temp/why-gaze.md`. Add YAML frontmatter per research.md R5: title="Why Contract Coverage: How Gaze Redefines What It Means to Have Good Tests", description="Line coverage tells you what code ran, not what was verified. Contract Coverage measures whether tests check what functions are actually responsible for.", lead="Line coverage tells you what code ran. Contract Coverage tells you what was verified.", date=2026-02-27T00:00:00+00:00, draft=false, weight=100, toc=true, categories=["Engineering"], tags=["gaze", "testing", "go", "static-analysis"], contributors=["Unbound Force"]. Remove the H1 title from the body (frontmatter generates it). Ensure body starts with `##`. Ensure all code blocks use fenced syntax with language identifiers (`go` for Go code, `bash` for shell commands).
+- [x] T007 [US1] Apply accuracy correction FR-009 in `content/blog/why-contract-coverage.md`: Reword the sentence about AI agent classification refinement. Change "Optionally, project documentation (architecture docs, specs, READMEs) can be fed through an AI agent to refine confidence further" to clearly state this is an optional external workflow via OpenCode agents that analyzes project documentation to refine classification, not a built-in feature of the Gaze binary.
+- [x] T008 [US1] Apply accuracy correction FR-010 in `content/blog/why-contract-coverage.md`: Update the GazeCRAP formula to use consistent `/100` notation matching the CRAP formula. Change `GazeCRAP(m) = complexity^2 * (1 - contractCoverage)^3 + complexity` to `GazeCRAP(m) = complexity^2 * (1 - contractCoverage/100)^3 + complexity`. Both the CRAP and GazeCRAP formulas should use the same percentage notation.
+- [x] T009 [US1] Apply accuracy correction FR-011 in `content/blog/why-contract-coverage.md`: Fix CLI command examples. Change `gaze quality ./...` to `gaze quality ./internal/analysis` (the quality command takes a single package argument, not the `./...` multi-package wildcard). Fix or remove the `gaze crap --gaze ./...` example — the `--gaze` flag does not exist. Replace with a valid example using the actual flags (e.g., `gaze crap --max-gaze-crapload=3 ./...`).
+- [x] T010 [US1] Apply accuracy correction FR-012 in `content/blog/why-contract-coverage.md`: Add a note clarifying that while Gaze's core side effect detection and classification are purely static analysis (AST + SSA, no test execution), the `crap` subcommand can optionally invoke `go test -coverprofile` to generate line coverage data for the traditional CRAP formula. Add this caveat near the description of Gaze as a "static analysis tool" or in the comparison table's "Runtime Cost" column.
+- [x] T011 [US1] Run `npm run build` and verify zero errors. Run `npm run dev` and verify the article renders at `/blog/why-contract-coverage/` with all sections, syntax-highlighted code blocks, and comparison tables.
+
+**Checkpoint**: Article is published and all 4 accuracy corrections are applied. Blog index now lists the article with title, date, and description. FR-006 through FR-014 satisfied.
+
+---
+
+## Phase 4: User Story 3 - Homepage "Latest Articles" Section (Priority: P2)
+
+**Goal**: Add a "Latest Articles" section to the homepage that dynamically shows the single most recent blog post.
+
+**Independent Test**: Load the homepage. Scroll past the Projects section to find "Latest Articles" showing the blog post title, date, and description. Click through to the full article. Verify dark mode renders correctly. Verify existing homepage sections are unchanged.
+
+- [x] T012 [US3] Add "Latest Articles" section to `layouts/home.html` between the Projects section (ending at line 111 `</section>`) and the CTA section (starting at line 113 `{{/* CTA Section */}}`). Use Hugo template logic: `{{ with site.GetPage "/blog" }}` to access the blog section, then `{{ range first 1 .Pages.ByDate.Reverse }}` to select the most recent post. Render an article card displaying the post title (`.Title`), formatted publication date (`.Date`), description (`.Params.description`), and a link to the full article (`.Permalink`). Style consistently with the existing Projects section — use the same container structure, `section-md` spacing, responsive grid (`row`, `col-lg-6`), and card styling (`rounded-4`, `p-4`, `h-100`). Use Bootstrap CSS variables (`var(--bs-*)` and semantic classes like `text-body`, `text-body-secondary`, `bg-body-tertiary`) for dark mode compatibility. Add a section heading "Latest Articles" with a lead paragraph. Include an `aria-label` attribute on the section element for accessibility.
+- [x] T013 [US3] Run `npm run build` and verify zero errors. Run `npm run dev` and verify: (1) "Latest Articles" section appears between Projects and CTA, (2) article card shows title, date, and description, (3) clicking the card navigates to the article, (4) dark mode renders correctly, (5) existing homepage sections (hero, features, projects, CTA, sidebar footer) are visually unchanged.
+
+**Checkpoint**: Homepage integration complete. The most recent blog post appears dynamically on the homepage. FR-015 through FR-018, FR-022 satisfied.
+
+---
+
+## Phase 5: Polish & Final Verification
+
+**Purpose**: Confirm all success criteria are met and no regressions exist.
+
+- [x] T014 Run `npm run build` and confirm zero errors (SC-003)
+- [x] T015 Run `npm run dev` and perform full visual verification: (1) "Blog" navbar link present on all pages (SC-001), (2) blog index page lists the article with title, date, description, (3) article renders at `/blog/why-contract-coverage/` with all sections, code blocks with syntax highlighting, and tables (SC-002), (4) homepage "Latest Articles" shows the single most recent post with title, date, description, linking to the article (SC-005), (5) dark mode renders correctly on homepage, blog index, and article pages (SC-008), (6) existing pages unchanged (SC-009), (7) blog section does NOT display sidebar navigation — confirm no sidebar appears on blog index or article pages (FR-003)
+- [x] T016 Verify article appears in RSS feed output — check `public/index.xml` or the RSS output for blog post entry (SC-007)
+- [x] T017 Verify article appears in search index — check `public/search-index.json` for blog post entry, or use the site search in `npm run dev` to search for "contract coverage" (SC-006)
+
+**Checkpoint**: All success criteria (SC-001 through SC-010) validated. Feature is complete.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 1)**: No dependencies — can start immediately. All 3 config tasks (T001-T003) are parallelizable (different files).
+- **US2 - Blog Infrastructure (Phase 2)**: Depends on Phase 1 completion (config must be in place before creating content).
+- **US1 - Article Content (Phase 3)**: Depends on Phase 2 (blog section must exist). This is the MVP delivery.
+- **US3 - Homepage Integration (Phase 4)**: Depends on Phase 3 (needs at least one blog post to display dynamically).
+- **Polish (Phase 5)**: Depends on all previous phases.
+
+### User Story Dependencies
+
+- **User Story 2 (P1)**: Depends on Foundational config (Phase 1). No other story dependencies.
+- **User Story 1 (P1)**: Depends on US2 (blog section must exist for article to be published).
+- **User Story 3 (P2)**: Depends on US1 (homepage section queries blog posts — needs at least one to render).
+
+### Within Each User Story
+
+- Article tasks T007-T010 (accuracy corrections) can be done in any order but all depend on T006 (article creation).
+- Homepage task T012 is a single file edit — no internal parallelism.
+
+### Parallel Opportunities
+
+Within Phase 1 (Foundational):
+
+```
+T001 (params.toml) | T002 (hugo.toml) | T003 (menus.en.toml) — all in parallel
+```
+
+Within Phase 3 (US1 - Article):
+
+```
+After T006 completes:
+T007 (FR-009 correction) | T008 (FR-010 correction) | T009 (FR-011 correction) | T010 (FR-012 correction) — all in parallel (different sections of same file, but non-overlapping edits)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2)
+
+1. Complete Phase 1: Foundational config (3 parallel tasks)
+2. Complete Phase 2: Blog section index (US2)
+3. Complete Phase 3: Article with corrections (US1)
+4. **STOP and VALIDATE**: Blog is functional — article accessible via navbar, correct URL, accurate content
+5. This is the MVP: a working blog with one published article
+
+### Full Delivery
+
+6. Complete Phase 4: Homepage integration (US3)
+7. Complete Phase 5: Polish and final verification
+8. All success criteria validated
+
+---
+
+## Notes
+
+- No automated tests — validation is `npm run build` + visual verification via `npm run dev`
+- The Doks theme provides built-in blog templates (`blog/list.html`, `blog/single.html`) — no custom layout files needed for the blog section itself
+- The only template modification is to `layouts/home.html` for the "Latest Articles" homepage section
+- Article accuracy corrections (T007-T010) were derived from verifying 15 claims against the Gaze repository source code
+- Commit after each phase checkpoint to maintain clean git history


### PR DESCRIPTION
## Summary

- Add a Blog section to the website using Doks built-in blog templates (no custom layouts for the blog itself)
- Publish the "Why Contract Coverage" article as the first blog post, explaining Gaze's core metric for measuring whether tests verify what functions are actually responsible for
- Add a "Latest Articles" section to the homepage that dynamically displays the single most recent blog post

## Changes

### Configuration (3 files)
- `config/_default/params.toml` — added `"blog"` to `mainSections` for RSS/search
- `config/_default/hugo.toml` — added blog permalink pattern (`/blog/:slug/`)
- `config/_default/menus/menus.en.toml` — added Blog navbar entry (weight 5)

### Content (2 new files)
- `content/blog/_index.md` — blog section index page
- `content/blog/why-contract-coverage.md` — full article adapted from source with 4 accuracy corrections applied

### Template (1 file)
- `layouts/home.html` — added "Latest Articles" section between Projects and CTA, dynamically sourcing the most recent blog post

### Spec artifacts (7 new files)
- `specs/003-blog-why-gaze/` — spec, plan, research, data model, quickstart, tasks, quality checklist

## Accuracy Corrections Applied

All 15 technical claims in the article were verified against the Gaze repository source code. Four required corrections:

1. **AI agent claim** — clarified as an external OpenCode agent workflow, not a built-in Gaze feature
2. **GazeCRAP formula** — added `/100` divisor for consistent notation with the CRAP formula
3. **CLI commands** — fixed `gaze quality` to use single package argument; replaced nonexistent `--gaze` flag with actual flag names
4. **Static analysis description** — added caveat that the `crap` subcommand can optionally invoke `go test` for line coverage data

## Verification

- `npm run build` succeeds with zero errors (26 pages generated)
- Blog post accessible at `/blog/why-contract-coverage/`
- Article appears in RSS feed (`index.xml`) and search index (`search-index.json`)
- Homepage "Latest Articles" section renders between Projects and CTA
- Dark mode compatible (Bootstrap semantic CSS classes used throughout)
- Visual verification confirmed by user