### PR TITLE
fix: rename CLI binary references from unbound to uf/unbound-force

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,7 @@ GitHub Pages deployment via `.github/workflows/deploy-gh-pages.yml`:
 - N/A (static site, Markdown files) (003-blog-why-gaze)
 - Markdown (Hugo content files) + Hugo (via @thulite), Doks theme (005-getting-started-guides)
 - N/A (static Markdown files) (005-getting-started-guides)
+- Hugo (Go-based SSG) via `@thulite` npm packages; Node.js >= 20.11.0; Go >= 1.23 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3` (006-binary-rename)
 
 ## Recent Changes
 - 001-site-scaffold: Added Hugo (via npm/thulite) + Go 1.23 (module resolution) + Node.js >= 20.11.0 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1`

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -190,14 +190,16 @@ The one-time setup for a new developer or a new project.
 
 ### 1. Install the CLI
 
+Install `uf` (short for `unbound-force`):
+
 ```bash
-brew install unbound-force/tap/unbound
+brew install unbound-force/tap/unbound-force
 ```
 
 ### 2. Run Setup
 
 ```bash
-unbound setup
+uf setup
 ```
 
 This installs everything in one command:
@@ -208,14 +210,14 @@ This installs everything in one command:
 - Installs the Swarm plugin (via npm)
 - Configures `opencode.json` with the Swarm plugin
 - Initializes `.hive/` for work tracking
-- Runs `unbound init` to scaffold project files
+- Runs `uf init` to scaffold project files
 
 Use `--dry-run` to preview what would be installed without making changes.
 
 ### 3. Verify
 
 ```bash
-unbound doctor
+uf doctor
 ```
 
 Doctor checks 7 areas and shows pass/warn/fail for each with install hints. Fix any failures by copying the suggested command from the output.

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -10,14 +10,14 @@ toc: true
 
 ## Prerequisites
 
-Everything starts with one command. Install the `unbound` CLI, then run setup to install the full tool chain:
+Everything starts with one command. Install the `uf` CLI (short for `unbound-force`), then run setup to install the full tool chain:
 
 ```bash
-brew install unbound-force/tap/unbound
-unbound setup
+brew install unbound-force/tap/unbound-force
+uf setup
 ```
 
-`unbound setup` detects your existing version managers (goenv, nvm, pyenv, Homebrew) and installs through them:
+`uf setup` detects your existing version managers (goenv, nvm, pyenv, Homebrew) and installs through them:
 
 - **OpenCode** -- the AI coding environment where you work
 - **Gaze** -- quality analysis for your Go code
@@ -27,7 +27,7 @@ unbound setup
 After setup, verify everything is working:
 
 ```bash
-unbound doctor
+uf doctor
 ```
 
 Doctor checks 7 areas: your detected environment (version managers), core tools, Swarm plugin health, scaffolded files, hero availability, MCP server config, and agent/skill integrity. Every failed check includes a copy-pasteable install command to fix it.
@@ -36,7 +36,7 @@ Doctor checks 7 areas: your detected environment (version managers), core tools,
 
 A typical development session follows this progression:
 
-1. **Check your environment**: Run `unbound doctor` to verify all tools are healthy
+1. **Check your environment**: Run `uf doctor` to verify all tools are healthy
 2. **Open OpenCode**: Start your AI coding environment
 3. **Check for work**: Run `hive_ready()` to see what tasks are available
 4. **Work**: Use `/swarm "task"` for parallel task execution, or code directly with Cobalt-Crush
@@ -135,7 +135,7 @@ Cobalt-Crush loads coding conventions from `.opencode/unbound/packs/`. These are
 - `[SHOULD]` -- Strong recommendations
 - `[MAY]` -- Optional improvements
 
-Packs come in pairs: a tool-owned canonical pack (e.g., `go.md`) and a user-owned customization file (e.g., `go-custom.md`). The canonical packs are updated by `unbound init`; your customizations are preserved.
+Packs come in pairs: a tool-owned canonical pack (e.g., `go.md`) and a user-owned customization file (e.g., `go-custom.md`). The canonical packs are updated by `uf init`; your customizations are preserved.
 
 ### Feedback Loops
 
@@ -160,4 +160,4 @@ The plane is not landed until `git push` succeeds. This ensures your work items,
 
 - Read the [Common Workflows](/docs/getting-started/common-workflows/) page to understand how your work flows through the full hero lifecycle
 - Explore the [Cobalt-Crush](/docs/team/cobalt-crush/) team page for the full persona details
-- Run `unbound doctor` to verify your environment, then try `/swarm "your first task"`
+- Run `uf doctor` to verify your environment, then try `/swarm "your first task"`

--- a/content/docs/getting-started/product-manager.md
+++ b/content/docs/getting-started/product-manager.md
@@ -28,10 +28,10 @@ The `mxf` command-line tool provides 7 subcommands for sprint management:
 | `mxf standup`    | Facilitate daily standups            |
 | `mxf retro`      | Facilitate retrospectives            |
 
-Install via Homebrew (included with the `unbound` package):
+Install via Homebrew (included with the `unbound-force` package, the `uf` CLI):
 
 ```bash
-brew install unbound-force/tap/unbound
+brew install unbound-force/tap/unbound-force
 ```
 
 ## Reading the Dashboard

--- a/specs/006-binary-rename/checklists/requirements.md
+++ b/specs/006-binary-rename/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Binary Rename -- Website Updates
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed on first validation iteration.
+- Scope is well-defined: 3 content files, ~12 CLI reference locations, no config/layout/SCSS changes needed.
+- No [NEEDS CLARIFICATION] markers were required -- the feature description and orchestration plan provide sufficient context.

--- a/specs/006-binary-rename/plan.md
+++ b/specs/006-binary-rename/plan.md
@@ -1,0 +1,105 @@
+# Implementation Plan: Binary Rename -- Website Updates
+
+**Branch**: `006-binary-rename` | **Date**: 2026-03-22 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/006-binary-rename/spec.md`
+
+## Summary
+
+Rename all CLI binary references across the website from `unbound` to `unbound-force` (canonical) / `uf` (preferred short alias). This addresses the naming collision with the NLnet Labs Unbound DNS resolver. The change is strictly content-level: 3 Markdown files contain ~14 CLI reference locations that need updating. No layout, config, SCSS, or structural changes are required.
+
+## Technical Context
+
+**Language/Version**: Hugo (Go-based SSG) via `@thulite` npm packages; Node.js >= 20.11.0; Go >= 1.23
+**Primary Dependencies**: `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`
+**Storage**: N/A (static Markdown files)
+**Testing**: Manual -- `npm run build` must succeed; visual verification via `npm run dev`
+**Target Platform**: GitHub Pages (static HTML)
+**Project Type**: Static documentation site (Hugo + Doks theme)
+**Performance Goals**: N/A (content-only change, no performance implications)
+**Constraints**: Must not break the build; must not alter non-CLI references to "Unbound Force" organization name
+**Scale/Scope**: 3 files, ~14 individual text replacements
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### I. Content Accuracy -- PASS
+
+The entire purpose of this feature is to improve content accuracy. The current site references the `unbound` CLI binary, which will be renamed upstream (Spec 013 in the meta repo). Updating the website to reflect the actual binary name (`unbound-force` / `uf`) directly serves this principle. After implementation, every CLI command on the site will match the actual installed binary.
+
+### II. Minimal Footprint -- PASS
+
+This change modifies only Markdown content. No custom HTML, CSS, JavaScript, or template overrides are introduced. No new dependencies are added. The implementation is the simplest possible approach: find the old CLI references and replace them with the new ones, plus a brief explanatory note about the alias on each page.
+
+### III. Visitor Clarity -- PASS
+
+The rename improves visitor clarity by eliminating the naming collision with the NLnet Labs Unbound DNS resolver. Developers who have the DNS resolver installed will no longer be confused by commands that could invoke the wrong binary. The addition of a brief note explaining that `uf` is a short alias for `unbound-force` ensures visitors understand both names immediately.
+
+**Gate result: ALL PASS -- proceeding to Phase 0.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-binary-rename/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+content/docs/getting-started/
+├── developer.md         # 8 CLI references to update
+├── common-workflows.md  # 4 CLI references to update
+└── product-manager.md   # 2 CLI references to update
+```
+
+**Structure Decision**: No new files or directories are created. This is a pure content update to 3 existing Markdown files. No data-model.md, contracts/, or quickstart.md are needed since there are no data entities, external interfaces, or new setup procedures involved.
+
+## Change Inventory
+
+The following table maps every CLI reference that must be updated, organized by file and line number (based on current content). This serves as the authoritative change manifest for implementation.
+
+### developer.md (8 references)
+
+| Line | Current Text                                        | Replacement                                                          | FR             |
+| ---- | --------------------------------------------------- | -------------------------------------------------------------------- | -------------- |
+| 13   | ``Install the `unbound` CLI, then run setup``       | ``Install the `uf` CLI (short for `unbound-force`), then run setup`` | FR-002, FR-003 |
+| 16   | `brew install unbound-force/tap/unbound`            | `brew install unbound-force/tap/unbound-force`                       | FR-001         |
+| 17   | `unbound setup`                                     | `uf setup`                                                           | FR-002         |
+| 20   | `` `unbound setup` detects your existing``          | `` `uf setup` detects your existing``                                | FR-002         |
+| 30   | `unbound doctor`                                    | `uf doctor`                                                          | FR-002         |
+| 39   | ``Run `unbound doctor` to verify``                  | ``Run `uf doctor` to verify``                                        | FR-002         |
+| 138  | ``updated by `unbound init` ``                      | ``updated by `uf init` ``                                            | FR-002         |
+| 163  | ``Run `unbound doctor` to verify your environment`` | ``Run `uf doctor` to verify your environment``                       | FR-002         |
+
+### common-workflows.md (4 references)
+
+| Line | Current Text                             | Replacement                                    | FR     |
+| ---- | ---------------------------------------- | ---------------------------------------------- | ------ |
+| 194  | `brew install unbound-force/tap/unbound` | `brew install unbound-force/tap/unbound-force` | FR-001 |
+| 200  | `unbound setup`                          | `uf setup`                                     | FR-002 |
+| 211  | ``Runs `unbound init` to scaffold``      | ``Runs `uf init` to scaffold``                 | FR-002 |
+| 218  | `unbound doctor`                         | `uf doctor`                                    | FR-002 |
+
+Additionally, the first CLI reference in the Environment Setup section (around line 191-194) should include a brief note that `uf` is the short alias for `unbound-force` (FR-003).
+
+### product-manager.md (2 references)
+
+| Line | Current Text                             | Replacement                                                  | FR             |
+| ---- | ---------------------------------------- | ------------------------------------------------------------ | -------------- |
+| 31   | ``included with the `unbound` package``  | ``included with the `unbound-force` package (the `uf` CLI)`` | FR-002, FR-003 |
+| 34   | `brew install unbound-force/tap/unbound` | `brew install unbound-force/tap/unbound-force`               | FR-001         |
+
+## Verification Strategy
+
+1. **Build check**: Run `npm run build` after all edits. Must complete with zero errors.
+2. **Content grep**: Search the built `public/` output for any remaining `unbound` CLI patterns (excluding org name references) to verify SC-001.
+3. **Visual check**: Run `npm run dev` and manually verify each of the 3 affected pages renders correctly with the updated commands.
+4. **Dark mode check**: Verify all 3 pages in dark mode to confirm inline code formatting renders correctly.

--- a/specs/006-binary-rename/research.md
+++ b/specs/006-binary-rename/research.md
@@ -1,0 +1,76 @@
+# Research: Binary Rename -- Website Updates
+
+**Branch**: `006-binary-rename` | **Date**: 2026-03-22
+
+## Research Summary
+
+No NEEDS CLARIFICATION items existed in the Technical Context. This research documents the key decisions, their rationale, and alternatives considered for the content update approach.
+
+## Decision 1: Primary CLI Name in Documentation
+
+**Decision**: Use `uf` as the primary command name in all CLI examples and inline references.
+
+**Rationale**: The orchestration plan (dewey-orchestration-plan.md, Phase 0.5) establishes `uf` as the short alias and `unbound-force` as the canonical full name. For documentation, brevity matters -- `uf setup` is easier to read, type, and remember than `unbound-force setup`. The first mention on each page explains the relationship between the two names.
+
+**Alternatives considered**:
+
+- Use `unbound-force` everywhere: Rejected because it's verbose for repeated CLI examples and code blocks. Makes command lines harder to scan.
+- Use both interchangeably: Rejected because inconsistency creates confusion. A single canonical documentation form is clearer.
+
+## Decision 2: Alias Explanation Placement
+
+**Decision**: Include a brief inline explanation of the `uf` alias at the first CLI reference on each page (FR-003).
+
+**Rationale**: Readers may land on any page directly (deep links, search results). Each page must be self-contained enough that a reader encountering `uf` for the first time understands it's the Unbound Force CLI. A brief parenthetical or inline note on first mention achieves this without cluttering subsequent references.
+
+**Alternatives considered**:
+
+- Explain only on the developer.md page: Rejected because common-workflows.md and product-manager.md can be entry points too.
+- Add a dedicated "CLI naming" section: Rejected as over-engineering for a simple alias note. Violates Minimal Footprint principle.
+- Add a glossary page: Rejected as unnecessary infrastructure for a single term.
+
+## Decision 3: Homebrew Formula Name
+
+**Decision**: Use `brew install unbound-force/tap/unbound-force` as the documented install command.
+
+**Rationale**: The orchestration plan specifies the formula will be renamed from `unbound` to `unbound-force` in the Homebrew tap. The tap namespace remains `unbound-force/tap`. This is the full, unambiguous install command that will work after the upstream rename is complete.
+
+**Alternatives considered**:
+
+- `brew install unbound-force/tap/uf`: Rejected because Homebrew formulae conventionally use the full binary name, not aliases. The `uf` symlink is created by the formula's post-install hook.
+
+## Decision 4: Scope Boundary -- Organization Name References
+
+**Decision**: Only update CLI binary/command references. Organization name references ("Unbound Force" in prose, GitHub URLs like `github.com/unbound-force/`) remain unchanged.
+
+**Rationale**: The organization name has not changed. The rename only affects the CLI binary. Changing prose references would be incorrect and would violate Content Accuracy. The formatting convention (backticks for CLI, plain text for org name) provides sufficient visual distinction.
+
+**Alternatives considered**:
+
+- None -- this boundary is unambiguous.
+
+## Decision 5: No New Files or Structural Changes
+
+**Decision**: This feature requires only content edits to 3 existing Markdown files. No data-model.md, contracts/, or quickstart.md artifacts are needed.
+
+**Rationale**: There are no data entities (static site, content-only change), no external interfaces (no APIs, CLIs, or protocols exposed by this change), and no new setup procedures. Creating empty placeholder artifacts would violate the Zero-Waste Mandate from AGENTS.md.
+
+**Alternatives considered**:
+
+- None -- the scope is strictly content updates.
+
+## Dependency Analysis
+
+| Dependency                            | Status                        | Impact                                                                             |
+| ------------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------- |
+| Spec 013 (binary rename in meta repo) | Must be merged upstream first | CLI commands documented on the site must actually work when copy-pasted            |
+| Homebrew tap formula update           | Must be published first       | `brew install unbound-force/tap/unbound-force` must resolve to the correct formula |
+| Dewey orchestration Phase 0.5.4       | This spec IS Phase 0.5.4      | This work item corresponds directly to the website portion of the binary rename    |
+
+## Risk Assessment
+
+| Risk                                                | Likelihood                               | Impact                                | Mitigation                                                                                     |
+| --------------------------------------------------- | ---------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Upstream rename not yet merged when website deploys | Low (deployment is gated on main branch) | High (documented commands would fail) | Website PR should not merge until Spec 013 is confirmed complete                               |
+| Missed CLI reference in content                     | Low (comprehensive grep performed)       | Medium (inconsistent user experience) | Post-implementation grep of `public/` build output for residual `unbound` CLI patterns         |
+| Organization name accidentally changed              | Low (clear formatting convention)        | Medium (incorrect content)            | FR-005 explicitly protects org name references; review focuses on backtick-formatted text only |

--- a/specs/006-binary-rename/spec.md
+++ b/specs/006-binary-rename/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Binary Rename -- Website Updates
+
+**Feature Branch**: `006-binary-rename`  
+**Created**: 2026-03-22  
+**Status**: Implemented  
+**Input**: User description: "Rename unbound CLI binary to unbound-force / uf (avoids collision with NLnet Labs DNS resolver)"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Developer Reads Accurate CLI Commands (Priority: P1)
+
+A developer visiting the getting-started guide needs to see the correct CLI binary name so they can install and use the Unbound Force toolchain without confusion. Currently, the site references the `unbound` binary name, which collides with the NLnet Labs Unbound DNS resolver available via `brew install unbound`. After the upstream binary rename (Spec 013 in the meta repo), the website must reflect the new `unbound-force` binary name and its `uf` short alias so developers follow working instructions.
+
+**Why this priority**: If the documented CLI commands are wrong, no developer can successfully set up their environment. This is the single highest-impact change -- incorrect install and setup commands render the entire getting-started experience broken.
+
+**Independent Test**: Can be fully tested by navigating to the Developer Environment Setup page, following every CLI command listed, and confirming each one executes correctly against the renamed binary. Delivers immediate value by unblocking new developers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer visits the Developer Environment Setup page, **When** they read the Homebrew install command, **Then** the command reads `brew install unbound-force/tap/unbound-force` (not `brew install unbound-force/tap/unbound`).
+2. **Given** a developer follows the setup instructions, **When** they encounter CLI subcommands, **Then** all references use `uf` as the primary command name (e.g., `uf setup`, `uf doctor`, `uf init`).
+3. **Given** a developer reads the page for the first time, **When** the `uf` alias is introduced, **Then** the page explains that `uf` is a short alias for `unbound-force` so the reader understands both names.
+4. **Given** a developer has the NLnet Labs Unbound DNS resolver installed, **When** they follow the website instructions, **Then** no command conflicts with the DNS resolver binary.
+
+---
+
+### User Story 2 - Developer Follows Accurate Workflow Documentation (Priority: P2)
+
+A developer reading the Common Workflows page needs the environment setup workflow section to reflect the renamed binary. This page documents the step-by-step flow for setting up a new project, including Homebrew installation, `uf setup`, and `uf doctor` commands.
+
+**Why this priority**: The common workflows page is the second most-visited page for environment setup after the developer guide. Incorrect commands here create a confusing experience where one page contradicts another.
+
+**Independent Test**: Can be fully tested by reading the Environment Setup section of the Common Workflows page and confirming every CLI command matches the renamed binary. No other page content is affected.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the Environment Setup workflow, **When** they see Homebrew install commands, **Then** the command uses `brew install unbound-force/tap/unbound-force`.
+2. **Given** a developer reads the step-by-step workflow, **When** CLI subcommands are listed, **Then** all references use `uf` (e.g., `uf setup`, `uf doctor`, `uf init`).
+
+---
+
+### User Story 3 - Product Manager Reads Correct Install Instructions (Priority: P3)
+
+A product manager reading the Product Manager guide needs to see accurate Homebrew install instructions for the CLI package. The current page references `brew install unbound-force/tap/unbound` and describes the package as `unbound`. These must be updated to reflect the renamed binary.
+
+**Why this priority**: Product managers are a secondary audience for CLI installation. The change is small (2 references) but must be consistent with the rest of the site to avoid confusion.
+
+**Independent Test**: Can be fully tested by reading the Product Manager page and confirming the Homebrew install command and package name reference are correct.
+
+**Acceptance Scenarios**:
+
+1. **Given** a product manager reads the installation section, **When** they see the Homebrew install command, **Then** it reads `brew install unbound-force/tap/unbound-force`.
+2. **Given** a product manager reads the installation context, **When** the CLI package is mentioned by name, **Then** it is referred to as `unbound-force` (with `uf` alias noted), not `unbound`.
+
+---
+
+### Edge Cases
+
+- What happens if a page references both the organization name "Unbound Force" and the CLI binary `uf` / `unbound-force` in close proximity? The content must clearly distinguish between the organization name and the CLI tool name through formatting (e.g., inline code backticks for the CLI binary, plain text for the org name).
+- What happens if a new getting-started page is added in the future that references CLI commands? The contributing guidelines and content conventions should make it clear that the CLI binary is `uf` / `unbound-force`, never `unbound`.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: All Homebrew install commands across the website MUST use `brew install unbound-force/tap/unbound-force` instead of `brew install unbound-force/tap/unbound`.
+- **FR-002**: All CLI subcommand references MUST use `uf` as the primary command name (e.g., `uf setup`, `uf doctor`, `uf init`) instead of `unbound setup`, `unbound doctor`, `unbound init`.
+- **FR-003**: The first mention of the `uf` command on each page MUST include a parenthetical or inline note explaining that `uf` is a short alias for `unbound-force`, so readers encountering either name understand they are the same tool.
+- **FR-004**: All inline code references to the CLI binary MUST use backtick formatting (e.g., `uf`, `unbound-force`) to visually distinguish the tool name from the "Unbound Force" organization name in prose.
+- **FR-005**: References to the organization name "Unbound Force" (not the CLI binary) MUST remain unchanged -- only CLI binary/command references are updated.
+- **FR-006**: The website MUST build successfully (`npm run build`) with zero errors after all content updates are applied.
+- **FR-007**: No page on the built website MUST contain the bare `unbound` command as a CLI reference (only `unbound-force` or `uf` are acceptable for CLI usage).
+
+### Assumptions
+
+- The upstream binary rename (Spec 013 in the `unbound-force/unbound-force` meta repo) is completed and merged before this website work is deployed, so the documented commands actually work.
+- The Homebrew tap formula has been updated to `unbound-force` with a `uf` symlink before the website changes go live.
+- The `uf` alias is the preferred short form for documentation. `unbound-force` is the canonical full name used in Homebrew and formal references. Day-to-day documentation prefers `uf` for brevity.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Zero instances of the bare `unbound` CLI command remain in any published website content (verified by searching the built site output for `unbound` CLI patterns while excluding organization name references).
+- **SC-002**: 100% of CLI command examples across all getting-started pages use the `uf` command name and produce correct output when copy-pasted into a terminal with the renamed binary installed.
+- **SC-003**: The site builds and deploys without errors after all updates are applied.
+- **SC-004**: A new developer following the getting-started guide from scratch can install and set up the toolchain in under 10 minutes without encountering any incorrect or ambiguous CLI command references.
+- **SC-005**: No naming confusion exists between the Unbound Force CLI tool (`uf` / `unbound-force`) and the NLnet Labs Unbound DNS resolver in any website content.

--- a/specs/006-binary-rename/tasks.md
+++ b/specs/006-binary-rename/tasks.md
@@ -1,0 +1,145 @@
+# Tasks: Binary Rename -- Website Updates
+
+**Input**: Design documents from `/specs/006-binary-rename/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md
+
+**Tests**: No test tasks included -- the spec does not request automated tests. Validation is manual: `npm run build`, visual verification, and content grep.
+
+**Organization**: Tasks are grouped by user story. All three stories operate on separate files and can run in parallel.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: User Story 1 - Developer Reads Accurate CLI Commands (Priority: P1) MVP
+
+**Goal**: Update all 8 CLI binary references in the Developer Environment Setup page so every install command and CLI subcommand uses the correct renamed binary (`uf` / `unbound-force`).
+
+**Independent Test**: Navigate to the Developer Environment Setup page, read every CLI command, and confirm each one matches the renamed binary. The first CLI mention explains that `uf` is short for `unbound-force`.
+
+### Implementation for User Story 1
+
+- [x] T001 [P] [US1] Update the introductory CLI reference from `unbound` to `uf` with alias explanation (FR-002, FR-003) in content/docs/getting-started/developer.md line 13: change ``Install the `unbound` CLI, then run setup`` to ``Install the `uf` CLI (short for `unbound-force`), then run setup``
+- [x] T002 [P] [US1] Update the Homebrew install command (FR-001) in content/docs/getting-started/developer.md line 16: change `brew install unbound-force/tap/unbound` to `brew install unbound-force/tap/unbound-force`
+- [x] T003 [P] [US1] Update the setup command in the code block (FR-002) in content/docs/getting-started/developer.md line 17: change `unbound setup` to `uf setup`
+- [x] T004 [P] [US1] Update the inline setup reference (FR-002) in content/docs/getting-started/developer.md line 20: change `` `unbound setup` `` to `` `uf setup` ``
+- [x] T005 [P] [US1] Update the doctor command in the code block (FR-002) in content/docs/getting-started/developer.md line 30: change `unbound doctor` to `uf doctor`
+- [x] T006 [P] [US1] Update the inline doctor reference in the daily workflow section (FR-002) in content/docs/getting-started/developer.md line 39: change `` `unbound doctor` `` to `` `uf doctor` ``
+- [x] T007 [P] [US1] Update the init reference in the convention packs section (FR-002) in content/docs/getting-started/developer.md line 138: change `` `unbound init` `` to `` `uf init` ``
+- [x] T008 [P] [US1] Update the doctor reference in the next steps section (FR-002) in content/docs/getting-started/developer.md line 163: change `` `unbound doctor` `` to `` `uf doctor` ``
+
+**Checkpoint**: Developer Environment Setup page shows correct CLI commands. All 8 references updated. Page builds without errors.
+
+---
+
+## Phase 2: User Story 2 - Developer Follows Accurate Workflow Documentation (Priority: P2)
+
+**Goal**: Update all 4 CLI binary references in the Common Workflows page (Environment Setup section) and add an alias explanation at the first CLI mention.
+
+**Independent Test**: Read the Environment Setup section of the Common Workflows page and confirm every CLI command matches the renamed binary. The section heading area explains that `uf` is short for `unbound-force`.
+
+### Implementation for User Story 2
+
+- [x] T009 [P] [US2] Add alias explanation and update the Homebrew install command (FR-001, FR-003) in content/docs/getting-started/common-workflows.md lines 191-194: add a brief note that `uf` (short for `unbound-force`) is the CLI tool, and change `brew install unbound-force/tap/unbound` to `brew install unbound-force/tap/unbound-force`
+- [x] T010 [P] [US2] Update the setup command in the code block (FR-002) in content/docs/getting-started/common-workflows.md line 200: change `unbound setup` to `uf setup`
+- [x] T011 [P] [US2] Update the inline init reference (FR-002) in content/docs/getting-started/common-workflows.md line 211: change `` `unbound init` `` to `` `uf init` ``
+- [x] T012 [P] [US2] Update the doctor command in the code block (FR-002) in content/docs/getting-started/common-workflows.md line 218: change `unbound doctor` to `uf doctor`
+
+**Checkpoint**: Common Workflows Environment Setup section shows correct CLI commands. All 4 references updated plus alias note added. Page builds without errors.
+
+---
+
+## Phase 3: User Story 3 - Product Manager Reads Correct Install Instructions (Priority: P3)
+
+**Goal**: Update both CLI references in the Product Manager guide so the Homebrew install command and package name use the renamed binary.
+
+**Independent Test**: Read the Product Manager page installation section and confirm the Homebrew command and package name reference are correct.
+
+### Implementation for User Story 3
+
+- [x] T013 [P] [US3] Update the package name reference with alias explanation (FR-002, FR-003) in content/docs/getting-started/product-manager.md line 31: change ``included with the `unbound` package`` to ``included with the `unbound-force` package (the `uf` CLI)``
+- [x] T014 [P] [US3] Update the Homebrew install command (FR-001) in content/docs/getting-started/product-manager.md line 34: change `brew install unbound-force/tap/unbound` to `brew install unbound-force/tap/unbound-force`
+
+**Checkpoint**: Product Manager page shows correct install command and package name. Both references updated. Page builds without errors.
+
+---
+
+## Phase 4: Verification & Cross-Cutting Concerns
+
+**Purpose**: Validate all changes across all three files, confirm no residual `unbound` CLI references remain, and verify the site builds cleanly.
+
+- [x] T015 Run `npm run build` and confirm zero build errors (FR-006, SC-003)
+- [x] T016 Search the built `public/` output for any remaining bare `unbound` CLI command references, excluding organization name references (FR-007, SC-001)
+- [x] T017 Visually verify all 3 updated pages render correctly via `npm run dev` (SC-002)
+- [x] T018 Verify all 3 updated pages render correctly in dark mode
+
+**Checkpoint**: All user stories verified. Site builds cleanly. Zero residual `unbound` CLI references. Ready for PR.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **User Stories (Phases 1-3)**: No dependencies on each other -- all operate on different files and can start immediately
+- **Verification (Phase 4)**: Depends on all three user story phases being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies -- edits only `developer.md`
+- **User Story 2 (P2)**: No dependencies -- edits only `common-workflows.md`
+- **User Story 3 (P3)**: No dependencies -- edits only `product-manager.md`
+
+### Within Each User Story
+
+- All tasks within a story are marked [P] because they edit different lines in the same file with no interdependencies
+- In practice, tasks within a single file are best applied sequentially to avoid merge conflicts, but they have no logical dependency on each other
+
+### Parallel Opportunities
+
+- All three user stories can run in parallel (different files)
+- A single implementer should work through stories sequentially (P1 then P2 then P3) for clean commits
+- With multiple implementers: each takes one story file
+
+---
+
+## Parallel Example: All User Stories
+
+```bash
+# All three stories can launch in parallel since they edit different files:
+Task: "Update CLI references in content/docs/getting-started/developer.md (US1)"
+Task: "Update CLI references in content/docs/getting-started/common-workflows.md (US2)"
+Task: "Update CLI references in content/docs/getting-started/product-manager.md (US3)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: User Story 1 (developer.md -- the most critical page)
+2. **STOP and VALIDATE**: Run `npm run build`, visually verify developer.md
+3. The most important page is now correct -- deploy if needed
+
+### Incremental Delivery
+
+1. Complete US1 (developer.md) -- MVP, highest impact
+2. Complete US2 (common-workflows.md) -- second most visited page
+3. Complete US3 (product-manager.md) -- smallest change, lowest risk
+4. Run full verification (Phase 4) -- build, grep, visual, dark mode
+5. Each story adds consistency without breaking previous stories
+
+---
+
+## Notes
+
+- All [P] tasks operate on different files or different lines -- no conflicts
+- No automated tests are needed; validation is manual build + visual + grep
+- Organization name references ("Unbound Force" in prose, GitHub URLs) MUST NOT be changed (FR-005)
+- Line numbers in task descriptions are based on current file content and may shift if tasks are applied out of order within the same file
+- Commit after completing each user story phase for clean git history


### PR DESCRIPTION
## Summary

- Renames all `unbound` CLI binary references across the website to `unbound-force` (canonical) / `uf` (short alias)
- Avoids naming collision with [NLnet Labs Unbound](https://nlnetlabs.nl/projects/unbound/) DNS resolver (`brew install unbound`)
- Corresponds to Phase 0.5.4 of the Dewey orchestration plan

## Changes

| File | References Updated | Details |
|------|-------------------|---------|
| `content/docs/getting-started/developer.md` | 8 | Homebrew install, `uf setup`, `uf doctor`, `uf init` |
| `content/docs/getting-started/common-workflows.md` | 4 + alias note | Homebrew install, `uf setup`, `uf init`, `uf doctor` |
| `content/docs/getting-started/product-manager.md` | 2 | Homebrew install, package name |
| `AGENTS.md` | 1 | Agent context update (auto-generated) |

### Naming Convention

- **`uf`** -- primary command name in documentation (brevity)
- **`unbound-force`** -- canonical full name for Homebrew and formal references
- **`brew install unbound-force/tap/unbound-force`** -- install command
- Each page explains `uf` is short for `unbound-force` on first mention

## Spec Artifacts

Full speckit pipeline artifacts included under `specs/006-binary-rename/`:
- `spec.md` -- feature specification (3 user stories, 7 FRs, 5 SCs)
- `plan.md` -- implementation plan with change inventory
- `research.md` -- 5 design decisions with rationale
- `tasks.md` -- 18 tasks, all marked complete
- `checklists/requirements.md` -- 16/16 items passing

## Verification

- `npm run build` succeeds with zero errors
- Zero residual `unbound` CLI references in built output (grep verified)
- All 3 pages verified visually in both light and dark mode
- Organization name references ("Unbound Force") unchanged per FR-005

## Review Council

- **Architect**: APPROVE
- **Guard**: APPROVE
- **Adversary**: REQUEST CHANGES (2 HIGH findings assessed as out-of-scope by all reviewers)
  - `.opencode/unbound/packs/` is a filesystem path, not a CLI command (FR-005 boundary)
  - `quick-start.md` install paradigm divergence is pre-existing, not introduced by this branch

## Deployment Gate

This PR should not merge to `main` until Spec 013 (upstream binary rename in `unbound-force/unbound-force`) and the Homebrew tap formula update are confirmed complete, so the documented commands actually work.