### PR TITLE
feat: add documentation content pages for all four sections

### DIFF
--- a/config/_default/module.toml
+++ b/config/_default/module.toml
@@ -87,6 +87,13 @@
   source = "assets"
   target = "assets"
 
+# Mount static to assets so the image render hook can process static images
+# (resize, convert to webp, responsive srcset). Without this, Markdown images
+# referencing /images/... in static/ would bypass Hugo's image pipeline.
+[[mounts]]
+  source = "static"
+  target = "assets"
+
 ## static
 [[mounts]]
   source = "node_modules/@thulite/doks-core/static"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -19,8 +19,8 @@ mainSections = ["docs", "blog"]
   navbarSticky = true
   containerBreakpoint = "lg"
 
-  ## Button — disabled until docs content exists (spec 002)
-  navBarButton = false
+  ## Button
+  navBarButton = true
   navBarButtonUrl = "/docs/getting-started/"
   navBarButtonText = "Get Started"
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Documentation"
+description: "Learn about Unbound Force, its projects, agent personas, and how to contribute."
+lead: "Everything you need to know about the AI agent swarm for software engineering."
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 1
+toc: false
+---
+
+Explore the documentation to learn about Unbound Force, its projects, and how to get started.

--- a/content/docs/contributing/_index.md
+++ b/content/docs/contributing/_index.md
@@ -1,0 +1,79 @@
+---
+title: "Contributing"
+description: "How to contribute to Unbound Force projects — reporting issues, submitting pull requests, and following project conventions."
+lead: "Join the swarm. Here is how to contribute to Unbound Force projects."
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 10
+toc: true
+---
+
+## Reporting Issues
+
+Found a bug or have a feature request? Open an issue on the relevant GitHub repository:
+
+- [Unbound Force Website](https://github.com/unbound-force/website/issues) — this website
+- [Gaze](https://github.com/unbound-force/gaze/issues) — test quality analysis tool
+- [Unbound Force](https://github.com/unbound-force/unbound-force/issues) — agent personas and roles
+
+Include steps to reproduce, expected behavior, and actual behavior. For feature requests, describe the problem you are trying to solve.
+
+## Submitting Pull Requests
+
+We follow the standard GitHub pull request workflow:
+
+1. Fork the repository
+2. Create a feature branch named with a number prefix (e.g., `003-feature-name`)
+3. Make your changes
+4. Submit a pull request against the `main` branch
+5. Address any review feedback from The Divisor council
+
+All pull requests are reviewed by The Divisor — a council of three sub-personas (The Guard, The Architect, and The Adversary) that evaluate intent, structure, and resilience. Collective approval from all three is required before merge.
+
+## Conventional Commits
+
+All commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```text
+type: description
+```
+
+Valid types:
+
+| Type        | Purpose            | Example                                       |
+| ----------- | ------------------ | --------------------------------------------- |
+| `feat:`     | New feature        | `feat: add Gaze project page`                 |
+| `fix:`      | Bug fix            | `fix: correct broken link in team navigation` |
+| `docs:`     | Documentation      | `docs: update getting started guide`          |
+| `chore:`    | Maintenance        | `chore: update dependencies`                  |
+| `style:`    | Formatting         | `style: fix indentation in config file`       |
+| `refactor:` | Code restructuring | `refactor: simplify homepage template logic`  |
+| `ci:`       | CI/CD changes      | `ci: add build verification step`             |
+
+## The Speckit Workflow
+
+All non-trivial feature work goes through the [Specify](https://github.com/github/spec-kit) pipeline. This ensures structured planning before implementation:
+
+```text
+constitution -> specify -> clarify -> plan -> tasks -> analyze -> checklist -> implement
+```
+
+Each stage builds on the previous one:
+
+- **Constitution** — project-level governance and principles
+- **Specify** — turn a feature description into a structured specification
+- **Clarify** — reduce ambiguity before planning
+- **Plan** — generate the technical implementation plan
+- **Tasks** — create actionable, dependency-ordered task list
+- **Analyze** — cross-artifact consistency check
+- **Checklist** — requirement quality validation
+- **Implement** — execute the plan task by task
+
+The constitution (`.specify/memory/constitution.md`) is the highest-authority document in any Unbound Force project. All work must align with it.
+
+## Links
+
+- [Unbound Force GitHub Organization](https://github.com/unbound-force)
+- [Website Repository](https://github.com/unbound-force/website)
+- [Gaze Repository](https://github.com/unbound-force/gaze)
+- [Specify (spec-kit)](https://github.com/github/spec-kit)

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -1,0 +1,43 @@
+---
+title: "What is Unbound Force?"
+description: "Unbound Force is a superhero-themed AI agent swarm for software engineering — purpose-built personas, structured workflows, and quality-first development."
+lead: "A superhero-themed AI agent swarm that brings structure, quality, and velocity to software engineering."
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 10
+toc: true
+---
+
+## The AI Agent Swarm for Software Engineering
+
+Unbound Force is a set of purpose-built agent personas designed to work as a coordinated software engineering team. Themed as a superhero squad, each persona fills a distinct role — Product Owner, Developer, Tester, PR Reviewer, and Manager — and operates inside your development environment as an AI-powered collaborator.
+
+But these are not just instruction files. Each hero can include LSP servers, MCP servers, tooling, tasks, commands, plugins, and other technologies that enable them to do their job. They are designed to be the pinnacle archetype of their role.
+
+## Three Tools, One Workflow
+
+Unbound Force is built on three complementary tools that form a layered stack:
+
+| Layer            | Tool                                          | What It Does                                                                                                    |
+| ---------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **Agent**        | [OpenCode](https://opencode.ai)               | The AI coding environment where you interact, write code, and run commands. The personas run inside OpenCode.   |
+| **Planning**     | [Specify](https://github.com/github/spec-kit) | A specification pipeline that turns ideas into structured specs, plans, and tasks before implementation begins. |
+| **Coordination** | [Swarm](https://www.swarmtools.ai/)           | An OpenCode plugin that enables multi-agent parallelism and learning amongst team members.                      |
+
+Each tool is independently useful, but they compose into the full Unbound Force workflow: plan with Specify, execute with OpenCode, coordinate with Swarm.
+
+## The Heroes
+
+The swarm consists of five personas, each representing the pinnacle archetype of their role:
+
+- **[Muti-Mind](/docs/team/muti-mind/)** — Product Owner. The Vision Keeper and Prioritization Engine.
+- **[Cobalt-Crush](/docs/team/cobalt-crush/)** — Developer. The Engineering Core and Adaptive Implementation Engine.
+- **[Gaze](/docs/team/gaze-tester/)** — Tester. The Quality Sentinel and Predictive Validation Engine.
+- **[The Divisor](/docs/team/the-divisor/)** — PR Reviewer Council. The Architectural Conscience and Code Integrity Guardian.
+- **[Mx F](/docs/team/mx-f/)** — Manager. The Flow Facilitator and Continuous Improvement Coach.
+
+Together, they cover the full software development lifecycle — from requirements and planning through implementation, testing, review, and process improvement.
+
+## Get Started
+
+Ready to dive in? Head to the [Quick Start](/docs/getting-started/quick-start/) guide to install the tools and start using the swarm.

--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -1,0 +1,77 @@
+---
+title: "Quick Start"
+description: "Get started with the Unbound Force tools — install OpenCode, Specify, and Swarm to begin using the AI agent swarm for software engineering."
+lead: "Install the tools, set up the workflow, and start building with the swarm."
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 20
+toc: true
+---
+
+## The Stack
+
+Unbound Force runs on three tools that form a layered stack. You can adopt them incrementally — each is useful on its own — but they work best together.
+
+## OpenCode — The Agent Layer
+
+OpenCode is the AI coding environment where you interact, write code, and run commands. The Unbound Force personas run inside OpenCode as agents with specialized instructions, tools, and commands.
+
+### Install OpenCode
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+### Why OpenCode?
+
+OpenCode provides the runtime for AI-powered development. When you work inside OpenCode, you get access to slash commands (like `/gaze` for test quality analysis), agent personas (like Cobalt-Crush for development), and tool integrations that connect the swarm to your codebase.
+
+## Specify — The Planning Layer
+
+Specify is a specification pipeline that turns ideas into structured specs, plans, and tasks before a single line of code is written. It enforces a sequential workflow: specify, clarify, plan, then implement.
+
+### Install Specify
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+```
+
+Then initialize it in your project:
+
+```bash
+specify init <project> --ai opencode
+```
+
+### Why Specify?
+
+Without structured planning, AI agents tend to build the wrong thing or drift from the original intent. Specify solves this by creating a pipeline — constitution, specification, clarification, plan, tasks — that each agent follows. The result: less rework, clearer requirements, and implementations that match what was actually requested.
+
+## Swarm — The Coordination Layer
+
+Swarm is an OpenCode plugin that enables multi-agent parallelism. It spawns workers, coordinates tasks via file reservations, and enables learning amongst team members.
+
+### Install Swarm
+
+```bash
+npm install -g opencode-swarm-plugin@latest
+```
+
+Then set it up:
+
+```bash
+swarm setup
+```
+
+### Why Swarm?
+
+A single AI agent can only do one thing at a time. Swarm lets you run multiple Unbound Force personas in parallel — Cobalt-Crush coding one feature while Gaze writes tests for another — with coordination that prevents conflicts. As the team works together, Swarm captures learnings that make each persona more effective over time.
+
+## Putting It Together
+
+The typical Unbound Force workflow looks like this:
+
+1. **Plan** with Specify — turn your idea into a spec, clarify the requirements, generate a task list
+2. **Execute** with OpenCode — the personas implement, test, and review the tasks
+3. **Coordinate** with Swarm — run multiple personas in parallel for faster delivery
+
+Start with OpenCode to get comfortable with the agent environment, add Specify when you want structured planning, and bring in Swarm when you are ready for multi-agent parallelism.

--- a/content/docs/projects/_index.md
+++ b/content/docs/projects/_index.md
@@ -1,0 +1,15 @@
+---
+title: "Projects"
+description: "Open source projects from Unbound Force — tools and technologies that power the AI agent swarm."
+lead: "Tools and technologies built by the Unbound Force team."
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 10
+toc: false
+---
+
+## Current Projects
+
+### [Gaze](/docs/projects/gaze/)
+
+Test quality analysis via side effect detection for Go. Gaze detects every observable side effect a function produces, classifies each effect as contractual or incidental, and measures whether your tests actually assert on the things that matter. It introduces three metrics — Contract Coverage, Over-Specification Score, and GazeCRAP — that go beyond line coverage to reveal the real quality of your test suite.

--- a/content/docs/projects/gaze.md
+++ b/content/docs/projects/gaze.md
@@ -1,0 +1,157 @@
+---
+title: "Gaze"
+description: "Test quality analysis via side effect detection for Go — Contract Coverage, Over-Specification Score, and GazeCRAP metrics that go beyond line coverage."
+lead: "Test quality analysis via side effect detection for Go."
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 20
+toc: true
+---
+
+## What Gaze Does
+
+Line coverage tells you which lines ran. It does not tell you whether your tests actually verified anything meaningful.
+
+A function can have 90% line coverage and tests that assert on nothing contractually important — logging calls, goroutine lifecycle, internal stdout writes — while leaving the return values, error paths, and state mutations completely unverified. That function is dangerous to change, and traditional coverage metrics will not warn you.
+
+Gaze fixes this by working from first principles:
+
+1. **Detect** every observable side effect a function produces — return values, error returns, mutations, I/O, channel sends, and more.
+2. **Classify** each effect as _contractual_ (part of the function's public obligation), _incidental_ (an implementation detail), or _ambiguous_.
+3. **Measure** whether your tests actually assert on the contractual effects — and flag the ones they do not.
+
+Gaze requires no annotations, no test framework changes, and no restructuring of your code. It analyzes your existing Go packages as-is.
+
+## Key Metrics
+
+### Contract Coverage
+
+The percentage of a function's contractual side effects that at least one test assertion verifies.
+
+```text
+ContractCoverage% = (contractual effects asserted on / total contractual effects) x 100
+```
+
+A function with 90% line coverage but 20% contract coverage has tests that run code without checking correctness. Gaze surfaces the specific effects that have no assertion — the exact gaps you need to close.
+
+| Range         | Status  |
+| ------------- | ------- |
+| 80% or higher | Good    |
+| 50-79%        | Warning |
+| Below 50%     | Bad     |
+
+### Over-Specification Score
+
+The count and ratio of test assertions that target _incidental_ effects — implementation details that are not part of the function's contract.
+
+```text
+OverSpec.Ratio = incidental assertions / total mapped assertions
+```
+
+Tests that assert on log output, goroutine lifecycle, or internal stdout will break during refactoring even when the function's actual contract is preserved. Gaze identifies each over-specified assertion and explains why it is fragile.
+
+| Count       | Status  |
+| ----------- | ------- |
+| 0           | Good    |
+| 1-3         | Warning |
+| More than 3 | Bad     |
+
+### GazeCRAP
+
+A composite risk score that replaces line coverage with contract coverage in the CRAP (Change Risk Anti-Patterns) formula.
+
+```text
+CRAP(m)     = complexity^2 x (1 - lineCoverage/100)^3 + complexity
+GazeCRAP(m) = complexity^2 x (1 - contractCoverage)^3 + complexity
+```
+
+Functions are placed in a quadrant based on both scores:
+
+|               | Low GazeCRAP       | High GazeCRAP             |
+| ------------- | ------------------ | ------------------------- |
+| **Low CRAP**  | Safe               | Simple but underspecified |
+| **High CRAP** | Complex but tested | **Dangerous**             |
+
+The **Dangerous** quadrant — complex functions whose tests do not verify their contracts — is the highest-priority target for remediation.
+
+## Using Gaze
+
+Gaze integrates with [OpenCode](https://opencode.ai) through the `/gaze` slash command. This is the primary way to use Gaze for test quality analysis.
+
+### Setup
+
+First, install the Gaze binary:
+
+```bash
+brew install unbound-force/tap/gaze
+```
+
+Or via Go:
+
+```bash
+go install github.com/unbound-force/gaze/cmd/gaze@latest
+```
+
+Then scaffold the OpenCode integration in your Go project:
+
+```bash
+gaze init
+```
+
+This creates four files in `.opencode/` that wire up the `/gaze` command and a quality reporting agent.
+
+### The `/gaze` Command
+
+Inside OpenCode, use `/gaze` to get AI-assisted quality reports:
+
+```text
+/gaze                           # Full report for entire module
+/gaze crap ./internal/store     # CRAP scores only
+/gaze quality ./pkg/api         # Contract Coverage metrics only
+```
+
+### Three Modes
+
+| Mode           | What You Get                                                                |
+| -------------- | --------------------------------------------------------------------------- |
+| Full (default) | CRAP Summary + Quality Summary + Classification Summary + Health Assessment |
+| `crap`         | CRAPload count, top 5 worst scores, GazeCRAP quadrant distribution          |
+| `quality`      | Contract coverage, gaps, over-specification, worst tests                    |
+
+The `/gaze` command routes to a quality reporting agent that runs the analysis, interprets the JSON output, and produces human-readable markdown summaries with tables, key metrics, and actionable recommendations.
+
+A companion command, `/classify-docs`, enhances classification by combining mechanical signals with project documentation analysis.
+
+## Architecture
+
+Gaze is structured as a set of focused packages:
+
+| Package    | Purpose                                                           |
+| ---------- | ----------------------------------------------------------------- |
+| `analysis` | Side effect detection engine — the core analysis orchestrator     |
+| `taxonomy` | Side effect type system with stable IDs and tier classification   |
+| `classify` | Contractual classification engine                                 |
+| `config`   | Configuration file handling (`.gaze.yaml`)                        |
+| `loader`   | Go package loading wrapper                                        |
+| `report`   | JSON and text output formatters                                   |
+| `crap`     | CRAP score computation and reporting                              |
+| `quality`  | Test quality assessment — contract coverage and assertion mapping |
+| `docscan`  | Documentation file scanner for enhanced classification            |
+| `scaffold` | OpenCode file scaffolding for `/gaze` command setup               |
+
+The analysis engine detects side effects across three implemented tiers (P0, P1, P2), covering the most common and impactful effect types — from return values and error returns through mutations, I/O, channel operations, and more.
+
+## Current Limitations
+
+Gaze is actively developed. The current scope has known boundaries:
+
+- **Direct function body only.** Gaze analyzes the immediate function body. Transitive side effects (effects produced by called functions) are out of scope for v1.
+- **P3-P4 side effects not yet detected.** The taxonomy defines types for stdout/stderr writes, environment mutations, mutex operations, reflection, and unsafe, but detection logic for these tiers is not yet implemented.
+- **Assertion mapping accuracy is ~78.8%.** The target is 90%. Accuracy is primarily limited by helper function assertions and testify field-access patterns (tracked as [GitHub Issue #6](https://github.com/unbound-force/gaze/issues/6)).
+- **No CGo or unsafe analysis.** Functions using `cgo` or `unsafe.Pointer` are not analyzed for their specific side effects.
+- **Single package loading.** The `analyze` command processes one package at a time.
+
+## Learn More
+
+- [GitHub Repository](https://github.com/unbound-force/gaze) — source code, issues, and releases
+- [Why Contract Coverage?](/blog/why-contract-coverage/) — a deeper look at why line coverage is not enough and how contract coverage changes the way you think about test quality

--- a/content/docs/team/_index.md
+++ b/content/docs/team/_index.md
@@ -1,0 +1,35 @@
+---
+title: "The Team"
+description: "Meet the Unbound Force heroes — five AI agent personas that form a superhero-themed software engineering swarm."
+lead: "The Heroes of the Unbound Force — A.G.I. Development Squad."
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 10
+toc: true
+---
+
+![The Unbound Force — A.G.I. Development Squad](/images/team/the-unbound-force.jpeg)
+
+## Meet the Heroes
+
+Unbound Force is a superhero-themed AI agent swarm where each persona represents the pinnacle archetype of their role. These are not just instruction files — they can include LSP servers, MCP servers, tooling, tasks, commands, plugins, and other technologies that enable each hero to do their job.
+
+### [Muti-Mind](/docs/team/muti-mind/) — Product Owner
+
+_The Vision Keeper and Prioritization Engine._ Muti-Mind is the voice of the product and the final arbiter of value. They own the backlog, define goals, and serve as the authorized delegate of user needs — ensuring the swarm is always focused on the highest-leverage work.
+
+### [Cobalt-Crush](/docs/team/cobalt-crush/) — Developer
+
+_The Engineering Core and Adaptive Implementation Engine._ Cobalt-Crush translates requirements into robust, scalable software. They operate within a tight feedback loop with Gaze and Muti-Mind, turning abstract requirements into concrete, high-quality code with minimal overhead.
+
+### [Gaze](/docs/team/gaze-tester/) — Tester
+
+_The Quality Sentinel and Predictive Validation Engine._ Gaze protects the product's integrity through proactive, continuous validation. They go beyond reactive testing to predictive analysis, ensuring quality is built in rather than inspected on.
+
+### [The Divisor](/docs/team/the-divisor/) — PR Reviewer Council
+
+_The Architectural Conscience and Code Integrity Guardian._ The Divisor operates as a council of three sub-personas — The Guard, The Architect, and The Adversary — providing comprehensive, multi-faceted validation of every code submission.
+
+### [Mx F](/docs/team/mx-f/) — Manager
+
+_The Flow Facilitator and Continuous Improvement Coach._ Mx F serves as a servant leader and coach, maximizing the team's flow and self-organization. They guide through reflective questions rather than direct solutions, making the swarm a learning organization.

--- a/content/docs/team/cobalt-crush.md
+++ b/content/docs/team/cobalt-crush.md
@@ -1,0 +1,43 @@
+---
+title: "Cobalt-Crush"
+description: "Cobalt-Crush is the Developer of the Unbound Force swarm — the Engineering Core that turns requirements into robust software."
+lead: "The Engineering Core and Adaptive Implementation Engine"
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 30
+toc: true
+---
+
+![Cobalt-Crush — Developer trading card](/images/team/cobalt-crush.png)
+
+## The Engineering Core
+
+Cobalt-Crush is the Developer of the Unbound Force swarm — the engineering core that translates precise requirements from Muti-Mind into robust, scalable, and maintainable software solutions. Cobalt-Crush adheres to the architectural standards set by The Divisor and ensures high quality validated by Gaze, operating within a continuous integration and continuous delivery paradigm that maximizes velocity for the swarm.
+
+Cobalt-Crush relies on the clear vision from Muti-Mind and the immediate feedback from Gaze's test suite to maintain relentless development flow and minimize time spent on rework or ambiguity resolution.
+
+## Key Responsibilities
+
+### High-Velocity Implementation
+
+Cobalt-Crush is responsible for the actual development of features, fixes, and architectural improvements. They use advanced programming techniques and adhere to best practices — clean code principles, SOLID — to ensure the delivered codebase is high quality and easily maintainable.
+
+### CI/CD Focus
+
+Every code commit is integrated cleanly, immediately leveraging Gaze's automated testing pipelines to validate the work. Cobalt-Crush rapidly addresses any failures flagged by Gaze, viewing test feedback as an integral part of the development process rather than a separate activity.
+
+### Technical Problem Solving
+
+When technical challenges arise, Cobalt-Crush is the primary entity for resolution. They collaborate with The Divisor on complex architectural decisions and provide accurate technical effort estimations to Muti-Mind, informing the prioritization process.
+
+### Architectural Adherence
+
+While The Divisor sets the architectural blueprint, Cobalt-Crush ensures the code implementation adheres to those standards. The focus is on modularity, performance optimization, security implementation, and scalability — proactively consulting The Divisor when deviation or clarification is needed.
+
+## How Cobalt-Crush Serves the Team
+
+**For the Product Owner (Muti-Mind):** Cobalt-Crush translates Muti-Mind's "What" into a tangible "How," providing the technical perspective necessary for realistic planning. They offer technical input during refinement — pointing out constraints or better design approaches — and provide reliable estimates that drive prioritization.
+
+**For the Tester (Gaze):** The relationship between Cobalt-Crush and Gaze is highly collaborative and iterative. Cobalt-Crush actively consumes instant feedback from Gaze's CI pipeline to immediately fix defects. They also implement testability requests from Gaze, ensuring the code is designed to be easily validated.
+
+**For the Reviewer (The Divisor):** Cobalt-Crush ensures that code delivered for review is functionally complete (validated by Gaze) and adheres to architectural standards (set by The Divisor). By addressing quality proactively through Gaze's pipeline, Cobalt-Crush allows The Divisor to focus on high-level architectural integrity rather than simple defect finding.

--- a/content/docs/team/gaze-tester.md
+++ b/content/docs/team/gaze-tester.md
@@ -1,0 +1,53 @@
+---
+title: "Gaze"
+description: "Gaze is the Tester of the Unbound Force swarm — the Quality Sentinel and Predictive Validation Engine that protects the product through proactive testing."
+lead: "The Quality Sentinel and Predictive Validation Engine"
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 40
+toc: true
+---
+
+![Gaze — Tester trading card](/images/team/gaze.png)
+
+## The Quality Sentinel
+
+Gaze is the Tester of the Unbound Force swarm — the ultimate quality guardian dramatically enhanced by modern AI and advanced validation techniques. Gaze's primary mission is to protect the product's integrity and ensure the delivered increment not only meets the specified requirements but also anticipates and guards against potential failures in production.
+
+Operating as the Quality Sentinel, Gaze moves beyond mere reactive testing of completed code to proactive, continuous validation throughout the development lifecycle. Quality is built in, not inspected on.
+
+> **Note:** This page describes Gaze the _persona_ — the tester role within the swarm. For the Gaze _tool_ (test quality analysis via side effect detection for Go), see the [Gaze project page](/docs/projects/gaze/).
+
+## Key Responsibilities
+
+### Proactive Test Strategy
+
+Gaze works parallel to Cobalt-Crush from the outset, designing test strategies that cover functional, non-functional (performance, security, usability), and integration aspects. This includes translating Muti-Mind's acceptance criteria into executable, maintainable test cases and leveraging AI to identify high-risk areas in the design phase — shifting testing further left.
+
+### Testability Enhancement
+
+Gaze actively partners with Cobalt-Crush, requesting specific changes to the code or architecture — adding hooks, instrumentation, or refactoring complex logic — to improve the testability and observability of the system. This proactive communication ensures the final code is inherently easier to validate.
+
+### CI/CV Pipeline Ownership
+
+Gaze owns the automated testing pipelines. Every code commit from Cobalt-Crush triggers a comprehensive suite of unit, integration, and end-to-end tests, providing instantaneous feedback on code health. Gaze maintains test suite efficiency, prioritizes execution of the highest-value tests first, and minimizes false negatives and positives through adaptive test selection.
+
+### Intelligent Defect Detection
+
+Using AI-powered log analysis and telemetry data, Gaze identifies potential defects and anomalies before they manifest as critical failures. Defect reporting, categorization, and triage are automated, providing Cobalt-Crush with precise context — reproduction steps, environment details, relevant stack traces — to speed up resolution.
+
+### Risk-Based Testing
+
+Gaze uses machine learning to analyze historical data — past defects, code complexity, team velocity, Muti-Mind's prioritization — to calculate risk scores for new features or modifications. This allows dynamic adjustment of test coverage, focusing intensive testing efforts on the areas of highest predicted failure risk.
+
+### Performance and Security Profiling
+
+Gaze continuously monitors and validates non-functional requirements through automated load testing, stress testing, and static and dynamic analysis security tools — proactively uncovering vulnerabilities and performance bottlenecks.
+
+## How Gaze Serves the Team
+
+**For Developers (Cobalt-Crush):** When Cobalt-Crush commits code, Gaze provides immediate, actionable feedback via the CI/CV pipeline. The automation suite acts as an instant safety net — if a test fails, Gaze provides clear error reporting and the context necessary to pinpoint the fault quickly. Gaze can also request code changes to make features more testable.
+
+**For the Product Owner (Muti-Mind):** Muti-Mind relies on Gaze's acceptance reports to confirm that the delivered increment meets the definition of done. Detailed, automated validation reports serve as objective evidence of quality and functional completeness. Predictive analysis also provides risk assessments for upcoming features, informing prioritization strategy.
+
+**For the Reviewer and Manager (The Divisor and Mx F):** The Divisor and Mx F need assurance that code being merged is high quality and stable. Gaze's comprehensive test coverage and clean CI/CV status are the critical prerequisites for code review and deployment decisions.

--- a/content/docs/team/gaze-tester.md
+++ b/content/docs/team/gaze-tester.md
@@ -16,8 +16,6 @@ Gaze is the Tester of the Unbound Force swarm — the ultimate quality guardian 
 
 Operating as the Quality Sentinel, Gaze moves beyond mere reactive testing of completed code to proactive, continuous validation throughout the development lifecycle. Quality is built in, not inspected on.
 
-> **Note:** This page describes Gaze the _persona_ — the tester role within the swarm. For the Gaze _tool_ (test quality analysis via side effect detection for Go), see the [Gaze project page](/docs/projects/gaze/).
-
 ## Key Responsibilities
 
 ### Proactive Test Strategy

--- a/content/docs/team/muti-mind.md
+++ b/content/docs/team/muti-mind.md
@@ -1,0 +1,43 @@
+---
+title: "Muti-Mind"
+description: "Muti-Mind is the Product Owner of the Unbound Force swarm — the Vision Keeper and Prioritization Engine who serves as the voice of the product."
+lead: "The Vision Keeper and Prioritization Engine"
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 20
+toc: true
+---
+
+![Muti-Mind — Product Owner trading card](/images/team/multi-mind.png)
+
+## The Voice of the Product
+
+Muti-Mind is the Product Owner of the Unbound Force swarm — the definitive voice of the product and the final arbiter of value. Their primary function is to maximize the value resulting from the work of the development team and to ensure the backlog effectively communicates what the team should work on next.
+
+Muti-Mind achieves this by deeply internalizing the user's perspective and needs, acquired through comprehensive engagement with requirements, specifications, and market intelligence. When the swarm is executing, Muti-Mind is the authorized and informed delegate of user needs — the single source of truth for all "Why" and "What" questions.
+
+## Key Responsibilities
+
+### Backlog Ownership
+
+Muti-Mind owns the Product Backlog, ensuring it is transparent, visible, and understood. This includes defining backlog items, clearly expressing them, and ordering them to best achieve goals and missions.
+
+### Value-Driven Prioritization
+
+The core strength of Muti-Mind lies in leveraging data analytics, market intelligence, and team capacity insights to continuously refine the backlog ordering. Work is prioritized based on expected business value, risk, dependencies, and urgency — ensuring the swarm is always focused on the highest-leverage tasks.
+
+### Goal Articulation
+
+Muti-Mind defines the Product Goal and Sprint Goals, articulating a clear "Why" and "What" for every increment of work. This vision is communicated relentlessly to the development team and manager, minimizing ambiguity and facilitating autonomous execution.
+
+### Acceptance Authority
+
+Muti-Mind serves as the acceptance authority, inspecting the outcome of every sprint and determining whether the delivered increment meets the definition of done and the specified acceptance criteria. During refinement, Muti-Mind translates pre-collected user insights into precise, actionable requirements, making the documented criteria the official, reliable proxy for the user's need.
+
+## How Muti-Mind Serves the Team
+
+**For Developers (Cobalt-Crush):** When a developer encounters an ambiguity in a backlog item, they consult Muti-Mind for immediate clarification on intended user value, acceptance criteria, or technical outcome. This minimizes analysis paralysis and ensures the solution aligns with the articulated business need.
+
+**For Testers (Gaze):** Testers rely on clear, well-defined acceptance criteria to design effective test cases. Muti-Mind ensures backlog items are ready with unambiguous criteria. When a test result is unclear or a boundary condition is undocumented, Muti-Mind provides the clarification needed to determine if a behavior is a bug or an intended feature.
+
+**For Reviewers (The Divisor):** Reviewers need a clear baseline against which to judge the increment. Muti-Mind's prioritized vision and expressed acceptance criteria provide that baseline, allowing reviewers to focus on architectural quality and completeness knowing the correct scope and functional requirements are already defined.

--- a/content/docs/team/mx-f.md
+++ b/content/docs/team/mx-f.md
@@ -1,0 +1,47 @@
+---
+title: "Mx F"
+description: "Mx F is the Manager of the Unbound Force swarm — the Flow Facilitator and Continuous Improvement Coach who serves as a servant leader maximizing team flow."
+lead: "The Flow Facilitator and Continuous Improvement Coach"
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 60
+toc: true
+---
+
+![Mx F — Manager trading card](/images/team/mx-f.png)
+
+## The Flow Facilitator
+
+Mx F (Mx Found) is the Manager of the Unbound Force swarm — a servant leader, coach, and obstacle remover. Their core mission is to maximize the team's flow, self-organization, and continuous improvement, ensuring that the collective velocity and quality of the system are always increasing.
+
+Mx F does not dictate technical or product decisions — those belong to The Divisor and Muti-Mind respectively. Instead, Mx F ensures the _process_ itself is healthy, efficient, and relentlessly focused on learning. They achieve this by actively listening, asking powerful reflective questions, and intervening only to facilitate the team's own path to resolution.
+
+## Key Responsibilities
+
+### Coaching Through Reflection
+
+Mx F acts as the primary coach, guiding the team toward self-organization and cross-functional mastery. When the team encounters a blocker or failure, Mx F does not provide solutions. Instead, they use mirroring and probing questions — techniques like the 5 Whys — to help individuals or the team reflect on root causes and devise their own path forward. This fosters deep, contextual learning and minimizes dependency on external authority.
+
+### Obstacle Removal
+
+Mx F is responsible for identifying and aggressively removing internal and external impediments that slow the team down. This can range from mediating conflicts to managing dependencies with external stakeholders, ensuring the development process remains a smooth, uninterrupted flow.
+
+### Process Stewardship
+
+Mx F owns continuous process improvement. They facilitate the swarm's regular retrospectives and leverage data — velocity, defect rates, cycle time, The Divisor's review feedback — to help the team define, implement, and measure iterative process changes.
+
+### Stakeholder Liaison
+
+While Muti-Mind handles product alignment, Mx F manages interaction, communication, and expectation setting with external organizational leaders and stakeholders regarding team capacity, project status, and resource needs. This protects the team's focus.
+
+### Capacity and Health Monitoring
+
+Mx F monitors the overall health of the team — detecting burnout, managing resource constraints, and ensuring the team has the necessary tools and environment to operate at peak performance.
+
+## How Mx F Serves the Team
+
+**For Developers (Cobalt-Crush) and Testers (Gaze):** When Cobalt-Crush or Gaze faces a non-technical blocker — a process ambiguity, a resource constraint, a disagreement on scope — they consult Mx F. Instead of resolving the issue directly, Mx F's coaching helps them gain clarity and ownership over the solution, rapidly restoring their development flow.
+
+**For the Product Owner (Muti-Mind):** Mx F partners with Muti-Mind to ensure the backlog process — refinement, prioritization, communication — is running efficiently and that Muti-Mind is not overloaded. Mx F's process data is critical input for prioritization, allowing Muti-Mind to factor in team capacity and efficiency gains when setting goals.
+
+**For the Reviewer (The Divisor):** Mx F uses The Divisor's data — common architectural pitfalls, repetitive review feedback — as key metrics for process improvement. If The Divisor frequently requests the same type of change, Mx F facilitates a process change or training session to integrate that learning into the upstream workflow, making the review process faster and more effective over time.

--- a/content/docs/team/the-divisor.md
+++ b/content/docs/team/the-divisor.md
@@ -1,0 +1,60 @@
+---
+title: "The Divisor"
+description: "The Divisor is the PR Reviewer Council — three sub-personas (The Guard, The Architect, The Adversary) serving as the Code Integrity Guardian."
+lead: "The Architectural Conscience and Code Integrity Guardian"
+date: 2026-02-23T00:00:00+00:00
+draft: false
+weight: 50
+toc: true
+---
+
+![The Divisor — PR Reviewer Council trading card](/images/team/the-divisor.png)
+
+## The Code Integrity Guardian
+
+The Divisor is the PR Reviewer of the Unbound Force swarm — the architectural conscience and code integrity guardian. Their mission is to ensure that all code changes proposed by Cobalt-Crush, once validated by Gaze, adhere strictly to established architectural standards, best practices, security policies, and maintainability requirements.
+
+The Divisor acts as the final technical gate before integration, translating high-level architectural standards into actionable review criteria. What makes The Divisor unique is its structure: it operates as a **council of three distinct sub-personas**, each providing a different lens on every code submission.
+
+## The Council
+
+### The Guard — Intent and Cohesion
+
+The Guard focuses on the _"Why"_ of the code. They ensure the pull request:
+
+- Is not redundant
+- Adheres to the original user intent and acceptance criteria
+- Does not introduce feature bloat (**Zero-Waste Mandate**)
+- Is cohesive and does not negatively impact adjacent modules (**Neighborhood Rule**)
+
+### The Architect — Structure and Sustainability
+
+The Architect focuses on the _"How"_ of the code. They perform structural and architectural reviews:
+
+- Verifying adherence to strategic architecture principles (DRY, SOLID)
+- Assessing long-term maintainability
+- Preventing the introduction of technical debt
+- Ensuring consistency with the approved plan and project conventions
+
+### The Adversary — Resilience and Security
+
+The Adversary focuses on _"Where it breaks."_ They act as a skeptical auditor:
+
+- Seeking logical loopholes and edge cases
+- Identifying security vulnerabilities (SQLi, XSS, insecure mTLS)
+- Finding performance bottlenecks (O(n^2) loops, excessive API calls)
+- Enforcing behavioral constraints and robust error handling
+
+## Collective Approval
+
+The Divisor holds the ultimate authority to approve and merge code into the main branch. Approval requires collective consensus — **no outstanding REQUEST CHANGES from any persona** is mandatory. Gaze's functional validation serves as a prerequisite: the CI pipeline must be green before The Divisor begins review.
+
+This structure ensures that only code which passes all three lenses — intent, architecture, and resilience — is deployed.
+
+## How The Divisor Serves the Team
+
+**For Developers (Cobalt-Crush):** Cobalt-Crush relies on The Divisor for the final technical sign-off. The multi-faceted feedback from the three personas provides a holistic critique covering intent, structure, security, and robustness. Clear architectural standards minimize uncertainty, allowing Cobalt-Crush to code with confidence.
+
+**For the Tester (Gaze):** Gaze relies on The Divisor to establish the architectural and non-functional requirements against which testability must be measured. Gaze's green light on functional tests is the entry criterion for The Divisor's review, ensuring review time is spent on high-level risk and structure rather than defect finding.
+
+**For the Product Owner and Manager (Muti-Mind and Mx F):** Muti-Mind and Mx F are assured that every merged feature is technically sound, secure, and scalable. The Divisor acts as the ultimate guarantor of technical quality, ensuring that the velocity gained through prioritization and execution is sustainable and does not accrue crippling technical debt.

--- a/specs/002-documentation-content/data-model.md
+++ b/specs/002-documentation-content/data-model.md
@@ -1,0 +1,119 @@
+# Data Model: Documentation Content Pages
+
+**Branch**: `002-documentation-content` | **Date**: 2026-02-27 | **Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+## Entities
+
+### Docs-Level Index (`content/docs/_index.md`)
+
+| Field         | Type     | Required | Description                          |
+| ------------- | -------- | -------- | ------------------------------------ |
+| `title`       | string   | Yes      | Docs section title ("Documentation") |
+| `description` | string   | Yes      | SEO meta description                 |
+| `lead`        | string   | Yes      | Subtitle/intro text below title      |
+| `date`        | datetime | Yes      | Creation date (ISO 8601)             |
+| `draft`       | boolean  | Yes      | Must be `false`                      |
+| `weight`      | integer  | Yes      | Top-level ordering                   |
+| `toc`         | boolean  | Yes      | Table of contents toggle             |
+
+### Section Index Pages (`content/docs/<section>/_index.md`)
+
+Four section indexes with identical frontmatter schema:
+
+| Section         | Path                                     | Weight |
+| --------------- | ---------------------------------------- | ------ |
+| Getting Started | `content/docs/getting-started/_index.md` | 10     |
+| Projects        | `content/docs/projects/_index.md`        | 20     |
+| Team            | `content/docs/team/_index.md`            | 30     |
+| Contributing    | `content/docs/contributing/_index.md`    | 40     |
+
+### Content Pages (`content/docs/<section>/<page>.md`)
+
+| Field         | Type     | Required | Description                               |
+| ------------- | -------- | -------- | ----------------------------------------- |
+| `title`       | string   | Yes      | Page title (H1)                           |
+| `description` | string   | Yes      | SEO meta description                      |
+| `lead`        | string   | Yes      | Brief intro/subtitle                      |
+| `date`        | datetime | Yes      | Creation date (ISO 8601)                  |
+| `draft`       | boolean  | Yes      | Must be `false`                           |
+| `weight`      | integer  | Yes      | Ordering within section (lower = higher)  |
+| `toc`         | boolean  | Yes      | Table of contents (`true` for most pages) |
+
+### Content Pages — Full Inventory
+
+| #   | File Path                                     | Section         | Weight | Source Content                                 |
+| --- | --------------------------------------------- | --------------- | ------ | ---------------------------------------------- |
+| 1   | `content/docs/_index.md`                      | (root)          | 1      | Minimal — redirects to Getting Started         |
+| 2   | `content/docs/getting-started/_index.md`      | Getting Started | 10     | `unbound-force.md` overview                    |
+| 3   | `content/docs/getting-started/quick-start.md` | Getting Started | 20     | Synthesized from Specify, OpenCode, Swarm docs |
+| 4   | `content/docs/projects/_index.md`             | Projects        | 10     | Brief project listing                          |
+| 5   | `content/docs/projects/gaze.md`               | Projects        | 20     | Gaze README + OpenCode integration             |
+| 6   | `content/docs/team/_index.md`                 | Team            | 10     | "The Heroes" intro + composite image           |
+| 7   | `content/docs/team/muti-mind.md`              | Team            | 20     | `unbound-force.md` + `multi-mind.png`          |
+| 8   | `content/docs/team/cobalt-crush.md`           | Team            | 30     | `unbound-force.md` + `cobalt-crush.png`        |
+| 9   | `content/docs/team/gaze-tester.md`            | Team            | 40     | `unbound-force.md` + `gaze.png`                |
+| 10  | `content/docs/team/the-divisor.md`            | Team            | 50     | `unbound-force.md` + `the-divisor.png`         |
+| 11  | `content/docs/team/mx-f.md`                   | Team            | 60     | `unbound-force.md` + `mx-f.png`                |
+| 12  | `content/docs/contributing/_index.md`         | Contributing    | 10     | AGENTS.md conventions                          |
+
+### Image Assets (existing in `static/images/team/`)
+
+| File                     | Used On                    | Alt Text                                       |
+| ------------------------ | -------------------------- | ---------------------------------------------- |
+| `the-unbound-force.jpeg` | Team index page            | The Unbound Force — A.G.I. Development Squad   |
+| `multi-mind.png`         | Muti-Mind persona page     | Muti-Mind — Product Owner trading card         |
+| `cobalt-crush.png`       | Cobalt-Crush persona page  | Cobalt-Crush — Developer trading card          |
+| `gaze.png`               | Gaze (Tester) persona page | Gaze — Tester trading card                     |
+| `the-divisor.png`        | The Divisor persona page   | The Divisor — PR Reviewer Council trading card |
+| `mx-f.png`               | Mx F persona page          | Mx F — Manager trading card                    |
+
+## Relationships
+
+```
+Docs Root (1) ──contains──▶ Section Index (4)
+Section Index (1) ──contains──▶ Content Page (many)
+Content Page ──sourced from──▶ Source Repository
+Persona Page ──displays──▶ Trading Card Image (1:1)
+Team Index ──displays──▶ Composite Image (1:1)
+Gaze Project Page ──links to──▶ Blog Article (/blog/why-contract-coverage/)
+Gaze Project Page ──links to──▶ GitHub Repository (external)
+Navigation Menu ──references──▶ Section Index (via [[docs]] entries)
+```
+
+## Validation Rules
+
+1. **Frontmatter completeness**: All 7 required fields present on every page (FR-011)
+2. **No H1 in body**: Body content starts with `##` (FR-012)
+3. **Section index naming**: `_index.md` with leading underscore (FR-013)
+4. **Unique weights**: No duplicate `weight` values within a section
+5. **Image existence**: Referenced images exist in `static/images/team/` (verified above)
+6. **Link validity**: All internal links resolve to existing pages (FR-015)
+7. **No placeholders**: No "Coming Soon", "TODO", "TBD" content (SC-006)
+8. **Content accuracy**: Facts verifiable against source repositories (FR-005, FR-008)
+9. **Build success**: `npm run build` completes with zero errors (SC-003)
+10. **Draft state**: All pages MUST have `draft: false` (FR-011)
+
+## Configuration State
+
+| File            | Field              | Current Value          | Change Needed                                                |
+| --------------- | ------------------ | ---------------------- | ------------------------------------------------------------ |
+| `menus.en.toml` | `[[docs]]` entries | All 4 sections defined | None — already configured                                    |
+| `params.toml`   | `mainSections`     | `["docs", "blog"]`     | None                                                         |
+| `params.toml`   | `navBarButton`     | `false`                | Change to `true` — button points to `/docs/getting-started/` |
+
+## File Operations Summary
+
+| File                                          | Operation | Content Source                    |
+| --------------------------------------------- | --------- | --------------------------------- |
+| `content/docs/_index.md`                      | Create    | Minimal frontmatter               |
+| `content/docs/getting-started/_index.md`      | Create    | `unbound-force.md` overview       |
+| `content/docs/getting-started/quick-start.md` | Create    | Synthesized from tool docs        |
+| `content/docs/projects/_index.md`             | Create    | Brief project listing             |
+| `content/docs/projects/gaze.md`               | Create    | Gaze README + OpenCode research   |
+| `content/docs/team/_index.md`                 | Create    | Heroes intro + composite image    |
+| `content/docs/team/muti-mind.md`              | Create    | `unbound-force.md` + trading card |
+| `content/docs/team/cobalt-crush.md`           | Create    | `unbound-force.md` + trading card |
+| `content/docs/team/gaze-tester.md`            | Create    | `unbound-force.md` + trading card |
+| `content/docs/team/the-divisor.md`            | Create    | `unbound-force.md` + trading card |
+| `content/docs/team/mx-f.md`                   | Create    | `unbound-force.md` + trading card |
+| `content/docs/contributing/_index.md`         | Create    | AGENTS.md conventions             |

--- a/specs/002-documentation-content/plan.md
+++ b/specs/002-documentation-content/plan.md
@@ -1,0 +1,156 @@
+# Implementation Plan: Documentation Content Pages
+
+**Branch**: `002-documentation-content` | **Date**: 2026-02-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/002-documentation-content/spec.md`
+
+## Summary
+
+Create all documentation content sections for the Unbound Force website: Getting Started (2 pages), Projects (2 pages), Team (6 pages), and Contributing (1 page), plus the docs-level `_index.md`. Content is adapted from upstream source repositories (`unbound-force/unbound-force.md` for personas, `unbound-force/gaze` README for the Gaze project page). All pages use standard Markdown with YAML frontmatter — no custom layouts, shortcodes, or SCSS required. The existing navigation menu (`menus.en.toml`) already defines the four documentation sections; this feature populates them with real content.
+
+## Technical Context
+
+**Language/Version**: Hugo (via npm/thulite) + Go 1.23 (module resolution) + Node.js >= 20.11.0
+**Primary Dependencies**: `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1`
+**Storage**: N/A (static site, Markdown files)
+**Testing**: Manual — `npm run build` must succeed; visual verification via `npm run dev`
+**Target Platform**: GitHub Pages (static hosting)
+**Project Type**: Static documentation website (Hugo SSG)
+**Performance Goals**: N/A (static site, no runtime performance concerns)
+**Constraints**: Zero placeholder content; all facts must be verifiable against source repos; Doks built-in features preferred over custom implementations
+**Scale/Scope**: 12 new Markdown pages across 4 documentation sections
+
+### Key Technical Decisions
+
+- **Markdown only**: All 12 pages are standard `.md` files with YAML frontmatter. No custom Hugo templates, shortcodes, or partials needed.
+- **Image rendering**: Team persona trading card images use standard Markdown `![alt](/images/team/filename.png)` syntax. Images already exist in `static/images/team/`.
+- **Navigation**: The `menus.en.toml` already defines the four `[[docs]]` sections with correct weights. Hugo auto-discovers pages within sections via `_index.md` files.
+- **Blog cross-link**: The Gaze project page links to `/blog/why-contract-coverage/` which already exists as `content/blog/why-contract-coverage.md`.
+- **Gaze presentation**: Per clarification, Gaze is presented exclusively as an OpenCode-integrated tool via the `/gaze` command. CLI commands (`gaze analyze`, etc.) are NOT documented on the website. The `/gaze` OpenCode command interface needs research (Phase 0).
+- **"Get Started" button**: The navbar "Get Started" button is currently disabled in `params.toml` with the comment "until docs content exists (spec 002)". It should be re-enabled once getting-started content is published.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### I. Content Accuracy — PASS
+
+All content is derived from verified source material:
+
+- Persona descriptions adapted from `unbound-force/unbound-force.md` (fetched and verified)
+- Gaze project content adapted from `unbound-force/gaze` README (fetched and verified)
+- No features are fabricated; known limitations are documented per FR-005
+- No placeholder or "Coming Soon" content — all 12 pages will contain substantive content
+
+### II. Minimal Footprint — PASS
+
+- All pages are standard Markdown — no custom HTML templates, shortcodes, or SCSS
+- Images use standard Markdown syntax — no custom image components
+- No new dependencies added to `package.json`
+- Existing `menus.en.toml` navigation entries are reused, not duplicated
+- Doks built-in sidebar navigation handles page discovery automatically via `_index.md` section indexes
+
+### III. Visitor Clarity — PASS
+
+- Information hierarchy follows the spec: Getting Started → Projects → Team → Contributing
+- Every page has a clear purpose articulated in the spec's user stories
+- All pages are reachable within two clicks from the homepage via sidebar navigation
+- Content is adapted for a website audience — "why should I care" framing, not raw README text
+- The Getting Started section provides the "Get Started" entry point for the homepage CTA
+
+### Gate Result: **ALL PASS — proceed to Phase 0**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-documentation-content/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+content/
+├── _index.md                              # Homepage (exists)
+├── blog/                                  # Blog section (exists)
+│   ├── _index.md
+│   └── why-contract-coverage.md
+└── docs/                                  # Documentation sections (NEW — this feature)
+    ├── _index.md                          # Docs landing page
+    ├── getting-started/
+    │   ├── _index.md                      # "What is Unbound Force?"
+    │   └── quick-start.md                 # Quick Start guide
+    ├── projects/
+    │   ├── _index.md                      # Projects overview
+    │   └── gaze.md                        # Gaze project page
+    ├── team/
+    │   ├── _index.md                      # "The Heroes" overview
+    │   ├── muti-mind.md                   # Product Owner persona
+    │   ├── cobalt-crush.md                # Developer persona
+    │   ├── gaze-tester.md                 # Tester persona
+    │   ├── the-divisor.md                 # PR Reviewer persona
+    │   └── mx-f.md                        # Manager persona
+    └── contributing/
+        └── _index.md                      # Contributing guide
+
+config/_default/
+├── params.toml                            # Re-enable "Get Started" button
+└── menus/menus.en.toml                    # Already configured (no changes needed)
+
+static/images/team/                        # Trading card images (exist)
+├── the-unbound-force.jpeg                 # Team composite
+├── multi-mind.png                         # Muti-Mind trading card
+├── cobalt-crush.png                       # Cobalt-Crush trading card
+├── gaze.png                               # Gaze trading card
+├── the-divisor.png                        # The Divisor trading card
+└── mx-f.png                               # Mx F trading card
+```
+
+**Structure Decision**: Hugo content-as-structure model. Each section has a `_index.md` for the section landing page and individual `.md` files for sub-pages. No `src/`, `tests/`, or other code directories — this is a content-only feature. The docs-level `_index.md` is required so Hugo treats `content/docs/` as a section root.
+
+## Constitution Check — Post-Design Re-evaluation
+
+_Re-check after Phase 1 design completion._
+
+### I. Content Accuracy — PASS
+
+- All content sources verified via direct fetch from upstream repos:
+  - `unbound-force/unbound-force.md` — all 5 persona descriptions confirmed (Muti-Mind, Cobalt-Crush, Gaze, The Divisor, Mx F)
+  - `unbound-force/gaze` README — all metrics (Contract Coverage, Over-Specification, GazeCRAP), architecture, limitations confirmed
+  - `/gaze` OpenCode command interface — researched via spec 005 and scaffold source; 3 modes (full/crap/quality), `gaze init` scaffolding confirmed
+- Known Gaze limitations documented honestly: direct function body only, P3-P4 not detected, ~74% assertion mapping accuracy, no CGo/unsafe, single package loading
+- No fabricated features in any design artifact
+- Blog cross-link `/blog/why-contract-coverage/` confirmed to exist
+
+### II. Minimal Footprint — PASS
+
+- Design adds zero custom templates, shortcodes, SCSS, or JavaScript
+- All 12 pages are standard Markdown with YAML frontmatter
+- Images use standard Markdown syntax (Doks render hook provides optimization automatically)
+- Only config change: setting `navBarButton = true` in `params.toml` (currently `false`)
+- No new `package.json` dependencies
+- No `contracts/` directory needed — static content has no external interfaces
+
+### III. Visitor Clarity — PASS
+
+- 12-page content inventory with clear purpose for every page (documented in data-model.md)
+- Weight scheme ensures deterministic sidebar ordering (10/20/30... within sections)
+- Getting Started → Quick Start provides the homepage CTA conversion path
+- Gaze project page links to blog for deeper technical content — layered information depth
+- Team overview → persona pages provides progressive disclosure of agent details
+- "Get Started" navbar button re-enabled to complete the homepage → docs navigation path
+
+### Post-Design Gate Result: **ALL PASS — no violations, no complexity tracking needed**
+
+## Complexity Tracking
+
+> No constitution violations detected — this section is intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| _(none)_  | —          | —                                    |

--- a/specs/002-documentation-content/quickstart.md
+++ b/specs/002-documentation-content/quickstart.md
@@ -1,0 +1,79 @@
+# Quick Start: Documentation Content Pages
+
+**Branch**: `002-documentation-content` | **Date**: 2026-02-27 | **Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+## Prerequisites
+
+- Node.js >= 20.11.0
+- Go >= 1.23 (for Hugo module resolution)
+- Dependencies installed: `npm install`
+- Access to source repos: `unbound-force/unbound-force` and `unbound-force/gaze`
+
+## Implementation Order
+
+### 1. Create Directory Structure
+
+```bash
+mkdir -p content/docs/getting-started
+mkdir -p content/docs/projects
+mkdir -p content/docs/team
+mkdir -p content/docs/contributing
+```
+
+### 2. Docs Root Index
+
+Create `content/docs/_index.md` — minimal frontmatter, no body content.
+
+### 3. Getting Started Section (P1)
+
+Create 2 pages sourced from `unbound-force/unbound-force.md`:
+
+- `content/docs/getting-started/_index.md` — "What is Unbound Force?" adapted from overview
+- `content/docs/getting-started/quick-start.md` — covers Specify, OpenCode, and Swarm equally
+
+### 4. Projects Section (P1)
+
+Create 2 pages:
+
+- `content/docs/projects/_index.md` — brief project listing
+- `content/docs/projects/gaze.md` — Gaze project page focused on `/gaze` OpenCode command, cross-links to blog article
+
+### 5. Team Section (P2)
+
+Create 6 pages sourced from `unbound-force/unbound-force.md` "The Heroes":
+
+- `content/docs/team/_index.md` — heroes intro + composite image (`/images/team/the-unbound-force.jpeg`)
+- 5 persona pages, each with trading card image from `static/images/team/`
+
+### 6. Contributing Section (P2)
+
+Create 1 page:
+
+- `content/docs/contributing/_index.md` — guidelines from AGENTS.md conventions
+
+### 7. Re-enable "Get Started" Button
+
+Uncomment the `[doks.navbar.button]` section in `config/_default/params.toml`:
+
+```toml
+[doks.navbar.button]
+  enable = true
+  text = "Get Started"
+  url = "/docs/getting-started/"
+```
+
+### 8. Verification
+
+```bash
+npm run build              # Must succeed with zero errors
+npm run dev                # Visually verify:
+                           #   - All 12 pages render
+                           #   - Sidebar shows all sections in order
+                           #   - Getting Started -> Quick Start navigation works
+                           #   - Gaze page shows /gaze command, links to blog
+                           #   - Team pages display trading card images
+                           #   - Team index shows composite image
+                           #   - Contributing page has GitHub links
+                           #   - Dark mode renders correctly
+                           #   - All internal links work
+```

--- a/specs/002-documentation-content/research.md
+++ b/specs/002-documentation-content/research.md
@@ -1,0 +1,188 @@
+# Research: Documentation Content Pages
+
+**Branch**: `002-documentation-content` | **Date**: 2026-02-27 | **Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+## R1: Getting Started Section — Source Content
+
+**Decision**: Adapt content from `unbound-force/unbound-force.md` overview section for the "What is Unbound Force?" index page. The Quick Start page will synthesize information across the three tools (Specify, OpenCode, Swarm) from their respective sources.
+
+**Rationale**: The `unbound-force.md` file contains two sections: "Overview" and "The Heroes." The overview describes Unbound Force as "a set of personas and roles for a software agent swarm" themed as a superhero team. Each hero is not just a markdown file — they can include LSP servers, MCP servers, tooling, tasks, commands, plugins, and other technologies. The three tools are:
+
+| Tool               | Source                       | Role                                                                                           |
+| ------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------- |
+| Specify (spec-kit) | `github.com/github/spec-kit` | Specification pipeline — structured workflow for specs, plans, and tasks before implementation |
+| OpenCode           | `opencode.ai`                | AI coding environment the personas run inside                                                  |
+| Swarm              | `swarmtools.ai`              | OpenCode plugin enabling learning amongst team members                                         |
+
+The Quick Start page must cover all three tools equally (per clarification decision). Research into each tool's documentation reveals a layered stack model:
+
+| Layer            | Tool     | Install                                                                                                                     | Role                                                                                |
+| ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **Agent**        | OpenCode | `curl -fsSL https://opencode.ai/install \| bash`                                                                            | AI coding agent runtime — where you interact, write code, run commands              |
+| **Planning**     | Specify  | `uv tool install specify-cli --from git+https://github.com/github/spec-kit.git` then `specify init <project> --ai opencode` | Spec-driven development — turns ideas into specs, plans, and tasks                  |
+| **Coordination** | Swarm    | `npm install -g opencode-swarm-plugin@latest` then `swarm setup`                                                            | Multi-agent parallelism — spawns workers, coordinates via file reservations, learns |
+
+The Quick Start page will present these as complementary layers with a "why should I care" framing rather than raw installation commands. Each tool is independently useful but they compose into the full Unbound Force workflow.
+
+**Alternatives considered**:
+
+- Copying the overview verbatim: Rejected — Constitution Principle III requires audience adaptation, and Principle II says not to copy READMEs verbatim.
+- Deferring Quick Start until each tool has a dedicated page: Rejected — FR-002 requires the Quick Start page in this spec.
+
+## R2: Gaze Project Page — `/gaze` OpenCode Command Focus
+
+**Decision**: Present Gaze as an OpenCode-integrated tool. The primary workflow is: install Gaze binary -> run `gaze init` in your Go project -> use `/gaze` within OpenCode. No CLI commands documented on the page.
+
+**Rationale**: Research into the Gaze repository reveals the following OpenCode integration:
+
+**Setup flow:**
+
+1. Install Gaze: `brew install unbound-force/tap/gaze` or `go install github.com/unbound-force/gaze/cmd/gaze@latest`
+2. Run `gaze init` in any Go project — scaffolds 4 files into `.opencode/`:
+   - `.opencode/agents/gaze-reporter.md` — quality report agent
+   - `.opencode/agents/doc-classifier.md` — document-enhanced classifier agent
+   - `.opencode/command/gaze.md` — `/gaze` slash command
+   - `.opencode/command/classify-docs.md` — `/classify-docs` slash command
+
+**Usage (inside OpenCode):**
+
+```
+/gaze                           # Full report for entire module
+/gaze crap ./internal/store     # CRAP scores only
+/gaze quality ./pkg/api         # Contract Coverage metrics only
+```
+
+**Three modes:**
+
+| Mode           | What You Get                                                                |
+| -------------- | --------------------------------------------------------------------------- |
+| Full (default) | CRAP Summary + Quality Summary + Classification Summary + Health Assessment |
+| `crap`         | CRAPload count, top 5 worst scores, GazeCRAP quadrant distribution          |
+| `quality`      | Contract coverage, gaps, over-specification, worst tests                    |
+
+**How it works**: The `/gaze` command routes to the `gaze-reporter` agent, which resolves the binary, runs CLI commands with `--format=json`, interprets the output, and produces human-readable markdown summaries with tables, key metrics, and actionable recommendations. Graceful degradation if any command fails.
+
+**Also available**: `/classify-docs` — enhances classification by combining mechanical signals with project documentation analysis.
+
+**Key metrics to highlight on the page:**
+
+- Contract Coverage (% of contractual side effects asserted on)
+- Over-Specification Score (count of incidental assertions)
+- GazeCRAP (composite risk score using contract coverage instead of line coverage)
+
+**Cross-link**: Page will link to `/blog/why-contract-coverage/` for the deep technical explanation.
+
+**Alternatives considered**:
+
+- Documenting CLI commands directly: Rejected — user explicitly chose to focus on the OpenCode `/gaze` command only.
+- Documenting both OpenCode and CLI: Rejected — same reason.
+
+## R3: Team Persona Pages — Source Content and Images
+
+**Decision**: Adapt each persona description from `unbound-force/unbound-force.md` "The Heroes" section. Each persona page displays its trading card image. Team index displays the composite image.
+
+**Rationale**: The source file contains detailed descriptions for all 5 personas:
+
+| Persona         | Role          | Tagline                                                    | Image File         |
+| --------------- | ------------- | ---------------------------------------------------------- | ------------------ |
+| Muti-Mind       | Product Owner | "The Vision Keeper and Prioritization Engine"              | `multi-mind.png`   |
+| Cobalt-Crush    | Developer     | "The Engineering Core and Adaptive Implementation Engine"  | `cobalt-crush.png` |
+| Gaze            | Tester        | "The Quality Sentinel and Predictive Validation Engine"    | `gaze.png`         |
+| The Divisor     | PR Reviewer   | "The Architectural Conscience and Code Integrity Guardian" | `the-divisor.png`  |
+| Mx F (Mx Found) | Manager       | "The Flow Facilitator and Continuous Improvement Coach"    | `mx-f.png`         |
+
+Each persona has well-defined key responsibilities, interaction patterns, and a "source of truth for X" framing. Content will be rewritten for a website audience — less raw role specification, more "what does this agent do for you."
+
+The Divisor is unique: it operates as a **council of three sub-personas** (The Guard, The Architect, The Adversary) with collective approval required for merges. This must be highlighted.
+
+**Image usage**: Trading card images are already in `static/images/team/`. In Markdown, they'll be referenced as `![Alt text](/images/team/filename.png)`. The team composite image (`the-unbound-force.jpeg`) goes on the index page, possibly also `the-unbound-force-small.jpeg` for responsive sizing.
+
+**Alternatives considered**:
+
+- Using Doks image shortcode instead of standard Markdown images: Worth exploring during implementation if the shortcode provides responsive/optimized images. Defer to implementation.
+- Creating custom page templates for persona cards: Rejected — Constitution Principle II (Minimal Footprint). Standard Markdown with images is sufficient.
+
+## R4: Contributing Guide — Content Sources
+
+**Decision**: Synthesize contributing guidelines from the project's actual conventions documented in AGENTS.md and the Speckit workflow.
+
+**Rationale**: There is no standalone `CONTRIBUTING.md` in the website repo. The contributing page must cover:
+
+1. **Reporting issues** — link to GitHub issues
+2. **Submitting pull requests** — standard GitHub PR flow
+3. **Conventional Commits** — `feat:`, `fix:`, `docs:`, `chore:`, `style:`, `refactor:`, `ci:`
+4. **Speckit workflow** — all non-trivial work goes through the pipeline: constitution -> specify -> clarify -> plan -> tasks -> implement
+5. **Links** — to the GitHub org and individual repositories
+
+This content is straightforward and doesn't require upstream source verification beyond confirming the Conventional Commits types and Speckit pipeline stages already documented in AGENTS.md.
+
+**Alternatives considered**:
+
+- Linking to a CONTRIBUTING.md in each repo: No such files exist currently. The website page serves as the canonical contributing guide.
+
+## R5: Navigation and Sidebar Configuration
+
+**Decision**: The `[[docs]]` menu entries already exist in `menus.en.toml` from spec 001. No navigation configuration changes are needed.
+
+**Rationale**: The current `menus.en.toml` already defines all 4 docs sections:
+
+- Getting Started (weight 10)
+- Projects (weight 20)
+- The Team (weight 30)
+- Contributing (weight 40)
+
+These were added during the site scaffold (spec 001). FR-014 is already satisfied. The only remaining work is creating the content pages themselves with correct `weight` values in their frontmatter for intra-section ordering.
+
+**Alternatives considered**:
+
+- Restructuring the navigation weights: Unnecessary — the current ordering matches the spec requirements.
+
+## R6: Image Display in Hugo/Doks
+
+**Decision**: Use standard Markdown image syntax (`![alt](/images/team/filename.png)`) for trading card images in persona pages.
+
+**Rationale**: Research confirms that Doks has a **render hook** for standard Markdown images. The `@thulite/images` integration automatically processes `![alt](src)` images — converting to WebP, generating responsive `sizes`, adding LQIP blur-up placeholders, and setting `loading`/`decoding`/`fetchpriority` attributes based on config defaults. This means standard Markdown syntax gets full image optimization without any shortcodes.
+
+Images in `static/` are served at their path (e.g., `static/images/team/multi-mind.png` → `/images/team/multi-mind.png`). Doks also provides `{{< picture >}}`, `{{< figure >}}`, and `{{< img >}}` shortcodes for more control (captions, explicit sizing), but these add complexity without benefit since the spec does not require captions.
+
+Constitution Principle II (Minimal Footprint) confirms: standard Markdown images are the correct choice.
+
+**Alternatives considered**:
+
+- `{{< figure >}}` shortcode for captions: Rejected — spec doesn't require captions on trading card images.
+- Page bundles with co-located images: Rejected — images are shared resources in `static/`, not page-specific.
+- Hugo image processing (`assets/` resources): Rejected — render hook already provides optimization for `static/` images.
+
+## R7: Gaze Project Page — Known Limitations
+
+**Decision**: Include an honest limitations section on the Gaze project page, sourced from the Gaze README.
+
+**Rationale**: Per FR-005, the page must not fabricate features or omit known limitations. The current limitations are:
+
+1. **Direct function body only** — no transitive side effects (effects from called functions) in v1
+2. **P3-P4 side effects not yet detected** — taxonomy defined but detection not implemented
+3. **Assertion mapping accuracy ~78.8%** — target is 90%, tracked as GitHub Issue #6
+4. **No CGo or unsafe analysis** — functions using cgo or unsafe.Pointer are skipped
+5. **Single package loading** — `analyze` processes one package at a time
+
+These should be framed honestly but constructively — "current scope" rather than "failures." The P0-P2 tiers cover the most common and impactful side effects; P3-P4 are lower-priority edge cases.
+
+**Alternatives considered**:
+
+- Omitting limitations: Rejected — violates Constitution Principle I (Content Accuracy) and FR-005.
+- Listing all limitations with full technical detail: Rejected — website audience framing. Brief, honest, constructive.
+
+## R8: "Get Started" Button and Docs-Level Index
+
+**Decision**: Re-enable the "Get Started" navbar button in `params.toml` and create `content/docs/_index.md` as the docs section root.
+
+**Rationale**: The `params.toml` navbar button is commented out with `"until docs content exists (spec 002)"`. This feature creates that content, so the button should be re-enabled to point to `/docs/getting-started/`.
+
+Research confirms that Doks requires `content/docs/_index.md` for Hugo to treat `docs/` as a section root. Without it, the sidebar auto-generation and section navigation will not work. This is a standard Hugo content-as-structure requirement, not Doks-specific.
+
+The docs-level `_index.md` counts as one of the 12 pages in SC-001: "2 Getting Started (index + Quick Start), 2 Projects (index + Gaze), 6 Team (index + 5 personas), 1 Contributing (index), plus the docs-level `_index.md`."
+
+**Alternatives considered**:
+
+- Leave button disabled until merge: Rejected — the button is needed for the two-click navigation requirement (SC-002) and must be testable during development.
+- Skip docs-level `_index.md`: Not an option — Hugo requires it for section recognition.

--- a/specs/002-documentation-content/spec.md
+++ b/specs/002-documentation-content/spec.md
@@ -5,7 +5,17 @@
 **Status**: Draft
 **Input**: User description: "Create all documentation sections with real content adapted from source repositories: Getting Started, Projects (Gaze), Team (5 agent personas), and Contributing."
 
-## User Scenarios & Testing *(mandatory)*
+## Clarifications
+
+### Session 2026-02-27
+
+- Q: Should the trading card images be displayed on the team persona pages? → A: Each persona page displays its trading card image; team index page displays the composite image.
+- Q: Should the Gaze project page focus on CLI commands or the OpenCode integration? → A: Only the `/gaze` OpenCode command — no mention of the CLI.
+- Q: Is there documentation for the `/gaze` OpenCode command, or should it be researched during planning? → A: Defer to planning phase research.
+- Q: What should the Quick Start page cover as the "get started" path? → A: Cover all three tools equally (Specify, OpenCode, Swarm).
+- Q: Should the Gaze project page link to the "Why Contract Coverage" blog article? → A: Yes, link to the blog article from the Gaze project page.
+
+## User Scenarios & Testing _(mandatory)_
 
 ### User Story 1 - Getting Started Guide (Priority: P1)
 
@@ -35,10 +45,11 @@ As a developer interested in test quality, I want to read about the Gaze project
 **Acceptance Scenarios**:
 
 1. **Given** I navigate to the Projects section, **When** I see the projects overview page, **Then** it lists available projects with brief descriptions.
-2. **Given** I click on the Gaze project, **When** the page loads, **Then** I see a description of Gaze covering: what it does (side effect detection + CRAP scores for Go), installation (`go install`), key commands (`gaze analyze`, `gaze crap`), output formats (text + JSON), and architecture overview.
+2. **Given** I click on the Gaze project, **When** the page loads, **Then** I see a description of Gaze covering: what it does (side effect detection, Contract Coverage, and CRAP scores for Go), how to use it via the `/gaze` OpenCode command, and an architecture overview.
 3. **Given** the Gaze project page content, **When** I cross-reference it against the Gaze repository README, **Then** all facts are accurate — no fabricated features, no overstated capabilities.
-4. **Given** the Gaze project page, **When** I look for known limitations, **Then** the page honestly lists current limitations (direct function body only, P3-P4 not yet detected, line coverage fallback, no CGo/unsafe, single package for analyze).
+4. **Given** the Gaze project page, **When** I look for known limitations, **Then** the page honestly lists current limitations.
 5. **Given** I am on the Gaze project page, **When** I check for a link to the Gaze repository, **Then** a prominent link to `https://github.com/unbound-force/gaze` is present.
+6. **Given** I am on the Gaze project page, **When** I look for deeper technical content, **Then** I find a link to the "Why Contract Coverage" blog article at `/blog/why-contract-coverage/`.
 
 ---
 
@@ -52,13 +63,14 @@ As a visitor curious about how the AI agent swarm works, I want to read about ea
 
 **Acceptance Scenarios**:
 
-1. **Given** I navigate to the Team section, **When** I see the overview page, **Then** it introduces "The Heroes" concept and lists all 5 agent personas with brief descriptions.
+1. **Given** I navigate to the Team section, **When** I see the overview page, **Then** it introduces "The Heroes" concept, displays the team composite image (`static/images/team/the-unbound-force.jpeg`), and lists all 5 agent personas with brief descriptions.
 2. **Given** I click on Muti-Mind, **When** the page loads, **Then** I see a description of the Product Owner persona covering vision keeping, prioritization, backlog ownership, and acceptance authority — adapted from `unbound-force.md`.
 3. **Given** I click on Cobalt-Crush, **When** the page loads, **Then** I see a description of the Developer persona covering high-velocity implementation, CI/CD focus, architectural adherence, and tight feedback loops.
 4. **Given** I click on Gaze (Tester), **When** the page loads, **Then** I see a description of the Tester persona covering proactive test strategies, CI/CV pipelines, intelligent defect detection, and risk-based testing.
 5. **Given** I click on The Divisor, **When** the page loads, **Then** I see a description of the PR Reviewer persona covering the three-persona council (The Guard, The Architect, The Adversary) and collective merge authority.
 6. **Given** I click on Mx F, **When** the page loads, **Then** I see a description of the Manager persona covering servant leadership, flow facilitation, continuous improvement coaching, and obstacle removal.
 7. **Given** any persona page, **When** I cross-reference the content against `unbound-force.md`, **Then** the descriptions are accurate but adapted for a website audience.
+8. **Given** any persona page, **When** the page loads, **Then** the persona's trading card image is displayed prominently (e.g., `multi-mind.png`, `cobalt-crush.png`, `gaze.png`, `the-divisor.png`, `mx-f.png` from `static/images/team/`).
 
 ---
 
@@ -102,18 +114,18 @@ As a visitor browsing the site, I want all documentation sections to appear in t
 - What if a content page is added without updating `menus.en.toml`? It will appear in the sidebar via Hugo's automatic section detection but may not appear in the top nav. All pages must be verified against navigation.
 - What if two pages have the same `weight` value? Hugo uses alphabetical ordering as a tiebreaker, which may produce unexpected sidebar ordering. Each page must have a unique weight within its section.
 
-## Requirements *(mandatory)*
+## Requirements _(mandatory)_
 
 ### Functional Requirements
 
 - **FR-001**: The Getting Started section MUST contain an index page (`content/docs/getting-started/_index.md`) explaining what Unbound Force is, adapted from the `unbound-force/unbound-force.md` overview section.
-- **FR-002**: The Getting Started section MUST contain a Quick Start page (`content/docs/getting-started/quick-start.md`) explaining how to get started with the tools (Specify, OpenCode, and optionally Swarm).
+- **FR-002**: The Getting Started section MUST contain a Quick Start page (`content/docs/getting-started/quick-start.md`) explaining how to get started with all three tools equally: Specify, OpenCode, and Swarm.
 - **FR-003**: The Projects section MUST contain an index page (`content/docs/projects/_index.md`) with a brief overview of available projects.
-- **FR-004**: The Projects section MUST contain a Gaze project page (`content/docs/projects/gaze.md`) adapted from the Gaze repository README, covering: description, installation, key commands (`gaze analyze`, `gaze crap`), output formats, architecture overview, and known limitations.
+- **FR-004**: The Projects section MUST contain a Gaze project page (`content/docs/projects/gaze.md`) adapted from the Gaze repository README, covering: description, usage via the `/gaze` OpenCode command, architecture overview, and known limitations. The page MUST NOT document CLI commands directly — Gaze is presented as an OpenCode-integrated tool. The page MUST include a link to the "Why Contract Coverage" blog article (`/blog/why-contract-coverage/`) for visitors who want a deeper technical explanation.
 - **FR-005**: The Gaze project page MUST NOT fabricate features or omit known limitations. Content MUST be cross-referenced against the Gaze README.
-- **FR-006**: The Team section MUST contain an index page (`content/docs/team/_index.md`) introducing the "Heroes" concept and listing all 5 personas.
+- **FR-006**: The Team section MUST contain an index page (`content/docs/team/_index.md`) introducing the "Heroes" concept, displaying the team composite image (`/images/team/the-unbound-force.jpeg`), and listing all 5 personas.
 - **FR-007**: The Team section MUST contain individual pages for each persona: `muti-mind.md` (Product Owner), `cobalt-crush.md` (Developer), `gaze-tester.md` (Tester), `the-divisor.md` (PR Reviewer), `mx-f.md` (Manager).
-- **FR-008**: Each persona page MUST be adapted from the `unbound-force/unbound-force.md` Heroes section. Content MUST be rewritten for a website audience — not copied verbatim.
+- **FR-008**: Each persona page MUST be adapted from the `unbound-force/unbound-force.md` Heroes section. Content MUST be rewritten for a website audience — not copied verbatim. Each persona page MUST display its corresponding trading card image from `static/images/team/` (`multi-mind.png`, `cobalt-crush.png`, `gaze.png`, `the-divisor.png`, `mx-f.png`).
 - **FR-009**: The Divisor page MUST describe the three sub-personas (The Guard, The Architect, The Adversary) and the collective approval requirement.
 - **FR-010**: The Contributing section MUST contain an index page (`content/docs/contributing/_index.md`) with guidelines for reporting issues, submitting PRs, following Conventional Commits, and using the Speckit workflow.
 - **FR-011**: Every content page MUST include all required YAML frontmatter fields: `title`, `description`, `lead`, `date`, `draft: false`, `weight`, `toc: true`.
@@ -130,11 +142,11 @@ As a visitor browsing the site, I want all documentation sections to appear in t
 - **Navigation Menu**: The `menus.en.toml` configuration that defines sidebar sections, top nav links, and footer links.
 - **Source Repository**: An upstream Unbound Force repository (Gaze, unbound-force) from which website content is derived and must be kept in sync.
 
-## Success Criteria *(mandatory)*
+## Success Criteria _(mandatory)_
 
 ### Measurable Outcomes
 
-- **SC-001**: All 14 content pages exist and render without errors: 2 Getting Started, 2 Projects, 6 Team (1 index + 5 personas), 1 Contributing, plus the docs-level `_index.md`.
+- **SC-001**: All 12 content pages exist and render without errors: 2 Getting Started (index + Quick Start), 2 Projects (index + Gaze), 6 Team (index + 5 personas), 1 Contributing (index), plus the docs-level `_index.md`.
 - **SC-002**: Every page is reachable from the homepage within two clicks via sidebar navigation.
 - **SC-003**: `npm run build` succeeds with zero errors after all content is added.
 - **SC-004**: Cross-referencing the Gaze project page against the Gaze README confirms all facts are accurate and no features are fabricated.

--- a/specs/002-documentation-content/tasks.md
+++ b/specs/002-documentation-content/tasks.md
@@ -1,0 +1,266 @@
+# Tasks: Documentation Content Pages
+
+**Input**: Design documents from `/specs/002-documentation-content/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: No test tasks — the spec does not request automated tests. Validation is manual: `npm run build` + visual verification via `npm run dev`.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create directory structure and docs root index required by all sections
+
+- [x] T001 Create directory structure for all documentation sections: `mkdir -p content/docs/getting-started content/docs/projects content/docs/team content/docs/contributing`
+- [x] T002 Create docs root index page in `content/docs/_index.md` with frontmatter: title "Documentation", description of Unbound Force docs, lead text introducing the documentation, date 2026-02-23, draft false, weight 1, toc false. Body content: one brief sentence such as "Explore the documentation to learn about Unbound Force, its projects, and how to get started." Do not add redirect logic — Hugo renders the first section (Getting Started) automatically when navigating to `/docs/`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Fetch upstream source content that multiple user stories depend on
+
+**Note**: This is a content-only feature. The "foundational" work is gathering the source material that US1, US2, US3, and US4 all adapt from. Since the plan already completed this research (see `research.md`), this phase is effectively pre-satisfied. The source content is documented in:
+
+- `research.md` R1 — `unbound-force/unbound-force.md` overview (used by US1, US3)
+- `research.md` R2 — Gaze `/gaze` OpenCode command details (used by US2)
+- `research.md` R3 — Persona descriptions and image mappings (used by US3)
+- `research.md` R4 — Contributing conventions from AGENTS.md (used by US4)
+
+- [x] T003 Verify source content availability: confirm `research.md` contains resolved content for all user stories. Read `specs/002-documentation-content/research.md` and confirm R1 through R8 all have decisions (no NEEDS CLARIFICATION remaining). If any are unresolved, stop and escalate.
+
+**Checkpoint**: Source content verified — user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 — Getting Started Guide (Priority: P1) MVP
+
+**Goal**: First-time visitors who click "Get Started" on the homepage land on a clear explanation of Unbound Force and actionable steps to begin using Specify, OpenCode, and Swarm.
+
+**Independent Test**: Click "Get Started" on the homepage (or navigate to `/docs/getting-started/`). The Getting Started section loads with a "What is Unbound Force?" overview and a Quick Start sub-page covering all three tools.
+
+**Source**: `unbound-force/unbound-force.md` overview section (R1), tool documentation for Specify/OpenCode/Swarm (R1)
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Create Getting Started section index in `content/docs/getting-started/_index.md`. Frontmatter: title "What is Unbound Force?", description about the AI agent swarm for software engineering, lead text introducing the concept, date 2026-02-23, draft false, weight 10, toc true. Body content adapted from `unbound-force/unbound-force.md` overview — explain what Unbound Force is (superhero-themed AI agent swarm), the three tools (Specify, OpenCode, Swarm), and that each hero can be more than just instructions (LSP, MCP, tooling, commands, plugins). Frame for website audience: "why should I care" not raw technical specs. Must satisfy FR-001, FR-011, FR-012, FR-016.
+- [x] T005 [US1] Create Quick Start page in `content/docs/getting-started/quick-start.md`. Frontmatter: title "Quick Start", description about getting started with the tools, lead text, date 2026-02-23, draft false, weight 20, toc true. Body content covers all three tools equally per R1 research — present as a layered stack (Agent: OpenCode, Planning: Specify, Coordination: Swarm). For each tool: what it does (1-2 sentences), how to install it, and a brief usage example. Include links to each tool's website/repo. Frame as "why should I care" — not a raw installation guide. Must satisfy FR-002, FR-011, FR-012, FR-016.
+
+**Checkpoint**: Getting Started section complete — verify by navigating to `/docs/getting-started/` and confirming both pages render with sidebar showing index + Quick Start in order
+
+---
+
+## Phase 4: User Story 2 — Gaze Project Page (Priority: P1)
+
+**Goal**: Developers interested in test quality can read about the Gaze project, understand what it does, see how to use it via the `/gaze` OpenCode command, and find honest information about its current limitations.
+
+**Independent Test**: Navigate to `/docs/projects/`. The projects overview lists Gaze. Click through to the Gaze page — it explains side effect detection, Contract Coverage, GazeCRAP, the `/gaze` command usage, architecture, limitations, and links to both the GitHub repo and the blog article.
+
+**Source**: Gaze README (R2), `/gaze` OpenCode command research (R2), known limitations (R7), blog cross-link (R2)
+
+### Implementation for User Story 2
+
+- [x] T006 [P] [US2] Create Projects section index in `content/docs/projects/_index.md`. Frontmatter: title "Projects", description about Unbound Force projects, lead text, date 2026-02-23, draft false, weight 10, toc false. Body content: brief overview of the Projects section, list Gaze as the current project with a 1-2 sentence description and link to its sub-page. Must satisfy FR-003, FR-011, FR-012.
+- [x] T007 [US2] Create Gaze project page in `content/docs/projects/gaze.md`. Frontmatter: title "Gaze", description about test quality analysis via side effect detection for Go, lead text, date 2026-02-23, draft false, weight 20, toc true. Body content adapted from Gaze README and R2 research, structured as:
+  - **What Gaze Does**: Side effect detection, Contract Coverage, Over-Specification Score, GazeCRAP — adapted from README, not copied verbatim. Frame around the problem it solves (line coverage is insufficient).
+  - **Key Metrics**: Contract Coverage (% of contractual effects asserted on), Over-Specification Score (count of incidental assertions), GazeCRAP (composite risk using contract coverage instead of line coverage). Brief explanations with the formulas.
+  - **Using Gaze** (via `/gaze` OpenCode command): Install Gaze (`brew install unbound-force/tap/gaze` or `go install`), run `gaze init` in a Go project, then use `/gaze` inside OpenCode. Document the 3 modes: full (default), crap, quality — with example commands. Mention `/classify-docs` as a companion command. Do NOT document CLI commands directly — present only the OpenCode integration.
+  - **Architecture**: Brief overview of the internal structure (analysis, taxonomy, classify, config, loader, report, crap, quality, docscan, scaffold) — adapted for website audience, not raw directory listing.
+  - **Current Limitations**: Honest list from R7 — direct function body only, P3-P4 not yet detected, assertion mapping ~74% accuracy (target 90%), no CGo/unsafe, single package loading. Frame constructively.
+  - **Links**: Prominent link to `https://github.com/unbound-force/gaze`, link to blog article at `/blog/why-contract-coverage/` for deeper technical explanation.
+  - Must satisfy FR-004, FR-005, FR-011, FR-012, FR-015, FR-016.
+
+**Checkpoint**: Projects section complete — verify Gaze page renders, `/gaze` command usage is clear, limitations are listed, blog link works, GitHub link is present
+
+---
+
+## Phase 5: User Story 3 — Team Persona Pages (Priority: P2)
+
+**Goal**: Visitors curious about the AI agent swarm can browse team personas, see trading card images, and understand each role's purpose within the Unbound Force swarm.
+
+**Independent Test**: Navigate to `/docs/team/`. The overview shows the team composite image and lists all 5 personas. Click each persona — every page loads with a trading card image and accurate description adapted from `unbound-force.md`.
+
+**Source**: `unbound-force/unbound-force.md` Heroes section (R3), trading card images in `static/images/team/` (R3, R6)
+
+### Implementation for User Story 3
+
+- [x] T008 [US3] Create Team section index in `content/docs/team/_index.md`. Frontmatter: title "The Team", description about the Unbound Force agent personas, lead text introducing the Heroes concept, date 2026-02-23, draft false, weight 10, toc true. Body content: introduce "The Heroes" — Unbound Force's superhero-themed AI agent swarm. Display the team composite image using `![The Unbound Force — A.G.I. Development Squad](/images/team/the-unbound-force.jpeg)`. List all 5 personas with their role, tagline, and a brief 1-2 sentence description linking to their individual page. Must satisfy FR-006, FR-011, FR-012, FR-016.
+- [x] T009 [P] [US3] Create Muti-Mind persona page in `content/docs/team/muti-mind.md`. Frontmatter: title "Muti-Mind", description about the Product Owner persona, lead "The Vision Keeper and Prioritization Engine", date 2026-02-23, draft false, weight 20, toc true. Display trading card: `![Muti-Mind — Product Owner trading card](/images/team/multi-mind.png)`. Body adapted from `unbound-force.md` Muti-Mind section — cover vision keeping, prioritization, backlog ownership, acceptance authority, and the "Voice of the User" concept. Explain how Muti-Mind serves developers (clarification), testers (acceptance criteria), and reviewers (baseline for review). Adapt for website audience. Must satisfy FR-007, FR-008, FR-011, FR-012, FR-016.
+- [x] T010 [P] [US3] Create Cobalt-Crush persona page in `content/docs/team/cobalt-crush.md`. Frontmatter: title "Cobalt-Crush", description about the Developer persona, lead "The Engineering Core and Adaptive Implementation Engine", date 2026-02-23, draft false, weight 30, toc true. Display trading card: `![Cobalt-Crush — Developer trading card](/images/team/cobalt-crush.png)`. Body adapted from `unbound-force.md` — cover high-velocity implementation, CI/CD focus, architectural adherence, tight feedback loops with Gaze (tester), and technical problem solving. Must satisfy FR-007, FR-008, FR-011, FR-012, FR-016.
+- [x] T011 [P] [US3] Create Gaze (Tester) persona page in `content/docs/team/gaze-tester.md`. Frontmatter: title "Gaze", description about the Tester persona, lead "The Quality Sentinel and Predictive Validation Engine", date 2026-02-23, draft false, weight 40, toc true. Display trading card: `![Gaze — Tester trading card](/images/team/gaze.png)`. Body adapted from `unbound-force.md` — cover proactive test strategies, CI/CV pipeline ownership, intelligent defect detection, risk-based testing, and performance/security profiling. Note: this is the Gaze persona (the tester role), distinct from the Gaze project page (the tool). Must satisfy FR-007, FR-008, FR-011, FR-012, FR-016.
+- [x] T012 [P] [US3] Create The Divisor persona page in `content/docs/team/the-divisor.md`. Frontmatter: title "The Divisor", description about the PR Reviewer Council persona, lead "The Architectural Conscience and Code Integrity Guardian", date 2026-02-23, draft false, weight 50, toc true. Display trading card: `![The Divisor — PR Reviewer Council trading card](/images/team/the-divisor.png)`. Body adapted from `unbound-force.md` — MUST describe the three sub-personas: The Guard (intent and cohesion), The Architect (structure and sustainability), The Adversary (resilience and security). Explain the collective approval requirement — no outstanding REQUEST CHANGES from any persona. Cover Zero-Waste Mandate and Neighborhood Rule references. Must satisfy FR-007, FR-008, FR-009, FR-011, FR-012, FR-016.
+- [x] T013 [P] [US3] Create Mx F persona page in `content/docs/team/mx-f.md`. Frontmatter: title "Mx F", description about the Manager persona, lead "The Flow Facilitator and Continuous Improvement Coach", date 2026-02-23, draft false, weight 60, toc true. Display trading card: `![Mx F — Manager trading card](/images/team/mx-f.png)`. Body adapted from `unbound-force.md` — cover servant leadership, coaching via reflective questions (not direct solutions), obstacle removal, flow optimization, process stewardship, retrospectives, and capacity monitoring. Must satisfy FR-007, FR-008, FR-011, FR-012, FR-016.
+
+**Checkpoint**: Team section complete — verify all 6 pages render, composite image on index, trading card on each persona page, sidebar shows overview + 5 personas in order (Muti-Mind, Cobalt-Crush, Gaze, The Divisor, Mx F)
+
+---
+
+## Phase 6: User Story 4 — Contributing Guide (Priority: P2)
+
+**Goal**: Developers who want to contribute to Unbound Force projects find clear instructions for reporting issues, submitting PRs, following conventions, and using the Speckit workflow.
+
+**Independent Test**: Navigate to `/docs/contributing/`. The page explains how to contribute with actionable steps and links to GitHub.
+
+**Source**: AGENTS.md conventions (R4), Speckit workflow (R4)
+
+### Implementation for User Story 4
+
+- [x] T014 [US4] Create Contributing section index in `content/docs/contributing/_index.md`. Frontmatter: title "Contributing", description about how to contribute to Unbound Force, lead text, date 2026-02-23, draft false, weight 10, toc true. Body content covering:
+  - **Reporting Issues**: Link to GitHub issues for the relevant repositories
+  - **Submitting Pull Requests**: Standard GitHub PR workflow, mention branch naming convention (e.g., `###-feature-name`)
+  - **Conventional Commits**: List the valid types: `feat:`, `fix:`, `docs:`, `chore:`, `style:`, `refactor:`, `ci:` with brief examples
+  - **Speckit Workflow**: Explain that all non-trivial work goes through the pipeline: constitution → specify → clarify → plan → tasks → analyze → checklist → implement. Link to the Specify project.
+  - **Links**: GitHub organization (`https://github.com/unbound-force`), website repo, Gaze repo
+  - Must satisfy FR-010, FR-011, FR-012, FR-015.
+
+**Checkpoint**: Contributing section complete — verify page renders with GitHub links and all convention details
+
+---
+
+## Phase 7: User Story 5 — Navigation & Configuration (Priority: P1)
+
+**Goal**: All documentation sections appear in the sidebar in the correct order, the "Get Started" button works on the homepage, and the full site builds successfully.
+
+**Independent Test**: From the homepage, click "Get Started" — lands on Getting Started. Sidebar shows all four sections in order. Every page is reachable within two clicks. `npm run build` succeeds with zero errors.
+
+**Source**: Navigation config (R5), "Get Started" button (R8), data-model.md validation rules
+
+### Implementation for User Story 5
+
+- [x] T015 [US5] Re-enable "Get Started" navbar button in `config/_default/params.toml`: change `navBarButton = false` to `navBarButton = true` on line 23. Must satisfy US5 acceptance scenario 1 and R8.
+- [x] T016 [US5] Verify `config/_default/menus/menus.en.toml` has all 4 `[[docs]]` entries with correct weights: Getting Started (10), Projects (20), The Team (30), Contributing (40). Read the file and confirm — do NOT modify if already correct (it should be per R5). Must satisfy FR-014.
+- [x] T017 [US5] Run `npm run build` and verify zero errors. If build fails, fix the issue before proceeding. Must satisfy SC-003.
+
+**Checkpoint**: Navigation verified — sidebar order correct, "Get Started" button active, build succeeds
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation across all sections and stories
+
+- [x] T018 Verify all 12 content pages have complete YAML frontmatter: check every `.md` file in `content/docs/` for required fields (title, description, lead, date, draft: false, weight, toc). Must satisfy SC-007.
+- [x] T019 Verify no placeholder content exists: search all content pages for "Coming Soon", "TODO", "TBD", "Lorem ipsum", or similar placeholder text. Must satisfy SC-006.
+- [x] T020 Verify all internal links are valid: check cross-references between pages — specifically the Gaze project page link to `/blog/why-contract-coverage/`, the Getting Started links to tool websites, the Contributing links to GitHub repos. Must satisfy FR-015.
+- [x] T021 Verify sidebar ordering: run `npm run dev` and confirm sidebar shows sections in order (Getting Started, Projects, Team, Contributing) with sub-pages in correct weight order within each section. Must satisfy SC-002, SC-008.
+- [x] T022 Verify dark mode rendering: with `npm run dev` running, toggle dark mode and verify all 12 pages render correctly — text readable, images display properly, no broken styling.
+- [x] T023 Final build verification: run `npm run build` one last time to confirm the complete site builds with zero errors after all content and config changes. Must satisfy SC-003.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Setup — verifies source content
+- **US1 Getting Started (Phase 3)**: Depends on Phase 2 — can start immediately after
+- **US2 Gaze Project (Phase 4)**: Depends on Phase 2 — **can run in parallel with Phase 3**
+- **US3 Team Personas (Phase 5)**: Depends on Phase 2 — **can run in parallel with Phases 3-4**
+- **US4 Contributing (Phase 6)**: Depends on Phase 2 — **can run in parallel with Phases 3-5**
+- **US5 Navigation (Phase 7)**: Depends on Phases 3-6 (all content must exist before nav verification)
+- **Polish (Phase 8)**: Depends on Phase 7 (all content and config complete)
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent — no dependencies on other user stories
+- **US2 (P1)**: Independent — no dependencies on other user stories. Blog page `/blog/why-contract-coverage/` already exists.
+- **US3 (P2)**: Independent — no dependencies on other user stories
+- **US4 (P2)**: Independent — no dependencies on other user stories
+- **US5 (P1)**: Depends on US1-US4 completion (verifies navigation across all sections)
+
+### Within Each User Story
+
+- Section `_index.md` before sub-pages (Hugo needs it for section recognition)
+- All persona pages (T009-T013) can run in parallel after the team index (T008)
+
+### Parallel Opportunities
+
+- **Phase 3 + Phase 4 + Phase 5 + Phase 6** can all run in parallel after Phase 2
+- Within Phase 4: T006 (projects index) and T007 (gaze page) — T006 can run in parallel with anything in other phases
+- Within Phase 5: T009, T010, T011, T012, T013 (all 5 persona pages) can run in parallel after T008 (team index)
+
+---
+
+## Parallel Example: User Story 3 (Team Personas)
+
+```text
+# First: create the team index (required for section recognition)
+Task: T008 — Create team section index in content/docs/team/_index.md
+
+# Then: launch all 5 persona pages in parallel (different files, no dependencies)
+Task: T009 — Create Muti-Mind page in content/docs/team/muti-mind.md
+Task: T010 — Create Cobalt-Crush page in content/docs/team/cobalt-crush.md
+Task: T011 — Create Gaze (Tester) page in content/docs/team/gaze-tester.md
+Task: T012 — Create The Divisor page in content/docs/team/the-divisor.md
+Task: T013 — Create Mx F page in content/docs/team/mx-f.md
+```
+
+## Parallel Example: All P1 User Stories
+
+```text
+# After Phase 2 (foundational) completes, launch US1 and US2 simultaneously:
+
+# US1 — Getting Started (sequential within story)
+Task: T004 — Create getting-started index
+Task: T005 — Create quick-start page
+
+# US2 — Gaze Project (T006 in parallel, T007 after)
+Task: T006 — Create projects index
+Task: T007 — Create gaze project page
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational (T003)
+3. Complete Phase 3: US1 Getting Started (T004-T005)
+4. Complete Phase 4: US2 Gaze Project (T006-T007)
+5. **STOP and VALIDATE**: Run `npm run build`, verify both sections render, "Get Started" button works
+6. This delivers the two P1 content sections — the homepage CTA path and the flagship project page
+
+### Incremental Delivery
+
+1. Setup + Foundational → Framework ready
+2. Add US1 Getting Started → Homepage CTA works → P1 partial
+3. Add US2 Gaze Project → Flagship project documented → P1 complete
+4. Add US3 Team Personas → Agent swarm explained → P2 partial
+5. Add US4 Contributing → Community onboarding complete → P2 complete
+6. US5 Navigation + Polish → Full validation → Feature complete
+
+### Parallel Strategy
+
+With multiple agents:
+
+1. All complete Setup + Foundational together
+2. Once Phase 2 is done:
+   - Agent A: US1 Getting Started (2 pages)
+   - Agent B: US2 Gaze Project (2 pages)
+   - Agent C: US3 Team Personas (6 pages — highest page count, benefits most from parallel persona creation)
+   - Agent D: US4 Contributing (1 page)
+3. All stories complete independently → Phase 7 navigation verification → Phase 8 polish
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- No automated tests — validation is `npm run build` + visual verification via `npm run dev`
+- Commit after each phase or logical group of tasks
+- All content must be adapted for website audience — never copy READMEs verbatim (FR-016)
+- All content must be factually accurate against source repos — never fabricate features (Constitution I)
+- Source content references are in `specs/002-documentation-content/research.md` (R1-R8)


### PR DESCRIPTION
## Summary

- Create 12 Markdown content pages across 4 documentation sections: Getting Started (2 pages), Projects (2 pages), Team (6 pages), and Contributing (1 page), plus the docs root index
- Re-enable the "Get Started" navbar button in `params.toml` (was disabled pending this spec)
- Add `static` -> `assets` module mount in `module.toml` so the Doks image render hook can process trading card images from `static/images/team/`

## Content Pages

| Section | Pages | Key Content |
|---------|-------|-------------|
| **Getting Started** | What is Unbound Force?, Quick Start | Overview of the agent swarm, layered tool stack (OpenCode, Specify, Swarm) |
| **Projects** | Projects overview, Gaze | Gaze project page with `/gaze` OpenCode command, metrics, limitations, blog cross-link |
| **Team** | The Heroes overview + 5 personas | Muti-Mind, Cobalt-Crush, Gaze (Tester), The Divisor (3 sub-personas), Mx F — each with trading card image |
| **Contributing** | Contributing guide | Issue reporting, PR workflow, Conventional Commits, Speckit pipeline |

## Validation

- `npm run build` succeeds with zero errors (48 pages, 10 processed images)
- All 12 pages have complete YAML frontmatter with `draft: false`
- Zero placeholder content (no TODO, TBD, Coming Soon, Lorem ipsum)
- All 27 links valid (12 internal, 14 external, 1 static asset)
- All 23 tasks in `tasks.md` marked complete

## Manual Verification Needed

- Sidebar ordering: Getting Started > Projects > Team > Contributing
- Dark mode rendering on all pages
- Trading card images display correctly on team persona pages