### PR TITLE
feat: add Gaze in Practice blog post and sample output to docs page

### DIFF
--- a/content/blog/gaze-in-practice.md
+++ b/content/blog/gaze-in-practice.md
@@ -1,0 +1,173 @@
+---
+title: "Gaze in Practice: A Real-World Quality Report Walkthrough"
+description: "A section-by-section walkthrough of an actual Gaze report run against a real Go project — what the numbers mean, what stands out, and what to do next."
+lead: "What does a Gaze report actually look like? Here is a real one, section by section."
+slug: "gaze-in-practice"
+date: 2026-03-02T00:00:00+00:00
+draft: false
+weight: 90
+toc: true
+categories: ["Engineering"]
+tags: ["gaze", "testing", "go", "quality"]
+contributors: ["Unbound Force"]
+---
+
+## Why Real Output Matters
+
+The [existing article on Contract Coverage](/blog/why-contract-coverage/) explains the theory — why line coverage is not enough, how Contract Coverage works, what GazeCRAP measures. But theory only gets you so far. If you are evaluating Gaze for your Go project, you want to know: what will I actually see when I run it?
+
+This walkthrough answers that question. We ran Gaze against [gcal-organizer](https://github.com/jflowers/gcal-organizer), a Go-based Google Calendar organizer tool — a real side project with real gaps, not a contrived demo built to make the tool look good. The project has 137 functions across multiple packages, a mix of well-tested core logic and completely untested CLI code, and a recently added feature branch (decision extraction) that has not yet had any tests written for it.
+
+The report below was generated using `/gaze` in OpenCode — the full report mode that combines CRAP analysis, contract quality assessment, side effect classification, and overall health scoring. Every number is reproduced exactly as Gaze produced it.
+
+**Report metadata:**
+- **Project**: github.com/jflowers/gcal-organizer
+- **Branch**: 008-decision-extraction
+- **Gaze Version**: v1.2.3
+- **Go**: 1.24.12
+- **Date**: 2026-03-02
+
+## 📊 CRAP Summary
+
+The CRAP (Change Risk Anti-Patterns) summary provides aggregate metrics across all functions in the module.
+
+| Metric | Value |
+|--------|------:|
+| Total functions analyzed | 137 |
+| Average complexity | 4.9 |
+| Average line coverage | 26.2% |
+| Average CRAP score | 29.7 |
+| CRAPload | 40 (functions ≥ threshold 15) |
+
+### What This Tells Us
+
+The average complexity of 4.9 is reasonable — most functions are not individually complex. But 26.2% average line coverage is low, and a CRAPload of 40 means 29.2% of all functions (40 out of 137) exceed the CRAP threshold of 15. That is a significant chunk of the codebase where complexity and poor coverage combine to create change risk.
+
+The average CRAP score of 29.7 is inflated by the tail — a handful of very complex, completely untested functions drive the average up. This is a common pattern in projects where core business logic has decent coverage but CLI entry points and infrastructure code have none.
+
+## Top 5 Worst CRAP Scores
+
+Gaze surfaces the functions with the highest individual CRAP scores — the specific places where change risk is concentrated.
+
+| Function | CRAP | Complexity | Coverage | File |
+|----------|-----:|----------:|---------:|------|
+| (\*Service).CreateDecisionsTab | 650.0 | 25 | 0.0% | internal/docs/service.go:460 |
+| runBrowserScript | 342.0 | 18 | 0.0% | cmd/gcal-organizer/assign_tasks.go:237 |
+| loadDotEnv | 240.0 | 15 | 0.0% | cmd/gcal-organizer/main.go:382 |
+| (\*Service).ListMeetingDocuments | 210.0 | 14 | 0.0% | internal/drive/service.go:113 |
+| (\*Organizer).printSummary | 156.0 | 12 | 0.0% | internal/organizer/organizer.go:227 |
+
+### What This Tells Us
+
+All five worst functions have 0% line coverage. These are not simple getters — they have cyclomatic complexities of 12 to 25, meaning they contain significant branching logic (conditionals, loops, error paths) that has never been exercised by a test.
+
+`CreateDecisionsTab` stands out with a CRAP score of 650 and complexity 25. This is the entry point for the newly added decision extraction feature — it was written on the current branch and has not yet had any tests written. At complexity 25, this function almost certainly needs to be decomposed before meaningful tests can be written against it.
+
+The next three functions (`runBrowserScript`, `loadDotEnv`, `ListMeetingDocuments`) are infrastructure and CLI code. This is the pattern mentioned earlier: core business logic gets tested, but the glue code that wires things together and handles configuration gets ignored. These functions are risky precisely because they handle error-prone operations (browser automation, environment loading, API calls) with no safety net.
+
+## GazeCRAP Quadrant Distribution
+
+This is where Gaze goes beyond traditional CRAP. The GazeCRAP quadrant places each function on a 2x2 grid comparing its traditional CRAP score (complexity + line coverage) against its GazeCRAP score (complexity + contract coverage). For a deeper explanation of this distinction, see [Why Contract Coverage](/blog/why-contract-coverage/).
+
+| Quadrant | Count | Meaning |
+|----------|------:|---------|
+| 🟢 Q1 — Safe | 12 | Low complexity, high contract coverage |
+| 🟡 Q2 — Complex But Tested | 0 | High complexity, contracts verified |
+| 🔴 Q4 — Dangerous | 2 | Complex AND contracts not adequately verified |
+| ⚪ Q3 — Needs Tests | 3 | Simple but underspecified |
+
+**GazeCRAPload**: 5 (functions ≥ threshold 15) — The 2 Q4 functions (`SyncCalendarAttachments` at GazeCRAP 1482 and `OrganizeDocuments` at 306) have decent line coverage but 0% contract coverage, meaning their side effects are tested incidentally rather than intentionally. The 3 Q3 functions need contract-level assertions added to existing tests, not new test files.
+
+### What This Tells Us
+
+The quadrant distribution reveals something the raw CRAP scores cannot: the difference between functions that are tested and functions that are *verified*.
+
+12 functions land in Q1 (Safe) — these are the functions where both complexity and contract obligations are under control. Zero functions are in Q2 (Complex But Tested), which means there are no complex functions where contracts are being intentionally verified. This is a gap.
+
+The two Q4 (Dangerous) functions are the most important finding. `SyncCalendarAttachments` has a GazeCRAP score of 1482 — by far the highest in the project. It has line coverage (code runs during tests), but 0% contract coverage (no test actually asserts on its contractual side effects). The tests exercise the code path without checking whether the function does what it is supposed to do. This is exactly the scenario that traditional coverage metrics miss and Contract Coverage was designed to catch.
+
+The 3 Q3 functions are the easiest wins: they are simple functions that just need contract-level assertions added to their existing tests. No new test files, no refactoring — just better assertions.
+
+## 🧪 Quality Summary
+
+The quality analysis measures contract coverage at the per-function level — which side effects are contractual, which tests assert on them, and where the gaps are.
+
+> ⚠️ Module-level quality analysis returned 0 tests — run per-package analysis (`/gaze quality ./internal/...`) for detailed contract coverage results.
+
+### What This Tells Us
+
+This warning means the module-level quality scan did not find test files at the root module scope. This is expected for projects that organize tests at the package level (which is the standard Go convention). The quality data that feeds the GazeCRAP quadrants above came from a different analysis path.
+
+The fix is straightforward: run `/gaze quality ./internal/store` or `/gaze quality ./internal/organizer` to get per-package contract coverage breakdowns. This is not a bug — it is the tool telling you to scope your query more narrowly for detailed results.
+
+## 🏷️ Classification Summary
+
+The classification analysis identifies the side effects of each function and classifies them as contractual, incidental, or ambiguous.
+
+The `analyze --classify` command returned only 1 function (`SetVerbose`) with no side effects classified, which is insufficient for a meaningful distribution table.
+
+> ⚠️ No documentation found — classification uses mechanical signals only.
+
+The docscan returned project-level documentation (AGENTS.md, README.md) but no function-level API docs or spec files referencing specific function contracts. Document-enhanced classification cannot meaningfully adjust mechanical scores without function-level documentation signals.
+
+### What This Tells Us
+
+Two things are happening here. First, the project does not have function-level API documentation — no godoc comments explaining what functions are responsible for, no spec files mapping functions to requirements. Without these signals, Gaze's classification engine falls back to purely mechanical heuristics (exported vs unexported, return types, interface satisfaction), which produces less confident classifications.
+
+Second, the single classified function (`SetVerbose`) is a trivial setter with no meaningful side effects, so it does not generate useful distribution data.
+
+This is honest reporting. Gaze does not inflate classification confidence when the signals are not there. The actionable takeaway: adding godoc comments to key exported functions would give the classification engine richer input and produce more useful contractual/incidental distinctions. Start with the functions that appear in the CRAP and GazeCRAP tables — those are the ones where accurate classification matters most.
+
+## 🏥 Overall Health Assessment
+
+The health assessment combines all dimensions into a single scorecard with letter grades and a prioritized action plan.
+
+### Summary Scorecard
+
+| Dimension | Grade | Details |
+|-----------|-------|---------|
+| CRAPload | 🔴 D | 40/137 functions (29.2%) above threshold |
+| GazeCRAPload | 🟢 A- | 5/17 analyzed functions above threshold |
+| Avg Line Coverage | 🔴 D | 26.2% — 101 of 137 functions have 0% coverage |
+| Contract Coverage | 🟡 C | 52.9% avg across 17 quality-analyzed functions |
+| Complexity | 🟢 B+ | Average 4.9, but 40 functions exceed threshold |
+
+### What This Tells Us
+
+The scorecard paints a nuanced picture. Complexity gets a B+ — the project is not over-engineered, and most individual functions are reasonably simple. But line coverage at 26.2% (with 101 functions at 0%) earns a D, and CRAPload at 29.2% confirms that the combination of untested + complex code is widespread.
+
+The interesting contrast is between the two CRAP dimensions: traditional CRAPload gets a D (40 functions above threshold across all 137), but GazeCRAPload gets an A- (only 5 of the 17 quality-analyzed functions above threshold). This suggests that the functions which *do* have tests are generally well-tested at the contract level. The problem is not test quality — it is test *quantity*. Large swaths of the codebase have no tests at all.
+
+Contract Coverage at 52.9% (C grade) across the 17 analyzed functions means about half of the contractual side effects are being verified. For the functions that have tests, there is room to tighten the assertions, but it is not catastrophic.
+
+### Top 5 Prioritized Recommendations
+
+Gaze produces a prioritized action plan based on the analysis:
+
+1. 🔴 **Decompose SyncCalendarAttachments** — complexity 38 with GazeCRAP 1482 makes this the single most dangerous function; split into smaller orchestration steps before adding contract assertions.
+2. 🔴 **Add tests for CreateDecisionsTab** — complexity 25 with 0% coverage produces CRAP 650; this is the newly added decision extraction entry point and needs both line and contract coverage.
+3. 🔴 **Increase coverage for the cmd/gcal-organizer package** — 39 functions at 0% coverage account for 95% of the CRAPload; prioritize `runBrowserScript` (complexity 18) and `loadDotEnv` (complexity 15).
+4. 🟡 **Add contract assertions for OrganizeDocuments, ExtractDecisionsForDoc, and retry.Do** — these have adequate line coverage (57-100%) but 0% contract coverage, placing them in Q3/Q4 quadrants.
+5. 🟢 **Run per-package quality analysis** — module-level returned 0 tests; per-package analysis will surface granular contract coverage gaps across internal packages.
+
+### What This Tells Us
+
+The recommendations follow a clear triage logic:
+
+**Red items first.** `SyncCalendarAttachments` is not just undertested — at complexity 38, it is too complex to test meaningfully in its current form. The recommendation is to decompose it before writing tests, because testing a function that complex would require an unwieldy number of test cases to cover the branching paths. `CreateDecisionsTab` is the next priority because it is new code (on the active branch) with zero tests — the easiest time to add tests is before the code becomes entangled with the rest of the system.
+
+**Yellow items are the contract gaps.** Three functions have tests that run the code but do not assert on the contractual outputs. These are the Q3/Q4 functions from the quadrant analysis. Fixing these does not require writing new test files — it means adding assertions to existing tests.
+
+**Green is a process improvement.** Running per-package analysis will surface more granular data that the module-level report could not provide. This is the next diagnostic step, not a code change.
+
+## Key Takeaways
+
+This report tells a common story for side projects and medium-sized codebases:
+
+1. **The code is not overly complex.** Average complexity of 4.9 is fine. The problem is concentrated in a few high-complexity functions, not spread uniformly.
+2. **Coverage is bimodal.** Core business logic has decent coverage. CLI and infrastructure code has none. This creates a long tail of high-CRAP functions that inflate the averages.
+3. **The tests that exist are decent but incomplete.** Contract coverage of 52.9% means the existing tests are doing useful work, but about half of the contractual obligations are unverified.
+4. **The biggest risk is a single function.** `SyncCalendarAttachments` at GazeCRAP 1482 is an outlier that dominates the risk profile. Decomposing it would materially improve the project's overall health score.
+5. **The easiest wins are the Q3 functions.** Adding contract assertions to existing tests requires no new test infrastructure — just better assertions in tests that already exist.
+
+For setup instructions and more about how Gaze works, see the [Gaze project page](/docs/projects/gaze/). For the conceptual foundation behind Contract Coverage and GazeCRAP, see [Why Contract Coverage](/blog/why-contract-coverage/).

--- a/content/docs/projects/gaze.md
+++ b/content/docs/projects/gaze.md
@@ -122,6 +122,32 @@ The `/gaze` command routes to a quality reporting agent that runs the analysis, 
 
 A companion command, `/classify-docs`, enhances classification by combining mechanical signals with project documentation analysis.
 
+## Sample Output
+
+Here is what a full Gaze report looks like on a real Go project — [gcal-organizer](https://github.com/jflowers/gcal-organizer), analyzed with Gaze v1.2.3.
+
+### Overall Health Assessment
+
+| Dimension | Grade | Details |
+|-----------|-------|---------|
+| CRAPload | 🔴 D | 40/137 functions (29.2%) above threshold |
+| GazeCRAPload | 🟢 A- | 5/17 analyzed functions above threshold |
+| Avg Line Coverage | 🔴 D | 26.2% — 101 of 137 functions have 0% coverage |
+| Contract Coverage | 🟡 C | 52.9% avg across 17 quality-analyzed functions |
+| Complexity | 🟢 B+ | Average 4.9, but 40 functions exceed threshold |
+
+### Top 5 Worst CRAP Scores
+
+| Function | CRAP | Complexity | Coverage | File |
+|----------|-----:|----------:|---------:|------|
+| (\*Service).CreateDecisionsTab | 650.0 | 25 | 0.0% | internal/docs/service.go:460 |
+| runBrowserScript | 342.0 | 18 | 0.0% | cmd/gcal-organizer/assign_tasks.go:237 |
+| loadDotEnv | 240.0 | 15 | 0.0% | cmd/gcal-organizer/main.go:382 |
+| (\*Service).ListMeetingDocuments | 210.0 | 14 | 0.0% | internal/drive/service.go:113 |
+| (\*Organizer).printSummary | 156.0 | 12 | 0.0% | internal/organizer/organizer.go:227 |
+
+For a section-by-section walkthrough of the full report — including GazeCRAP quadrants, quality analysis, classification, and prioritized recommendations — see [Gaze in Practice](/blog/gaze-in-practice/).
+
 ## Architecture
 
 Gaze is structured as a set of focused packages:

--- a/specs/004-gaze-in-practice/plan.md
+++ b/specs/004-gaze-in-practice/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: "Gaze in Practice" Blog Post and Docs Sample Output
+
+**Branch**: `004-gaze-in-practice` | **Date**: 2026-03-02 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/004-gaze-in-practice/spec.md`
+
+## Summary
+
+Add a new blog post ("Gaze in Practice: A Real-World Quality Report Walkthrough") that walks through real Gaze output from the gcal-organizer project, section by section, with interpretive narrative. Additionally, add a condensed "Sample Output" section to the existing Gaze project docs page showing the Health Assessment scorecard and Top 5 Worst CRAP Scores table, with a link to the full blog walkthrough.
+
+Both deliverables use real data from `temp/tmp.md` — no fabricated numbers. The blog post is standard Markdown content; the docs change is a new section inserted into an existing file. No custom templates, layouts, or CSS are needed.
+
+## Technical Context
+
+**Language/Version**: Hugo (via Thulite/npm), Markdown content
+**Primary Dependencies**: `@thulite/doks-core ^1.8.3` (theme), Hugo SSG
+**Storage**: N/A (static Markdown files)
+**Testing**: Manual — `npm run build` must succeed; visual verification via `npm run dev`
+**Target Platform**: GitHub Pages (static site)
+**Project Type**: Static documentation website
+**Performance Goals**: N/A
+**Constraints**: Content must follow AGENTS.md conventions (YAML frontmatter, H2 body start, fenced code blocks with language IDs)
+**Scale/Scope**: 1 new file (blog post), 1 modified file (docs page)
+
+## Constitution Check
+
+*GATE: Must pass before implementation.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Content Accuracy | PASS | All data is reproduced verbatim from actual Gaze output (`temp/tmp.md`). No features are fabricated. Warnings about insufficient data are included honestly. Gaze version (v1.2.3) and date (2026-03-02) are identified so content is understood as a point-in-time snapshot. |
+| II. Minimal Footprint | PASS | No custom templates, layouts, CSS, or dependencies. One new Markdown file and one section addition to an existing Markdown file. Uses standard Doks table and code block rendering. |
+| III. Visitor Clarity | PASS | Blog post explains each section of real output for developers evaluating Gaze. Docs page gets a quick visual preview. Cross-links connect the blog post, docs page, and existing "Why Contract Coverage" article. Blog post is reachable in two clicks from homepage (navbar → Blog → article, or "Latest Articles" → article). |
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-gaze-in-practice/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+└── tasks.md             # Task list (created next)
+```
+
+### Source Code (content changes)
+
+```text
+website/content/
+├── blog/
+│   ├── why-contract-coverage.md    # Existing — NOT modified
+│   └── gaze-in-practice.md         # NEW — full walkthrough blog post
+└── docs/
+    └── projects/
+        └── gaze.md                 # MODIFIED — new "Sample Output" section added
+```
+
+**Structure Decision**: No structural changes. One new content file and one section insertion into an existing content file. Both follow established Markdown and frontmatter conventions.
+
+## Implementation Approach
+
+### Phase 1: Blog Post (`content/blog/gaze-in-practice.md`)
+
+Create the blog post with the following structure:
+
+1. **Frontmatter** — title, description, lead, slug (`gaze-in-practice`), date (2026-03-02), categories (`["Engineering"]`), tags (`["gaze", "testing", "go", "quality"]`), contributors, weight 90 (lower than existing post's 100 so it sorts as newer).
+
+2. **Introduction** — Establish context: what project was analyzed (gcal-organizer, a Go-based Google Calendar organizer tool), why it's a good test subject (real side project with real gaps, not a contrived demo), what the reader will learn (how to read and act on each section of a Gaze report). Link to "Why Contract Coverage" for conceptual background.
+
+3. **Report walkthrough sections** — For each section of the Gaze output:
+   - Show the actual output (tables, metrics) in a fenced code block or Markdown table
+   - Follow with 2-4 paragraphs of interpretation: what the numbers mean, what stands out, what action a developer would take
+
+   Sections in order:
+   - CRAP Summary (aggregate metrics)
+   - Top 5 Worst CRAP Scores (specific functions)
+   - GazeCRAP Quadrant Distribution (Q1-Q4 breakdown)
+   - Quality Summary (including the "0 tests" warning)
+   - Classification Summary (including the insufficient data warning)
+   - Overall Health Assessment (scorecard + prioritized recommendations)
+
+4. **Wrap-up** — Brief summary of what the report tells us about gcal-organizer's test health and how a developer would prioritize next steps. Link to Gaze project docs page for setup instructions.
+
+### Phase 2: Docs Page Update (`content/docs/projects/gaze.md`)
+
+Insert a new `## Sample Output` section after the "Three Modes" subsection (after line 121 in current file) and before "Architecture" (line 127). Contents:
+
+1. One-sentence intro: "Here's what a full Gaze report looks like on a real Go project."
+2. Project identification (gcal-organizer, Gaze v1.2.3)
+3. Health Assessment scorecard table (5 rows: CRAPload, GazeCRAPload, Avg Line Coverage, Contract Coverage, Complexity)
+4. Top 5 Worst CRAP Scores table
+5. One-line link to blog post: "For a section-by-section walkthrough of the full report, see [Gaze in Practice](/blog/gaze-in-practice/)."
+
+### Phase 3: Verification
+
+1. `npm run build` — must complete with zero errors
+2. `npm run dev` — visual verification:
+   - Blog index lists both posts, "Gaze in Practice" appears first
+   - Blog post renders all tables and code blocks correctly
+   - Homepage "Latest Articles" shows "Gaze in Practice" as most recent
+   - Gaze docs page shows new section with correct tables
+   - All cross-links work
+   - Both light and dark mode render correctly

--- a/specs/004-gaze-in-practice/spec.md
+++ b/specs/004-gaze-in-practice/spec.md
@@ -1,0 +1,124 @@
+# Feature Specification: "Gaze in Practice" Blog Post and Docs Sample Output
+
+**Feature Branch**: `004-gaze-in-practice`
+**Created**: 2026-03-02
+**Status**: Draft
+**Input**: User description: "Add documentation/blog content showing real Gaze output from running it on the gcal-organizer project. Both a new blog post walking through the output and a sample output section added to the existing Gaze project docs page."
+
+## Clarifications
+
+### Session 2026-03-02
+
+- Q: Blog post title? → A: "Gaze in Practice: A Real-World Quality Report Walkthrough"
+- Q: Should emoji characters from the Gaze output (🔍, 📊, 🧪, 🏥, 🔴, 🟢, 🟡) be preserved in the blog post? → A: Yes, preserve them exactly as Gaze produces them — authenticity matters.
+- Q: Should the Quality Summary and Classification Summary sections (which contain "insufficient data" warnings) be included? → A: Yes, include all sections with honest interpretation — demonstrates the tool's transparent reporting.
+- Q: Where should the sample output section go on the docs page? → A: After "Three Modes" and before "Architecture" — natural flow from explaining modes to showing what output looks like.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Reading the "Gaze in Practice" Blog Post (Priority: P1)
+
+As a developer considering Gaze for my Go project, I want to see what a real Gaze report looks like when run against an actual codebase, so that I understand what the tool produces and how to interpret its output before investing time in setting it up.
+
+**Why this priority**: The existing documentation explains concepts (Contract Coverage, GazeCRAP, quadrants) but never shows real output. A walkthrough of actual output is the most effective way to bridge the gap between "what does this tool do?" and "what will I actually see when I use it?" This is the primary deliverable.
+
+**Independent Test**: Navigate to the blog index from the navbar. Click on the "Gaze in Practice" article. The full article renders with the real report output, section-by-section interpretation, and correct formatting.
+
+**Acceptance Scenarios**:
+
+1. **Given** I click "Blog" in the main navbar, **When** the blog index page loads, **Then** I see the "Gaze in Practice" post listed alongside the existing "Why Contract Coverage" post, with its title, description, and date.
+2. **Given** I click on the "Gaze in Practice" article, **When** the page loads, **Then** I see all report sections from the real Gaze output: CRAP Summary, Top 5 Worst CRAP Scores, GazeCRAP Quadrant Distribution, Quality Summary, Classification Summary, and Overall Health Assessment.
+3. **Given** the article includes output tables, **When** I read them, **Then** the data matches the actual Gaze output from the gcal-organizer project (137 functions analyzed, average complexity 4.9, CRAPload 40, etc.) — no fabricated or modified numbers.
+4. **Given** each section of output, **When** I read the surrounding narrative, **Then** there is interpretive text explaining what the numbers mean, why they matter, and what action I would take based on them.
+5. **Given** the article, **When** I check the report metadata, **Then** it identifies the project (gcal-organizer), branch (008-decision-extraction), Gaze version (v1.2.3), Go version (1.24.12), and date (2026-03-02).
+6. **Given** the article references concepts like GazeCRAP, Contract Coverage, or quadrants, **When** I want to learn more, **Then** there are links back to the existing "Why Contract Coverage" blog post and/or the Gaze project docs page.
+
+---
+
+### User Story 2 - Seeing Sample Output on the Gaze Project Docs Page (Priority: P2)
+
+As a developer scanning the Gaze documentation page, I want to see a condensed example of what the tool produces, so that I can quickly understand the output format without reading a full blog post.
+
+**Why this priority**: The docs page is the primary reference for Gaze. Adding a visual example of output makes it self-contained for quick evaluation. However, the blog post provides the deeper walkthrough, so this is secondary.
+
+**Independent Test**: Navigate to Docs > Projects > Gaze. Scroll to a new "Sample Output" or "What You'll See" section. A condensed excerpt of real output is displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am on the Gaze project docs page, **When** I scroll through the page, **Then** I see a new section showing a condensed sample of real Gaze output.
+2. **Given** the sample output section, **When** I read it, **Then** it includes at minimum: the Health Assessment scorecard (dimensions, grades, details) and the Top 5 Worst CRAP Scores table — enough to show the flavor of the tool without overwhelming the docs page.
+3. **Given** the sample output section, **When** I look for a link to the full walkthrough, **Then** I find a link to the "Gaze in Practice" blog post for readers who want the complete report with interpretation.
+4. **Given** the docs page, **When** I check the existing sections, **Then** none of them have been altered — only a new section has been added.
+5. **Given** the sample output section, **When** I compare the data to the blog post, **Then** the numbers are consistent (same project, same report run).
+
+---
+
+### Edge Cases
+
+- What happens if the Gaze output format changes in a future version? Both the blog post and docs excerpt include the Gaze version number (v1.2.3) so readers understand this is a point-in-time snapshot. The blog post date further signals when the output was captured.
+- What happens if readers have no context on GazeCRAP or Contract Coverage? The blog post links to the existing "Why Contract Coverage" article for conceptual background. The docs page already explains these metrics above the sample output section.
+- What if the gcal-organizer project is not publicly accessible? The blog post focuses on interpreting the output, not on the reader replicating the exact run. The gcal-organizer project is referenced by name but no links to its repository are required.
+- What if the report contains sections with warnings (e.g., "0 tests" in quality summary)? The blog post interprets these honestly — they reflect the real state of the project, including its gaps, which is precisely the point of showing real output.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+#### Blog Post: "Gaze in Practice"
+
+- **FR-001**: The blog post MUST be published as a Markdown file at `content/blog/gaze-in-practice.md` with complete YAML frontmatter including `title`, `description`, `lead`, `slug`, `date`, `draft: false`, `weight`, `toc: true`, `categories`, `tags`, and `contributors`.
+- **FR-002**: The article body MUST start with `##` (H2). The `title` frontmatter generates H1.
+- **FR-003**: The article MUST reproduce the actual Gaze output from the gcal-organizer project run. Numbers, function names, file paths, grades, and recommendations MUST match the source output exactly. No data may be fabricated or "rounded" for narrative convenience.
+- **FR-004**: Each section of the Gaze report (CRAP Summary, Top 5 Worst, GazeCRAP Quadrants, Quality Summary, Classification Summary, Health Assessment, Recommendations) MUST be followed by interpretive narrative explaining what the numbers mean and what actions a developer would consider.
+- **FR-005**: The article MUST include a brief introduction establishing context: what project was analyzed, why it was chosen (a real side project, not a synthetic example), and what the reader will learn.
+- **FR-006**: The article MUST link to the existing "Why Contract Coverage" blog post for readers who want conceptual background on the metrics.
+- **FR-007**: The article MUST link to the Gaze project docs page for readers who want setup instructions or architecture details.
+- **FR-008**: All tables MUST use standard Markdown table syntax and render correctly in the Hugo/Doks theme.
+- **FR-009**: The article MUST NOT editorialize beyond interpretation. The tone should be "here's what this means" rather than marketing copy.
+- **FR-010**: The article MUST honestly present the warnings in the output (e.g., "0 tests" in quality summary, insufficient classification data) without downplaying them.
+
+#### Docs Page: Sample Output Section
+
+- **FR-011**: A new section MUST be added to `content/docs/projects/gaze.md` showing condensed sample output from a real Gaze run.
+- **FR-012**: The new section MUST be positioned after the "Three Modes" subsection and before the "Architecture" section — logically placed after explaining what the modes do and before diving into internals.
+- **FR-013**: The sample output MUST include at minimum: (a) the Overall Health Assessment scorecard table and (b) the Top 5 Worst CRAP Scores table.
+- **FR-014**: The sample output section MUST include a link to the "Gaze in Practice" blog post with a call-to-action like "See the full report walkthrough."
+- **FR-015**: The sample output MUST identify the source project and Gaze version so readers understand the data is from a specific real run.
+- **FR-016**: The sample output section MUST NOT duplicate the full interpretive narrative from the blog post. It shows the output with minimal annotation — the blog post is for the deep dive.
+
+#### Build and Navigation Integrity
+
+- **FR-017**: The site MUST build successfully with zero errors after all changes.
+- **FR-018**: The new blog post MUST appear on the blog index page and in the homepage "Latest Articles" section (it will be the most recent post).
+- **FR-019**: All internal links (to "Why Contract Coverage" blog post, to Gaze docs page, between blog post and docs) MUST be valid.
+- **FR-020**: The existing "Why Contract Coverage" blog post MUST NOT be altered.
+- **FR-021**: All code blocks MUST use fenced syntax with language identifiers (`text` for Gaze output).
+
+### Key Entities
+
+- **Blog Post ("Gaze in Practice")**: A Markdown file in `content/blog/` containing a section-by-section walkthrough of real Gaze output with interpretive narrative. Links to existing conceptual content.
+- **Sample Output Section**: A new section in the existing Gaze project docs page showing a condensed excerpt of the same real output, with a link to the full blog walkthrough.
+- **Source Output**: The raw Gaze report at `temp/tmp.md`, captured from running `/gaze` on the `gcal-organizer` project (branch `008-decision-extraction`).
+
+### Assumptions
+
+- The Gaze output in `temp/tmp.md` is the authoritative source for all data. No numbers will be modified.
+- The gcal-organizer project is a personal side project, which makes it a genuine "real-world" example rather than a demo project built to look good.
+- The blog post weight should be lower than the existing "Why Contract Coverage" post (weight 100) so it appears as more recent / listed first on the blog index.
+- The homepage "Latest Articles" section (built in spec 003) dynamically sources the most recent blog post, so no homepage changes are needed.
+- Emoji characters in the Gaze output (used for grades and section headers) are acceptable in the blog post since they are part of the actual tool output.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: The "Gaze in Practice" blog post is accessible at `/blog/gaze-in-practice/` and renders with all sections, tables, and code blocks correctly formatted.
+- **SC-002**: The blog post appears on the blog index page listed above the "Why Contract Coverage" post (more recent date).
+- **SC-003**: The blog post appears in the homepage "Latest Articles" section as the most recent post.
+- **SC-004**: The Gaze docs page at `/docs/projects/gaze/` includes a new sample output section with the Health Assessment scorecard and Top 5 Worst CRAP Scores table.
+- **SC-005**: The sample output section links to the full blog post.
+- **SC-006**: All data in both the blog post and docs section exactly matches the source output in `temp/tmp.md`.
+- **SC-007**: The site builds successfully with zero errors (`npm run build`).
+- **SC-008**: All internal cross-links between the blog post, docs page, and existing "Why Contract Coverage" post are valid.
+- **SC-009**: No existing pages are altered except `content/docs/projects/gaze.md` (new section added).
+- **SC-010**: Both new and modified pages render correctly in both light and dark mode.

--- a/specs/004-gaze-in-practice/tasks.md
+++ b/specs/004-gaze-in-practice/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: "Gaze in Practice" Blog Post and Docs Sample Output
+
+**Input**: Design documents from `/specs/004-gaze-in-practice/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Exact file paths included in descriptions
+
+---
+
+## Phase 1: User Story 1 — Blog Post (Priority: P1) 🎯 MVP
+
+**Goal**: Publish a blog post walking through real Gaze output section by section with interpretive narrative.
+
+**Independent Test**: Navigate to `/blog/gaze-in-practice/`. The full article renders with all tables, correct data, and cross-links.
+
+### Implementation
+
+- [x] T001 [US1] Create blog post file at `content/blog/gaze-in-practice.md` with YAML frontmatter (title: "Gaze in Practice: A Real-World Quality Report Walkthrough", slug: `gaze-in-practice`, date: 2026-03-02, weight: 90, categories: `["Engineering"]`, tags: `["gaze", "testing", "go", "quality"]`, contributors: `["Unbound Force"]`, toc: true, draft: false)
+- [x] T002 [US1] Write introduction section: establish context (gcal-organizer project, branch 008-decision-extraction, Gaze v1.2.3), explain why a real project matters vs synthetic examples, link to "Why Contract Coverage" blog post for conceptual background
+- [x] T003 [US1] Write CRAP Summary section: reproduce the CRAP Summary table from `temp/tmp.md` (137 functions, avg complexity 4.9, avg coverage 26.2%, avg CRAP 29.7, CRAPload 40), followed by interpretation of what these numbers reveal about the project
+- [x] T004 [US1] Write Top 5 Worst CRAP Scores section: reproduce the Top 5 table (CreateDecisionsTab 650, runBrowserScript 342, loadDotEnv 240, ListMeetingDocuments 210, printSummary 156), followed by interpretation highlighting that all five have 0% coverage
+- [x] T005 [US1] Write GazeCRAP Quadrant Distribution section: reproduce the quadrant table (Q1: 12, Q2: 0, Q3: 3, Q4: 2), reproduce the GazeCRAPload narrative (5 functions, SyncCalendarAttachments at 1482, OrganizeDocuments at 306), followed by interpretation of what the quadrant distribution tells us
+- [x] T006 [US1] Write Quality Summary section: reproduce the warning about 0 tests at module level, interpret honestly — explain what this means (per-package analysis needed) and why it appears
+- [x] T007 [US1] Write Classification Summary section: reproduce the warning about only 1 function classified and no documentation found, interpret honestly — explain mechanical vs document-enhanced classification
+- [x] T008 [US1] Write Overall Health Assessment section: reproduce the Summary Scorecard table (CRAPload D, GazeCRAPload A-, Avg Line Coverage D, Contract Coverage C, Complexity B+), reproduce the Top 5 Prioritized Recommendations, followed by interpretation
+- [x] T009 [US1] Write wrap-up section: summarize key takeaways, explain how a developer would prioritize next steps using this report, link to Gaze project docs page for setup instructions
+
+**Checkpoint**: Blog post is complete and ready for build verification.
+
+---
+
+## Phase 2: User Story 2 — Docs Page Sample Output (Priority: P2)
+
+**Goal**: Add a condensed sample output section to the Gaze docs page.
+
+**Independent Test**: Navigate to `/docs/projects/gaze/`. The new "Sample Output" section appears between "Three Modes" and "Architecture" with correct tables and a link to the blog post.
+
+### Implementation
+
+- [x] T010 [US2] Add new `## Sample Output` section to `content/docs/projects/gaze.md` after the "Three Modes" subsection (after the `/classify-docs` paragraph, before `## Architecture`). Include: one-sentence intro, project identification (gcal-organizer, Gaze v1.2.3), Health Assessment scorecard table, Top 5 Worst CRAP Scores table, link to blog post ("For a section-by-section walkthrough, see [Gaze in Practice](/blog/gaze-in-practice/).")
+
+**Checkpoint**: Docs page update is complete and ready for build verification.
+
+---
+
+## Phase 3: Verification
+
+**Purpose**: Confirm all content renders correctly and the site builds without errors.
+
+- [x] T011 Run `npm run build` and confirm zero errors
+- [x] T012 Run `npm run dev` and visually verify: (a) blog index lists both posts with "Gaze in Practice" appearing first, (b) blog post renders all tables and code blocks correctly, (c) homepage "Latest Articles" shows "Gaze in Practice", (d) Gaze docs page shows new section with correct tables, (e) all cross-links work (blog ↔ docs, blog → "Why Contract Coverage"), (f) light and dark mode render correctly
+- [x] T013 Verify data accuracy: cross-reference all numbers in blog post and docs section against `temp/tmp.md` source output
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Blog Post)**: No dependencies — can start immediately
+- **Phase 2 (Docs Update)**: No dependency on Phase 1 (different file), but logically should be done after so the blog link target exists
+- **Phase 3 (Verification)**: Depends on Phase 1 and Phase 2 completion
+
+### Parallel Opportunities
+
+- T001 through T009 are sequential (single file, each section builds on the previous)
+- T010 is independent of T001-T009 (different file) but should logically follow to ensure blog post exists for cross-linking
+- T011, T012, T013 run after all content tasks are complete
+
+### Implementation Strategy
+
+Sequential delivery in priority order:
+1. Complete Phase 1 (blog post) — the primary deliverable
+2. Complete Phase 2 (docs update) — quick addition referencing the blog post
+3. Complete Phase 3 (verification) — confirm everything works


### PR DESCRIPTION
## Summary

- Add a new blog post **"Gaze in Practice: A Real-World Quality Report Walkthrough"** that walks through actual Gaze output from the gcal-organizer project, section by section, with interpretive narrative explaining what the numbers mean and what actions to take.
- Add a condensed **"Sample Output" section** to the existing Gaze project docs page (`docs/projects/gaze.md`) showing the Health Assessment scorecard and Top 5 Worst CRAP Scores, with a link to the full blog walkthrough.
- Include Speckit pipeline artifacts (`specs/004-gaze-in-practice/`) with spec, plan, and tasks.

## Motivation

The existing documentation explains Gaze concepts theoretically (the "Why Contract Coverage" blog post and the Gaze project page). Neither shows what a real report looks like. This PR bridges that gap with actual output from a real Go project — including its warts (0% coverage warnings, insufficient classification data) — so developers evaluating Gaze can see exactly what the tool produces before investing time in setup.

## Changes

| File | Change |
|------|--------|
| `content/blog/gaze-in-practice.md` | **New** — Full blog post with report walkthrough |
| `content/docs/projects/gaze.md` | **Modified** — New "Sample Output" section added between "Three Modes" and "Architecture" |
| `specs/004-gaze-in-practice/spec.md` | **New** — Feature specification |
| `specs/004-gaze-in-practice/plan.md` | **New** — Implementation plan with constitution check |
| `specs/004-gaze-in-practice/tasks.md` | **New** — Task list (all complete) |

## Verification

- `npm run build` succeeds with zero errors (51 pages)
- All data cross-referenced against source output — every number matches exactly
- All cross-links verified (blog ↔ docs, blog → "Why Contract Coverage")
- No existing pages altered except the new section in `gaze.md`