### PR TITLE
docs: update website for swarm delegation workflow and reflect stage

### DIFF
--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -36,7 +36,7 @@ The swarm consists of five personas, each representing the pinnacle archetype of
 - **[The Divisor](/docs/team/the-divisor/)** — PR Reviewer Council. The Architectural Conscience and Code Integrity Guardian.
 - **[Mx F](/docs/team/mx-f/)** — Manager. The Flow Facilitator and Continuous Improvement Coach.
 
-Together, they cover the full software development lifecycle — from requirements and planning through implementation, testing, review, and process improvement.
+Together, they cover the full software development lifecycle — from requirements and planning through implementation, testing, review, acceptance, and reflection. The swarm runs autonomously from implementation through review, pausing for human acceptance before completing the cycle.
 
 ## Get Started
 

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -10,9 +10,9 @@ toc: true
 
 ## New Feature (End-to-End)
 
-The full hero lifecycle for a new feature follows six stages. Each stage is owned by a specific hero, and each produces artifacts consumed by the next.
+The full hero lifecycle for a new feature follows six stages. Each stage is owned by a specific hero, and each produces artifacts consumed by the next. Every stage has an **execution mode** -- either `[human]` (driven by the operator) or `[swarm]` (run autonomously by the agent swarm).
 
-### 1. Define (Product Owner)
+### 1. Define (Product Owner) `[human]`
 
 The [Product Owner (Muti-Mind)](/docs/getting-started/product-owner/) creates a backlog item and drives specification creation.
 
@@ -23,30 +23,24 @@ The [Product Owner (Muti-Mind)](/docs/getting-started/product-owner/) creates a 
 
 **Output**: Backlog item + feature specification
 
-### 2. Specify and Plan (Developer)
+After the human completes this stage, the swarm takes over automatically.
 
-The [Developer (Cobalt-Crush)](/docs/getting-started/developer/) creates the technical plan and task breakdown.
+### 2. Implement (Developer) `[swarm]`
+
+The [Developer (Cobalt-Crush)](/docs/getting-started/developer/) creates the technical plan and implements the feature.
 
 - Generate the implementation plan: `/speckit.plan`
 - Generate tasks: `/speckit.tasks`
 - Run cross-artifact analysis: `/speckit.analyze`
 - Validate checklists: `/speckit.checklist`
-- Commit and push all spec artifacts before implementation
-
-**Output**: plan.md + tasks.md + research.md
-
-### 3. Implement (Developer)
-
-The Developer implements the feature following the task plan.
-
 - Execute implementation: `/speckit.implement` or `/cobalt-crush`
 - For parallel work: `/swarm "implement spec NNN"`
 - Mark each task `[x]` in tasks.md as it completes
 - Run tests after each phase checkpoint
 
-**Output**: Code + tests
+**Output**: plan.md + tasks.md + code + tests
 
-### 4. Validate (Tester)
+### 3. Validate (Tester) `[swarm]`
 
 [Gaze](/docs/getting-started/tester/) runs quality analysis on the implemented code.
 
@@ -57,7 +51,7 @@ The Developer implements the feature following the task plan.
 
 **Output**: Quality report (contract coverage, CRAP scores, over-specification)
 
-### 5. Review (Reviewer Council)
+### 4. Review (Reviewer Council) `[swarm]`
 
 [The Divisor](/docs/team/the-divisor/) reviews the code through five specialized personas.
 
@@ -73,26 +67,40 @@ If the council returns REQUEST CHANGES, the developer addresses findings and re-
 
 **Output**: Review verdict (APPROVE or REQUEST CHANGES)
 
-### 6. Accept (Product Owner)
+After the swarm completes review, the workflow pauses and returns control to the human.
+
+### 5. Accept (Product Owner) `[human]`
 
 The Product Owner evaluates the completed increment against acceptance criteria.
 
 - Reviews the Gaze quality report
+- Reviews the Divisor review verdict
 - Compares results against the backlog item's acceptance criteria
 - Makes a decision: accept, reject, or conditional
 - If rejected: a new backlog item is created with the rejection rationale
 
 **Output**: Acceptance decision
 
-### 7. Measure (Manager)
+### 6. Reflect (Manager) `[swarm]`
 
-[Mx F](/docs/getting-started/product-manager/) captures a metrics snapshot and identifies improvement opportunities.
+[Mx F](/docs/getting-started/product-manager/) runs a retrospective analysis with empirical data from all heroes.
 
-- Collects velocity, quality trends, review efficiency, and CI health
-- Updates the team dashboard
-- Identifies patterns for the next retrospective
+- Collects a metrics snapshot: velocity, quality trends, review efficiency, and CI health
+- Consumes Gaze's quality report and the Divisor's review verdict
+- Runs cross-hero learning analysis to detect recurring patterns across workflows
+- Produces learning feedback with actionable recommendations (e.g., convention pack updates for repeated review findings)
+- Updates the team dashboard and identifies improvements for the next retrospective
 
-**Output**: Metrics snapshot
+**Output**: Metrics snapshot + learning feedback + retrospective summary
+
+### Swarm Delegation
+
+The workflow is designed for **autonomous swarm delegation**. After the human completes the define stage (specify + clarify), the swarm runs implementation through review without human intervention. The workflow pauses automatically before the accept stage, returning control to the human for an acceptance decision. After acceptance, the swarm runs the final reflect stage autonomously.
+
+This means a complete feature workflow requires only **two human decision points**:
+
+1. **After define**: Hand off to the swarm
+2. **At accept**: Review the increment and accept or reject
 
 ## Bug Fix (Tactical)
 

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -92,6 +92,10 @@ Swarm analyzes the task, decomposes it into subtasks, reserves files for each wo
 
 When a `tasks.md` file exists from the Speckit pipeline, Swarm uses it as the authoritative task decomposition instead of generating its own. It maps each phase to a Swarm epic and respects the `[P]` parallel markers and phase dependencies.
 
+### Swarm Delegation
+
+The hero lifecycle supports **autonomous swarm delegation**. After the Product Owner completes the define stage (specify + clarify), the swarm takes over and runs the implement, validate, and review stages without human intervention. The workflow pauses automatically before the accept stage, returning control to the Product Owner. After acceptance, the swarm runs the final reflect stage (Mx F) autonomously. This means the developer's work -- planning, implementation, and quality validation -- runs as part of the swarm's autonomous stages.
+
 ### File Reservations
 
 Before editing any file under Swarm coordination, always reserve it first:

--- a/content/docs/getting-started/product-manager.md
+++ b/content/docs/getting-started/product-manager.md
@@ -113,7 +113,7 @@ When a technical question arises, Mx F redirects: "That's a question for Cobalt-
 
 ## Integration with Other Heroes
 
-Mx F is stage 6 (measure) in the [hero lifecycle](/docs/getting-started/common-workflows/#new-feature-end-to-end) -- the final stage that captures a metrics snapshot after each completed workflow.
+Mx F is stage 6 (reflect) in the [hero lifecycle](/docs/getting-started/common-workflows/#new-feature-end-to-end) -- the final stage that runs a retrospective analysis with empirical data from all heroes after each completed workflow. This stage runs autonomously as part of the swarm delegation workflow.
 
 ### Mx F and Muti-Mind
 
@@ -123,16 +123,18 @@ Backlog velocity data informs priority decisions. When Mx F observes that veloci
 
 Quality metrics from Gaze feed directly into Mx F's dashboards and coaching observations. Rising CRAP scores or declining contract coverage become coaching discussion topics in retrospectives.
 
-### The Measure Stage
+### The Reflect Stage
 
-After a feature is accepted (stage 5), Mx F:
+After a feature is accepted (stage 5), Mx F runs the reflect stage autonomously:
 
 1. Collects a metrics snapshot capturing velocity, quality, review efficiency, and CI health
-2. Updates the dashboard with the latest data
-3. Identifies improvement opportunities for the next retrospective
+2. Consumes Gaze's quality report and the Divisor's review verdict as empirical data
+3. Runs cross-hero learning analysis to detect recurring patterns across completed workflows
+4. Produces learning feedback with actionable recommendations
+5. Updates the dashboard and identifies improvements for the next retrospective
 
 ## Next Steps
 
-- Read [Common Workflows](/docs/getting-started/common-workflows/) to see how measurement fits the full lifecycle
+- Read [Common Workflows](/docs/getting-started/common-workflows/) to see how the reflect stage fits the full lifecycle
 - Explore the [Mx F](/docs/team/mx-f/) team page for the complete persona details
 - Try `mxf dashboard` to see the current state of your project metrics

--- a/content/docs/getting-started/product-owner.md
+++ b/content/docs/getting-started/product-owner.md
@@ -41,7 +41,7 @@ The composite score (0-100) maps to priority levels: P1 (highest urgency) throug
 
 When a feature is complete and validated by Gaze, the PO makes a structured acceptance decision:
 
-- **Accept**: The increment meets all acceptance criteria. Work proceeds to the measure stage.
+- **Accept**: The increment meets all acceptance criteria. Work proceeds to the reflect stage.
 - **Reject**: The increment fails one or more criteria. A new backlog item is created with the rejection rationale.
 - **Conditional**: Partial acceptance with specific conditions that must be met.
 
@@ -72,7 +72,7 @@ Then the response includes their name, email, and preferences.
 
 ### Stage 5: Accept
 
-After implementation (stage 2), validation (stage 3), and review (stage 4), the increment returns to you for acceptance:
+After implementation (stage 2), validation (stage 3), and review (stage 4) -- all run autonomously by the swarm -- the workflow pauses and the increment returns to you for acceptance:
 
 1. Review the **Gaze quality report** -- check contract coverage, CRAP scores, and over-specification
 2. Review the **Divisor review verdict** -- check that all 5 personas approved (or understand why they didn't)

--- a/content/docs/getting-started/tester.md
+++ b/content/docs/getting-started/tester.md
@@ -91,7 +91,7 @@ Gaze is stage 3 (validate) in the [hero lifecycle](/docs/getting-started/common-
 1. **Gaze produces** a quality report with contract coverage, CRAP scores, and over-specification findings
 2. **The Divisor consumes** the report during code review -- the Testing persona uses it as evidence for coverage assessment
 3. **Muti-Mind consumes** the report during acceptance -- the PO compares quality metrics against the backlog item's acceptance criteria
-4. **Mx F consumes** the report for metrics -- quality trends feed into sprint health dashboards and coaching observations
+4. **Mx F consumes** the report during the reflect stage -- quality trends feed into the retrospective analysis, sprint health dashboards, and coaching observations
 
 ## Running the Review Council
 

--- a/content/docs/team/mx-f.md
+++ b/content/docs/team/mx-f.md
@@ -28,7 +28,7 @@ Mx F is responsible for identifying and aggressively removing internal and exter
 
 ### Process Stewardship
 
-Mx F owns continuous process improvement. They facilitate the swarm's regular retrospectives and leverage data — velocity, defect rates, cycle time, The Divisor's review feedback — to help the team define, implement, and measure iterative process changes.
+Mx F owns continuous process improvement. They facilitate the swarm's regular retrospectives and leverage data — velocity, defect rates, cycle time, The Divisor's review feedback — to help the team define, implement, and reflect on iterative process changes. Mx F runs the final "reflect" stage of the hero lifecycle, consuming empirical data from Gaze's quality reports and the Divisor's review verdicts to produce learning feedback and a retrospective summary.
 
 ### Stakeholder Liaison
 


### PR DESCRIPTION
## Summary

- Align website documentation with [unbound-force/unbound-force#49](https://github.com/unbound-force/unbound-force/pull/49) (swarm delegation workflow with execution modes and reflect stage)
- Rename Measure stage to Reflect across all pages that reference the hero lifecycle
- Document the swarm delegation pattern: autonomous execution from implementation through review, pausing for human acceptance

## Changes (7 files)

| File | Changes |
|------|---------|
| common-workflows.md | Renamed stage 7 Measure to stage 6 Reflect with enriched description. Added [human]/[swarm] execution mode tags to all stages. Consolidated Specify-and-Plan + Implement into single Implement stage. Added Swarm Delegation section explaining autonomous handoff and two human decision points. |
| product-manager.md | stage 6 (measure) to stage 6 (reflect). The Measure Stage to The Reflect Stage with expanded description (artifact consumption, learning analysis, recommendations). |
| product-owner.md | measure stage to reflect stage. Added note about swarm running autonomously before accept. |
| developer.md | Added Swarm Delegation subsection under Working with Swarm. |
| tester.md | Updated Mx F report consumption from for metrics to during the reflect stage. |
| mx-f.md | measure iterative process changes to reflect on iterative process changes. Added reflect stage ownership sentence. |
| getting-started/_index.md | process improvement to acceptance, and reflection with swarm delegation context. |

## Verification

- npm run build succeeds with zero errors
- No remaining measure stage references in any content file
- All internal links preserved (no broken anchors)