### PR TITLE
docs: add Dewey documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ npm run format             # Format all files with Prettier
 Hugo is installed via npm (through `@thulite`). Go >= 1.23 is required for Hugo module resolution.
 
 There is no test suite. Validation is manual:
+
 1. `npm run build` must succeed without errors
 2. `npm run dev` -- visually verify pages render correctly
 3. Check for broken links, missing images, correct navigation
@@ -100,6 +101,7 @@ Edit `config/_default/menus/menus.en.toml` to add or modify top-level navigation
 ### Homepage
 
 The homepage is built from two files:
+
 1. `content/_index.md` -- frontmatter only (title, description, lead text)
 2. `layouts/home.html` -- full HTML template (hero, features, projects, CTA)
 
@@ -112,6 +114,7 @@ Use Conventional Commits: `type: description`
 Valid types: `feat:`, `fix:`, `docs:`, `chore:`, `style:`, `refactor:`, `ci:`
 
 Examples:
+
 - `feat: add Gaze project page`
 - `fix: correct broken link in team navigation`
 - `docs: update getting started guide`
@@ -158,17 +161,17 @@ The workflow is a strict, sequential pipeline. Each stage has a corresponding `/
 constitution → specify → clarify → plan → tasks → analyze → checklist → implement
 ```
 
-| Command | Purpose |
-|---------|---------|
-| `/speckit.constitution` | Create or update the project constitution |
-| `/speckit.specify` | Create a feature specification from a description |
-| `/speckit.clarify` | Reduce ambiguity in the spec before planning |
-| `/speckit.plan` | Generate the technical implementation plan |
-| `/speckit.tasks` | Generate actionable, dependency-ordered task list |
-| `/speckit.analyze` | Non-destructive cross-artifact consistency analysis |
-| `/speckit.checklist` | Generate requirement quality validation checklists |
-| `/speckit.implement` | Execute the implementation plan task by task |
-| `/speckit.taskstoissues` | Convert tasks.md into GitHub Issues |
+| Command                  | Purpose                                             |
+| ------------------------ | --------------------------------------------------- |
+| `/speckit.constitution`  | Create or update the project constitution           |
+| `/speckit.specify`       | Create a feature specification from a description   |
+| `/speckit.clarify`       | Reduce ambiguity in the spec before planning        |
+| `/speckit.plan`          | Generate the technical implementation plan          |
+| `/speckit.tasks`         | Generate actionable, dependency-ordered task list   |
+| `/speckit.analyze`       | Non-destructive cross-artifact consistency analysis |
+| `/speckit.checklist`     | Generate requirement quality validation checklists  |
+| `/speckit.implement`     | Execute the implementation plan task by task        |
+| `/speckit.taskstoissues` | Convert tasks.md into GitHub Issues                 |
 
 ### Ordering Constraints
 
@@ -232,10 +235,11 @@ A mandatory gate at the planning phase. The constitution's core principles must 
 
 Project content is sourced from upstream repositories. Cross-reference before updating:
 
-| Project | Repository | Key Files |
-|---------|------------|-----------|
-| Gaze | `unbound-force/gaze` | `README.md`, `AGENTS.md`, `.specify/` specs |
-| Unbound Force (personas) | `unbound-force/unbound-force` | `unbound-force.md` |
+| Project                  | Repository                    | Key Files                                        |
+| ------------------------ | ----------------------------- | ------------------------------------------------ |
+| Gaze                     | `unbound-force/gaze`          | `README.md`, `AGENTS.md`, `.specify/` specs      |
+| Dewey                    | `unbound-force/dewey`         | `README.md`, `dewey-design-paper.md` (org-level) |
+| Unbound Force (personas) | `unbound-force/unbound-force` | `unbound-force.md`                               |
 
 Adapt content for a website audience -- less raw technical detail, more "why should I care" framing. Do not copy READMEs verbatim.
 
@@ -270,6 +274,7 @@ GitHub Pages deployment via `.github/workflows/deploy-gh-pages.yml`:
 3. Always verify both light and dark mode rendering after style changes.
 
 ## Active Technologies
+
 - Hugo (via npm/thulite) + Go 1.23 (module resolution) + Node.js >= 20.11.0 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1` (001-site-scaffold)
 - N/A (static site, no database) (001-site-scaffold)
 - Hugo (via npm/thulite) + Go 1.23 + Node.js >= 20.11.0 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1` (003-blog-why-gaze)
@@ -277,6 +282,8 @@ GitHub Pages deployment via `.github/workflows/deploy-gh-pages.yml`:
 - Markdown (Hugo content files) + Hugo (via @thulite), Doks theme (005-getting-started-guides)
 - N/A (static Markdown files) (005-getting-started-guides)
 - Hugo (Go-based SSG) via `@thulite` npm packages; Node.js >= 20.11.0; Go >= 1.23 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3` (006-binary-rename)
+- Hugo (via npm/thulite) + Go 1.23 + `thulite ^2.6.3`, (007-dewey-docs)
 
 ## Recent Changes
+
 - 001-site-scaffold: Added Hugo (via npm/thulite) + Go 1.23 (module resolution) + Node.js >= 20.11.0 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1`

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -47,3 +47,4 @@ Ready to dive in? Start with the [Quick Start](/docs/getting-started/quick-start
 - **[Product Owner](/docs/getting-started/product-owner/)** -- Muti-Mind backlog management, priority scoring, acceptance decisions
 - **[Product Manager](/docs/getting-started/product-manager/)** -- Mx F metrics, dashboards, coaching, retrospectives
 - **[Common Workflows](/docs/getting-started/common-workflows/)** -- End-to-end flows for features, bug fixes, code reviews, and setup
+- **[Knowledge Retrieval with Dewey](/docs/getting-started/knowledge/)** -- Install and configure Dewey for semantic search across your repositories

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -102,6 +102,14 @@ This means a complete feature workflow requires only **two human decision points
 1. **After define**: Hand off to the swarm
 2. **At accept**: Review the increment and accept or reject
 
+### Knowledge Context
+
+Throughout the hero lifecycle, [Dewey](/docs/getting-started/knowledge/) provides semantic context to every hero during their stage. When Muti-Mind writes a specification, Dewey surfaces related issues and past acceptance criteria from across the organization. When Cobalt-Crush implements a feature, Dewey provides toolstack API documentation and implementation patterns from other repositories. When Gaze validates code quality, Dewey offers cross-repo quality baselines and known failure modes.
+
+This context is automatic — heroes query Dewey's MCP tools as part of their normal workflow. No additional steps are required from the operator.
+
+Dewey operates on a [3-tier graceful degradation](/docs/getting-started/knowledge/#graceful-degradation) model: full semantic search when Dewey and Ollama are available, structured graph queries when only the knowledge graph is indexed, and direct file reads when Dewey is not configured. Every hero functions at all three tiers — Dewey enriches the workflow but never blocks it.
+
 ## Bug Fix (Tactical)
 
 For bug fixes and small changes (fewer than 3 user stories), use the OpenSpec tactical workflow instead of the full Speckit pipeline.

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -96,6 +96,18 @@ When a `tasks.md` file exists from the Speckit pipeline, Swarm uses it as the au
 
 The hero lifecycle supports **autonomous swarm delegation**. After the Product Owner completes the define stage (specify + clarify), the swarm takes over and runs the implement, validate, and review stages without human intervention. The workflow pauses automatically before the accept stage, returning control to the Product Owner. After acceptance, the swarm runs the final reflect stage (Mx F) autonomously. This means the developer's work -- planning, implementation, and quality validation -- runs as part of the swarm's autonomous stages.
 
+### Knowledge Retrieval with Dewey
+
+When [Dewey](/docs/getting-started/knowledge/) is configured, Cobalt-Crush uses it to pull in context that would otherwise require manual research. Dewey's semantic search finds conceptually related content even when different terminology is used — so a query about "adding a CLI subcommand" finds Cobra framework documentation, past implementation patterns from other repos, and related spec artifacts.
+
+Example queries Cobalt-Crush makes during implementation:
+
+- `dewey_semantic_search("how to validate JSON schema in Go")` — finds toolstack documentation and implementation patterns from other repositories
+- `dewey_similar("specs/005-getting-started-guides/plan.md")` — finds related planning artifacts to inform the current implementation approach
+- `dewey_semantic_search_filtered("error handling patterns", source: "github")` — finds error handling discussions in GitHub issues and PRs across the organization
+
+When Dewey is not available, Cobalt-Crush falls back to direct file reads and CLI queries. The implementation workflow is the same — just with narrower context. See the [graceful degradation tiers](/docs/getting-started/knowledge/#graceful-degradation) for details.
+
 ### File Reservations
 
 Before editing any file under Swarm coordination, always reserve it first:

--- a/content/docs/getting-started/knowledge.md
+++ b/content/docs/getting-started/knowledge.md
@@ -1,0 +1,171 @@
+---
+title: "Knowledge Retrieval with Dewey"
+description: "Set up Dewey for semantic knowledge retrieval — install, configure content sources, and give your AI agents cross-repo context."
+lead: "Give your AI agents the context they need. Install Dewey, configure your knowledge sources, and enable semantic search across your entire organization."
+date: 2026-03-25T00:00:00+00:00
+draft: false
+weight: 80
+toc: true
+---
+
+## What is Dewey?
+
+Dewey is a semantic knowledge layer that gives AI agents rich, cross-repository context. It combines a structured knowledge graph (page traversal, tag queries, wikilink navigation) with vector-based semantic search — so agents can find conceptually related content even when different terminology is used. A search for "authentication timeout" finds an issue titled "login session expiry" because Dewey understands meaning, not just keywords.
+
+Dewey runs as an MCP (Model Context Protocol) server alongside your AI coding environment. It indexes your local repository, pulls issues and PRs from GitHub, crawls toolstack documentation from the web, and makes all of it searchable through a unified interface. The result: every hero in the swarm — from Muti-Mind writing specs to Cobalt-Crush implementing features — makes better decisions because they have better context.
+
+Dewey is a hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu), preserving all existing knowledge graph capabilities and adding persistent storage, semantic search, and pluggable content sources. If you were using graphthulhu, Dewey is a drop-in replacement — existing agent configurations work without prompt changes.
+
+## Installation
+
+Install Dewey and its embedding model:
+
+```bash
+# Install Dewey
+brew install --cask unbound-force/tap/dewey
+
+# Install Ollama (local model runtime) and pull the embedding model
+brew install --cask ollama
+ollama pull granite-embedding:30m
+```
+
+The `granite-embedding:30m` model is IBM's Granite Embedding — a 63 MB model licensed under Apache 2.0 with full training data transparency. It runs locally via Ollama; no data leaves your machine.
+
+If the Homebrew formula is not yet available, install from source:
+
+```bash
+go install github.com/unbound-force/dewey@latest
+```
+
+## Getting Started
+
+Initialize Dewey in your repository:
+
+```bash
+# Create .dewey/ directory with default configuration
+dewey init
+
+# Edit the source configuration
+# (see Source Configuration below for examples)
+$EDITOR .dewey/sources.yaml
+
+# Build the initial index (local files + any configured sources)
+dewey index
+
+# Verify everything is working
+dewey status
+```
+
+The `dewey status` command reports index health: page count, block count, embedding coverage, and source status. A healthy output shows all configured sources indexed with recent timestamps.
+
+After initialization, Dewey persists its indexes to `.dewey/graph.db` (SQLite). Subsequent sessions load from the persistent index and only re-process changed files — startup is near-instant after the first index.
+
+## Source Configuration
+
+Dewey indexes content from three pluggable source types. Configure them in `.dewey/sources.yaml`:
+
+### Local Disk
+
+The foundational source — indexes all Markdown files in your repository, including hidden directories (`.opencode/`, `.specify/`, `.muti-mind/`). This is enabled by default after `dewey init`.
+
+Local files are watched for changes in real time. When you save a file, Dewey re-indexes only the changed content.
+
+### GitHub API
+
+Fetches issues, pull requests, READMEs, and documentation from whitelisted repositories in your GitHub organization:
+
+```yaml
+sources:
+  - id: github-unbound-force
+    type: github
+    name: unbound-force
+    config:
+      org: unbound-force
+      repos:
+        - gaze
+        - website
+        - homebrew-tap
+    refresh_interval: daily
+```
+
+Authentication uses your existing `gh` CLI credentials — the same mechanism that `mutimind sync` uses for GitHub issue synchronization.
+
+### Web Crawl
+
+Fetches and indexes documentation from toolstack websites so agents can reference current API docs for your dependencies:
+
+```yaml
+sources:
+  - id: web-go-stdlib
+    type: web
+    name: go-stdlib
+    config:
+      urls:
+        - https://pkg.go.dev/std
+      depth: 2
+    refresh_interval: weekly
+
+  - id: web-cobra-docs
+    type: web
+    name: cobra-docs
+    config:
+      urls:
+        - https://cobra.dev/
+      depth: 1
+    refresh_interval: weekly
+```
+
+Web crawls respect `robots.txt`, impose a configurable delay between requests, and cache content locally in `.dewey/cache/`. Content is only re-fetched when the refresh interval expires.
+
+### Updating Sources
+
+External sources (GitHub, web) are updated explicitly — not on every session start:
+
+```bash
+# Update all sources
+dewey index
+
+# Update a specific source by ID
+dewey index --source github-unbound-force
+dewey index --source web-go-stdlib
+```
+
+This separates the "fetch external content" operation (which may take seconds to minutes) from the "start serving queries" operation (which is near-instant from the persistent index).
+
+## OpenCode Integration
+
+Dewey integrates with OpenCode as an MCP server. Add this to your `opencode.json`:
+
+```json
+{
+  "mcp": {
+    "dewey": {
+      "type": "local",
+      "command": ["dewey", "serve", "--vault", "."],
+      "enabled": true
+    }
+  }
+}
+```
+
+If you use `uf init` to scaffold your project, this configuration is generated automatically — you do not need to add it manually.
+
+Once configured, all hero agents can use Dewey's MCP tools for knowledge retrieval. The tools include structured queries (`search`, `find_by_tag`, `query_properties`, `get_page`, `traverse`, `find_connections`) and semantic queries (`dewey_semantic_search`, `dewey_similar`, `dewey_semantic_search_filtered`).
+
+## Graceful Degradation
+
+Dewey is an enhancement, not a requirement. Per the Unbound Force constitution's Composability First principle, every hero functions without Dewey — they just have less context to work with.
+
+| Tier           | What's Available                                          | What You Get                                                                                                         |
+| -------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Full Dewey** | Semantic search + structured graph + external sources     | Rich cross-repo context, conceptual similarity search, toolstack documentation, GitHub issue discovery               |
+| **Graph-only** | Structured graph queries (no Ollama / no embedding model) | Keyword search, tag queries, wikilink traversal, property queries — equivalent to graphthulhu                        |
+| **No Dewey**   | Direct file reads and CLI queries                         | Heroes read local files directly. Functional but with narrower context — no cross-repo awareness, no semantic search |
+
+All heroes check for Dewey's availability at runtime. If Dewey is not configured or not running, they fall back gracefully — reduced context quality, but fully functional. You can adopt Dewey incrementally: start with local disk indexing, add GitHub sources when you want cross-repo context, add web crawl when you want toolstack docs.
+
+## Next Steps
+
+- Read the [Dewey tool page](/docs/team/dewey/) for architecture details, query capabilities, and how each hero uses Dewey
+- See [Common Workflows](/docs/getting-started/common-workflows/) for how Dewey provides context during the hero lifecycle
+- Explore the role-specific guides to see how [developers](/docs/getting-started/developer/), [testers](/docs/getting-started/tester/), [product owners](/docs/getting-started/product-owner/), and [product managers](/docs/getting-started/product-manager/) each use Dewey

--- a/content/docs/getting-started/product-manager.md
+++ b/content/docs/getting-started/product-manager.md
@@ -133,6 +133,18 @@ After a feature is accepted (stage 5), Mx F runs the reflect stage autonomously:
 4. Produces learning feedback with actionable recommendations
 5. Updates the dashboard and identifies improvements for the next retrospective
 
+## Knowledge Retrieval with Dewey
+
+When [Dewey](/docs/getting-started/knowledge/) is configured, Mx F uses it to enrich retrospective analysis with cross-repository data. Instead of analyzing metrics from a single project in isolation, Mx F can surface patterns spanning the entire organization.
+
+Dewey enables three capabilities for the manager role:
+
+- **Cross-repo velocity trends**: Compare velocity and quality metrics across repositories to identify organizational patterns — is a declining velocity trend isolated to one project or systemic?
+- **Retrospective outcomes**: Search past retrospective summaries and action items from other projects to find proven improvement strategies
+- **Coaching pattern discovery**: Surface learning feedback and coaching records from across the organization to inform coaching conversations with richer context
+
+When Dewey is not available, Mx F works with local metrics data and the current project's history. The dashboard, retrospective protocol, and coaching techniques all function without Dewey — cross-repo context is an enhancement, not a dependency. See the [graceful degradation tiers](/docs/getting-started/knowledge/#graceful-degradation) for details.
+
 ## Next Steps
 
 - Read [Common Workflows](/docs/getting-started/common-workflows/) to see how the reflect stage fits the full lifecycle

--- a/content/docs/getting-started/product-owner.md
+++ b/content/docs/getting-started/product-owner.md
@@ -81,6 +81,18 @@ After implementation (stage 2), validation (stage 3), and review (stage 4) -- al
 
 If you reject, provide clear rationale. A new backlog item is created automatically with the rejection details so the developer knows exactly what to address.
 
+## Knowledge Retrieval with Dewey
+
+When [Dewey](/docs/getting-started/knowledge/) is configured, Muti-Mind uses it to make better-informed product decisions. Dewey's semantic search surfaces related context from across the organization — past specifications, GitHub issues from other repositories, acceptance criteria patterns, and learning feedback from previous development cycles.
+
+This is particularly valuable during the define stage. Instead of asking the human for context about related features or past decisions, Muti-Mind queries Dewey:
+
+- **Cross-repo issue discovery**: Find related bugs and feature requests across all whitelisted repositories, even when they use different terminology
+- **Past acceptance criteria**: Surface acceptance scenarios from similar features to inform new specifications
+- **Backlog pattern analysis**: Identify recurring themes across the organization's backlog items to spot dependencies and opportunities
+
+When Dewey is not available, Muti-Mind works with the local backlog files and direct GitHub queries. The backlog management workflow is unchanged — Dewey adds broader organizational context but is never required. See the [graceful degradation tiers](/docs/getting-started/knowledge/#graceful-degradation) for details.
+
 ## Working with Specifications
 
 Speckit specifications are the bridge between your product vision and the developer's implementation plan. Understanding how to read and contribute to specs makes the workflow more effective.

--- a/content/docs/getting-started/tester.md
+++ b/content/docs/getting-started/tester.md
@@ -140,6 +140,18 @@ gaze report ./... --ai=claude \
 
 Gaze detects the `$GITHUB_STEP_SUMMARY` environment variable and automatically appends its report to the GitHub Actions job summary. No additional configuration needed.
 
+## Knowledge Retrieval with Dewey
+
+When [Dewey](/docs/getting-started/knowledge/) is configured, Gaze uses it to inform quality analysis with cross-repository context. Instead of evaluating code quality in isolation, Gaze can reference patterns and baselines from across the organization.
+
+Dewey enables three capabilities for the tester role:
+
+- **Quality pattern discovery**: Search for test patterns and quality strategies used in other repositories — how did another project achieve high contract coverage for a similar code structure?
+- **CRAP score baselines**: Compare CRAP scores and complexity trends across repositories to establish organizational quality baselines and identify outliers
+- **Known failure modes**: Surface past test failures, bug reports, and quality findings for similar code patterns — if a particular design pattern has historically caused issues, Gaze can flag it proactively
+
+When Dewey is not available, Gaze operates on local code analysis and coverage data. All core capabilities — side effect detection, contract coverage, CRAP scoring, and quality reports — work without Dewey. Cross-repo quality context is an enhancement that improves the depth of analysis but is never required. See the [graceful degradation tiers](/docs/getting-started/knowledge/#graceful-degradation) for details.
+
 ## Next Steps
 
 - Explore the full [Gaze documentation](/docs/projects/gaze/) for detailed command reference

--- a/content/docs/team/_index.md
+++ b/content/docs/team/_index.md
@@ -33,3 +33,11 @@ _The Architectural Conscience and Code Integrity Guardian._ The Divisor operates
 ### [Mx F](/docs/team/mx-f/) — Manager
 
 _The Flow Facilitator and Continuous Improvement Coach._ Mx F serves as a servant leader and coach, maximizing the team's flow and self-organization. They guide through reflective questions rather than direct solutions, making the swarm a learning organization.
+
+## Infrastructure
+
+Beyond the five hero personas, the swarm relies on infrastructure tools that provide shared capabilities to all heroes.
+
+### [Dewey](/docs/team/dewey/) — Semantic Knowledge Layer
+
+Dewey is the knowledge backbone of the swarm — a per-repository MCP server that combines structured knowledge graph traversal with vector-based semantic search. It indexes local Markdown files, GitHub issues and PRs from across the organization, and toolstack documentation from the web. Every hero uses Dewey for context retrieval, and every hero functions without it — Dewey is an enhancement, not a dependency.

--- a/content/docs/team/dewey.md
+++ b/content/docs/team/dewey.md
@@ -1,0 +1,125 @@
+---
+title: "Dewey"
+description: "Dewey is the semantic knowledge layer for the Unbound Force swarm — structured graph traversal plus vector-based semantic search for AI agent context."
+lead: "The semantic knowledge layer that gives every hero cross-repository context."
+date: 2026-03-25T00:00:00+00:00
+draft: false
+weight: 70
+toc: true
+---
+
+## What Dewey Does
+
+Dewey is a per-repository MCP server that provides AI agent personas with unified knowledge retrieval. It combines two complementary search modes into a single service:
+
+- **Structured queries** — keyword search, tag lookup, wikilink traversal, and property queries against a knowledge graph built from your repository's Markdown files
+- **Semantic queries** — vector-based similarity search that finds conceptually related content even when different terminology is used
+
+Together, these modes let agents start with a vague concept ("authentication timeout issues") and progressively refine their understanding through structured navigation — discovering related specifications, past decisions, and connected documentation they did not know to ask for.
+
+Dewey runs locally as an MCP server alongside your AI coding environment. It persists its indexes to a SQLite database (`.dewey/graph.db`), so subsequent sessions load near-instantly from the persistent index instead of rebuilding from scratch. No data leaves your machine — the embedding model runs locally via Ollama.
+
+### The graphthulhu Relationship
+
+Dewey is a hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu), an Obsidian-compatible MCP knowledge graph server created by Max Skridlevsky. Dewey preserves every MCP tool that graphthulhu exposes and adds:
+
+- **Persistent storage** — indexes survive across sessions instead of rebuilding from scratch
+- **Semantic search** — vector embeddings via locally-run Ollama models
+- **Pluggable content sources** — GitHub API, web crawl, and local disk (graphthulhu only indexes local Markdown)
+- **Incremental updates** — only changed files are re-indexed, not the entire corpus
+
+Existing agent configurations that use graphthulhu can migrate to Dewey by changing the MCP server name in their configuration. No agent prompt changes are required for existing functionality.
+
+## Query Capabilities
+
+Dewey exposes 40+ MCP tools across 10 categories. For knowledge retrieval, agents primarily use 9 query tools across two search modes.
+
+### Structured Queries
+
+Inherited from graphthulhu, these tools provide precise, deterministic retrieval:
+
+| Tool               | What It Does                                                                      |
+| ------------------ | --------------------------------------------------------------------------------- |
+| `search`           | Full-text keyword search across all indexed content                               |
+| `find_by_tag`      | Find pages by tag values with child tag hierarchy support                         |
+| `query_properties` | Structured queries against YAML frontmatter properties (eq, contains, gt, lt)     |
+| `get_page`         | Retrieve the full block tree of a specific document                               |
+| `traverse`         | Follow wikilinks to discover relationships between documents via BFS path-finding |
+| `find_connections` | Discover direct links, shortest paths, and shared connections between pages       |
+
+### Semantic Queries
+
+New in Dewey, these tools use vector embeddings for conceptual similarity:
+
+| Tool                             | What It Does                                                                                 |
+| -------------------------------- | -------------------------------------------------------------------------------------------- |
+| `dewey_semantic_search`          | Find documents semantically similar to a natural language query, ranked by cosine similarity |
+| `dewey_similar`                  | Given a document ID, find the most similar documents in the index                            |
+| `dewey_semantic_search_filtered` | Semantic search constrained by source type, repository, or property values                   |
+
+### Combined Queries
+
+The most powerful retrieval pattern combines both modes:
+
+1. **Semantic search** to discover broadly relevant content: "authentication timeout issues"
+2. **Property filter** to narrow by source: `source = "github"` AND `repo = "gaze"`
+3. **Graph traversal** to explore relationships: follow wikilinks from the discovered documents to find connected specifications
+
+This pattern enables agents to start with a vague concept and progressively refine their understanding through structured navigation.
+
+## Content Sources
+
+Dewey indexes content from three pluggable source types. Each source implements a common interface, so adding new source types (Confluence, Notion, S3) is a matter of implementing the interface — not modifying core indexing logic.
+
+### Local Disk
+
+The foundational source, inherited from graphthulhu. Indexes all Markdown files in the repository, including hidden directories (`.opencode/`, `.specify/`, `.muti-mind/`). Files are watched for changes in real time via fsnotify — when you save a file, Dewey re-indexes only the changed content using SHA-256 content hashing for change detection.
+
+### GitHub API
+
+Fetches issues, pull requests, READMEs, and documentation directories from whitelisted repositories in your GitHub organization. This provides cross-repository context that is impossible with a single-repo knowledge graph. Authentication uses the `gh` CLI's existing credentials.
+
+### Web Crawl
+
+Fetches and indexes documentation from toolstack websites — Go standard library docs, framework documentation, tool references. Crawls respect `robots.txt`, impose configurable rate limiting, and cache content locally. HTML is converted to Markdown for consistent indexing.
+
+See the [getting-started guide](/docs/getting-started/knowledge/#source-configuration) for YAML configuration examples for each source type.
+
+## Embedding Model
+
+Dewey uses [IBM Granite Embedding](https://www.ibm.com/granite/docs/models/embedding/) for vector embeddings — a 63 MB model that runs locally via Ollama.
+
+| Attribute           | Value                                                       |
+| ------------------- | ----------------------------------------------------------- |
+| **Developer**       | IBM Research                                                |
+| **License**         | Apache 2.0                                                  |
+| **Training data**   | Permissibly licensed public datasets with full transparency |
+| **Model size**      | 30M parameters (63 MB)                                      |
+| **Context window**  | 512 tokens                                                  |
+| **Load time**       | 1-2 seconds on Apple Silicon                                |
+| **Embedding speed** | ~10-50 ms per chunk                                         |
+
+Enterprise licensing provenance matters. Granite's training data is fully disclosed and permissibly licensed — there are no questions about whether the model was trained on proprietary or restricted content. This is a deliberate choice for organizations where licensing provenance is a compliance requirement.
+
+The embedding model is configurable. While Granite is the recommended default, teams can swap to any Ollama-compatible embedding model by editing `.dewey/config.yaml`:
+
+```yaml
+embedding:
+  provider: ollama
+  model: granite-embedding:30m
+  # Alternative: granite-embedding:278m for multilingual content
+```
+
+## How Heroes Use Dewey
+
+Every hero in the swarm benefits from Dewey, but in different ways. Dewey is always optional — all heroes function without it, falling back to direct file reads and CLI queries.
+
+| Hero                                              | Role             | How They Use Dewey                                                                             |
+| ------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------- |
+| [Muti-Mind](/docs/getting-started/product-owner/) | Product Owner    | Cross-repo issue discovery, past acceptance criteria, backlog pattern analysis                 |
+| [Cobalt-Crush](/docs/getting-started/developer/)  | Developer        | Toolstack API documentation, implementation patterns from other repos, related spec artifacts  |
+| [Gaze](/docs/getting-started/tester/)             | Tester           | Quality patterns across repos, CRAP score baselines, known failure modes for similar code      |
+| [The Divisor](/docs/team/the-divisor/)            | Reviewer Council | Convention pack context enriched with framework docs, recurring review findings across the org |
+| [Mx F](/docs/getting-started/product-manager/)    | Manager          | Cross-repo velocity trends, retrospective outcomes, coaching pattern discovery                 |
+
+For installation and configuration, see the [Dewey getting-started guide](/docs/getting-started/knowledge/).

--- a/specs/007-dewey-docs/checklists/requirements.md
+++ b/specs/007-dewey-docs/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Dewey Documentation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation.
+- The spec references specific file paths
+  (content/docs/getting-started/knowledge.md,
+  content/docs/team/dewey.md) as content locations, not
+  as implementation prescriptions. These are the
+  Hugo content conventions documented in AGENTS.md.
+- Content will be derived from the Dewey design paper
+  and Spec 014, adapted for a website audience.
+- The spec explicitly notes Dewey may not be available
+  via Homebrew yet -- installation instructions should
+  cover both paths.

--- a/specs/007-dewey-docs/plan.md
+++ b/specs/007-dewey-docs/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Dewey Documentation
+
+**Branch**: `007-dewey-docs` | **Date**: 2026-03-25 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/007-dewey-docs/spec.md`
+
+## Summary
+
+Add Dewey documentation to the Unbound Force website:
+a getting-started guide for installation and
+configuration, a tool page describing Dewey's
+architecture and capabilities, updates to all
+role-specific guides and the common workflows page to
+reference Dewey's role, and navigation updates to make
+the new pages discoverable.
+
+Content is derived from the Dewey design paper
+(`../dewey-design-paper.md`) and architectural spec
+(Spec 014 in the meta repo), adapted for a website
+audience per Constitution Principle III (Visitor
+Clarity).
+
+## Technical Context
+
+**Language/Version**: Hugo (via npm/thulite) + Go 1.23
+(module resolution) + Node.js >= 20.11.0
+**Primary Dependencies**: `thulite ^2.6.3`,
+`@thulite/doks-core ^1.8.3`
+**Storage**: N/A (static site, Markdown files)
+**Testing**: Manual: `npm run build` must succeed,
+`npm run dev` for visual verification
+**Target Platform**: GitHub Pages (static site)
+**Project Type**: Hugo static site (Doks theme)
+**Performance Goals**: N/A (static content)
+**Constraints**: Markdown preferred over custom HTML
+(Constitution Principle II). Content must be derived
+from upstream repos (Constitution Principle I). No
+placeholder content.
+**Scale/Scope**: 2 new pages + 5 updated pages +
+navigation config update. ~500 lines of new Markdown
+content total.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check
+after Phase 1 design._
+
+### I. Content Accuracy -- PASS
+
+All Dewey content will be derived from the design paper
+and Spec 014 in the meta repo. Dewey's core
+implementation is complete (86/86 tasks in the dewey
+repo). The capabilities described (persistence, semantic
+search, content sources, 3-tier degradation) are
+implemented and tested. No features will be overstated.
+
+The getting-started guide will include both Homebrew
+and `go install` installation options since the Homebrew
+formula may not yet be published when the docs go live.
+This is transparent, not misleading.
+
+### II. Minimal Footprint -- PASS
+
+All new content is Markdown. No custom HTML, SCSS,
+JavaScript, or template overrides. Navigation is
+configured via the existing `menus.en.toml` file. The
+Doks theme provides sidebar navigation, dark mode,
+and responsive layout -- no custom code needed.
+
+### III. Visitor Clarity -- PASS
+
+The getting-started guide is self-contained: a developer
+can read it without prior knowledge of the hero pages.
+The tool page provides deeper reference. The workflow
+pages are updated incrementally (adding Dewey context
+to existing sections, not restructuring). Navigation
+is updated so new pages are discoverable within 2
+clicks from the homepage.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-dewey-docs/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output
+└── checklists/
+    └── requirements.md  # Already created
+```
+
+### Content (repository root)
+
+```text
+content/docs/
+├── getting-started/
+│   ├── knowledge.md          # NEW: Dewey getting-started guide
+│   ├── common-workflows.md   # UPDATED: Dewey context
+│   ├── developer.md          # UPDATED: Cobalt-Crush + Dewey
+│   ├── product-manager.md    # UPDATED: Mx F + Dewey
+│   ├── product-owner.md      # UPDATED: Muti-Mind + Dewey
+│   └── tester.md             # UPDATED: Gaze + Dewey
+└── team/
+    └── dewey.md              # NEW: Dewey tool page
+
+config/_default/
+└── menus/menus.en.toml       # UPDATED: navigation entries
+```
+
+**Structure Decision**: All content is standard Hugo
+Markdown pages in the existing directory structure. No
+new directories, templates, or layouts. The `knowledge.md`
+name was chosen to be descriptive without implying a
+specific tool name in the URL path.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications
+needed.

--- a/specs/007-dewey-docs/quickstart.md
+++ b/specs/007-dewey-docs/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: Dewey Documentation
+
+**Date**: 2026-03-25
+**Branch**: `007-dewey-docs`
+
+## Overview
+
+After this change, the Unbound Force website has
+comprehensive Dewey documentation: a getting-started
+guide, a tool reference page, and updated role guides
+that show how each hero uses Dewey for context.
+
+## New Pages
+
+### knowledge.md (Getting Started)
+
+Covers:
+
+1. What is Dewey? (1 paragraph)
+2. Installation (Homebrew + go install fallback)
+3. Initialization (`dewey init`)
+4. Source configuration (YAML examples for all 3 types)
+5. Indexing (`dewey index`)
+6. Verification (`dewey status`)
+7. 3-tier degradation explanation
+8. OpenCode integration (opencode.json config)
+
+### dewey.md (Team/Tools)
+
+Covers:
+
+1. What Dewey does (semantic knowledge layer, MCP
+   server with persistent index)
+2. How it relates to graphthulhu (hard fork, superset)
+3. Query capabilities (structured + semantic)
+4. Content sources (disk, GitHub, web)
+5. Embedding model (Granite, enterprise provenance)
+6. How heroes use it (brief per-hero overview)
+
+## Updated Pages
+
+### common-workflows.md
+
+Add a "Knowledge Context" subsection to the hero
+lifecycle description explaining that Dewey provides
+semantic context to all heroes during their stages.
+
+### developer.md
+
+Add "Knowledge Retrieval with Dewey" subsection
+under the Swarm section explaining how Cobalt-Crush
+uses Dewey for toolstack docs and patterns.
+
+### product-owner.md
+
+Add "Knowledge Retrieval with Dewey" subsection
+explaining how Muti-Mind uses Dewey for cross-repo
+backlog patterns.
+
+### product-manager.md
+
+Add "Knowledge Retrieval with Dewey" subsection
+explaining how Mx F uses Dewey for velocity trends
+and retrospective data.
+
+### tester.md
+
+Add "Knowledge Retrieval with Dewey" subsection
+explaining how Gaze uses Dewey for quality patterns
+and test baselines.
+
+## Verification
+
+```bash
+npm run build    # Must succeed with zero errors
+npm run dev      # Visual verification of all pages
+```
+
+Check:
+
+- New pages appear in sidebar navigation
+- Dark mode renders correctly
+- No broken internal links
+- Content is self-contained (Dewey guide readable
+  without prior hero knowledge)

--- a/specs/007-dewey-docs/research.md
+++ b/specs/007-dewey-docs/research.md
@@ -1,0 +1,105 @@
+# Research: Dewey Documentation
+
+**Date**: 2026-03-25
+**Branch**: `007-dewey-docs`
+
+## R1: Content Source Strategy
+
+**Decision**: Derive all Dewey content from the design
+paper (`../dewey-design-paper.md`) and the Dewey repo's
+README, adapted for a website audience.
+
+**Rationale**: The design paper is comprehensive (988
+lines covering motivation, architecture, embedding
+model, content sources, query model, agent impact,
+workflow impact, practical considerations). The Dewey
+repo README covers CLI commands and setup. Both need
+to be adapted: less technical depth, more "why should
+I care" framing per Constitution Principle III.
+
+**Source locations**:
+
+- Design paper: `https://github.com/unbound-force/unbound-force/blob/main/../dewey-design-paper.md`
+  (lives at the org level, not in any single repo --
+  available locally at `~/Projects/github/unbound-force/dewey-design-paper.md`)
+- Spec 014: `https://github.com/unbound-force/unbound-force/tree/main/specs/014-dewey-architecture/`
+- Dewey repo README: `https://github.com/unbound-force/dewey/blob/main/README.md`
+- Dewey MCP tool names: `dewey_search`, `dewey_semantic_search`,
+  `dewey_similar`, `dewey_semantic_search_filtered`,
+  `dewey_find_by_tag`, `dewey_query_properties`,
+  `dewey_get_page`, `dewey_traverse`, `dewey_find_connections`
+
+**Alternatives considered**:
+
+- Copy the design paper as-is: Rejected because it's
+  too technical for website visitors. The paper targets
+  architects; the website targets developers evaluating
+  the tool.
+- Write from scratch: Rejected because the design paper
+  already has the right content. Adapting is faster and
+  ensures accuracy (Principle I).
+
+## R2: Page Naming and URLs
+
+**Decision**: Getting-started guide at
+`content/docs/getting-started/knowledge.md` (URL:
+`/docs/getting-started/knowledge/`). Tool page at
+`content/docs/team/dewey.md` (URL:
+`/docs/team/dewey/`).
+
+**Rationale**: The filename `knowledge.md` is generic
+enough to cover the concept of knowledge retrieval
+without coupling to the tool name. If the tool were
+renamed, the URL would still make sense. The tool page
+uses the tool name directly since it's specifically
+about Dewey.
+
+**Alternatives considered**:
+
+- `dewey.md` in getting-started: Rejected because the
+  URL `/docs/getting-started/dewey/` is less
+  discoverable than `/docs/getting-started/knowledge/`.
+- `semantic-search.md`: Rejected because Dewey
+  provides more than just semantic search (structured
+  queries, content sources, persistence).
+
+## R3: Frontmatter Weight Values
+
+**Decision**: Getting-started guide gets `weight: 80`
+(after common-workflows at 70, maintaining the existing
+10-increment scheme). Tool page gets `weight: 70`
+(after mx-f at 60, maintaining the 10-increment scheme).
+
+**Rationale**: The existing getting-started weights use
+a 10-increment pattern (quick-start=20, developer=30,
+tester=40, product-owner=50, product-manager=60,
+common-workflows=70). Weight 80 places the Dewey guide
+after all role-specific guides. The team section uses
+the same pattern (muti-mind=20 through mx-f=60). Weight
+70 places Dewey after all heroes as an infrastructure
+component, not a persona.
+
+## R4: Role-Specific Dewey Additions
+
+**Decision**: Each role guide gets a short "Knowledge
+Retrieval with Dewey" subsection (3-5 paragraphs)
+added within the existing page structure, not a
+separate section. This keeps the pages cohesive.
+
+**Rationale**: Adding a full new section to each role
+guide would make Dewey feel more prominent than the
+hero itself. A subsection within the relevant context
+(e.g., under "Working with Swarm" for the developer
+guide) keeps the focus on the hero's role while
+naturally introducing Dewey as a context enhancement.
+
+**Content per role** (from Spec 014 research R3):
+
+- **Developer**: toolstack API docs, implementation
+  patterns from other repos
+- **Product Owner**: cross-repo backlog patterns, past
+  acceptance criteria, issue discovery
+- **Product Manager**: cross-repo velocity trends,
+  retrospective outcomes, coaching patterns
+- **Tester**: test quality patterns, CRAP score
+  baselines, known failure modes

--- a/specs/007-dewey-docs/spec.md
+++ b/specs/007-dewey-docs/spec.md
@@ -1,0 +1,280 @@
+# Feature Specification: Dewey Documentation
+
+**Feature Branch**: `007-dewey-docs`
+**Created**: 2026-03-25
+**Status**: Draft
+**Input**: User description: "Website Dewey documentation
+(Phase 4.4)"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Dewey Getting Started Guide (Priority: P1)
+
+A developer new to the Unbound Force ecosystem visits
+the website to learn how to set up Dewey for knowledge
+retrieval. They find a dedicated getting-started page
+that walks them through installation, initialization,
+source configuration, and first use. After following
+the guide, they have a working Dewey instance with
+semantic search available to their AI coding agents.
+
+**Why this priority**: Without a getting-started guide,
+developers have no documentation for installing and
+configuring Dewey. This is the most fundamental page --
+it enables adoption.
+
+**Independent Test**: Navigate to the Dewey getting
+started page. Verify it covers installation (Homebrew,
+model pull), initialization (`dewey init`), source
+configuration (YAML examples), indexing (`dewey index`),
+and verification (`dewey status`). Verify the page
+renders correctly and appears in the sidebar navigation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the getting-started section,
+   **When** they navigate to the Dewey guide, **Then**
+   the page explains what Dewey is, how to install it,
+   and how to configure it with step-by-step
+   instructions.
+2. **Given** a developer reading the Dewey guide,
+   **When** they reach the source configuration section,
+   **Then** they see YAML examples for local disk,
+   GitHub API, and web crawl sources.
+3. **Given** a developer reading the Dewey guide,
+   **When** they reach the 3-tier degradation section,
+   **Then** they understand that Dewey is optional and
+   all tools work without it (just with less context).
+
+---
+
+### User Story 2 - Updated Workflow Pages (Priority: P1)
+
+The existing getting-started guides (developer, product
+owner, product manager, tester) and the common workflows
+page are updated to reference Dewey's role in the hero
+lifecycle. Developers reading these pages understand
+how Dewey enriches each hero's context and how the
+3-tier degradation works in practice.
+
+**Why this priority**: The existing pages describe the
+hero workflow but don't mention Dewey or semantic
+search. Developers following these guides won't discover
+Dewey's capabilities. This is tied with US1 because
+both are needed for a coherent documentation experience.
+
+**Independent Test**: Visit each updated page. Verify
+it mentions Dewey in the context of the hero's role.
+Verify the common workflows page describes how Dewey
+provides cross-repo context. Verify no page implies
+Dewey is required (degradation is mentioned).
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the developer guide, **When**
+   they read the knowledge retrieval section, **Then**
+   they see how Cobalt-Crush uses Dewey for toolstack
+   docs and implementation patterns.
+2. **Given** a visitor on the product owner guide,
+   **When** they read the backlog management section,
+   **Then** they see how Muti-Mind uses Dewey for
+   cross-repo issue discovery.
+3. **Given** a visitor on the common workflows page,
+   **When** they read the hero lifecycle, **Then** they
+   understand that Dewey provides semantic context to
+   all heroes during their stages.
+4. **Given** a visitor on the tester guide, **When**
+   they read the quality analysis section, **Then**
+   they see how Gaze uses Dewey for cross-repo quality
+   patterns.
+5. **Given** a visitor on the product manager guide,
+   **When** they read the velocity analysis section,
+   **Then** they see how Mx F uses Dewey for cross-repo
+   velocity trends and retrospective data.
+
+---
+
+### User Story 3 - Dewey Tool Page (Priority: P2)
+
+A visitor looking at the team section of the website
+finds a page for Dewey as an infrastructure tool
+alongside the hero pages. The page explains what Dewey
+is (a semantic knowledge layer), how it relates to
+graphthulhu (its predecessor), what capabilities it
+provides (structured + semantic search, content
+sources), and how it fits into the ecosystem (used by
+all heroes, optional enhancement).
+
+**Why this priority**: The tool page provides a
+reference for visitors who want to understand Dewey's
+architecture and capabilities in depth. It's P2 because
+the getting-started guide (US1) covers the practical
+"how to use" angle first.
+
+**Independent Test**: Navigate to the Dewey tool page
+in the team section. Verify it explains what Dewey is,
+its relationship to graphthulhu, the MCP tools it
+provides, content sources, and the embedding model.
+Verify it appears in the sidebar navigation under the
+team section.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the team section, **When**
+   they navigate to the Dewey page, **Then** they see
+   a description of Dewey as a semantic knowledge
+   layer that replaces graphthulhu.
+2. **Given** a visitor reading the Dewey tool page,
+   **When** they look for capabilities, **Then** they
+   see both structured search (keyword, tags, wikilinks)
+   and semantic search (conceptual similarity).
+3. **Given** a visitor reading the Dewey tool page,
+   **When** they look for content sources, **Then**
+   they see local disk, GitHub API, and web crawl as
+   the three source types.
+
+---
+
+### User Story 4 - Navigation Updates (Priority: P2)
+
+The website navigation menus are updated to include the
+new Dewey pages. The getting-started section includes
+the Dewey guide in the sidebar with appropriate weight
+for ordering. The team section includes the Dewey tool
+page alongside the hero pages.
+
+**Why this priority**: Without navigation updates, the
+new pages exist but are unreachable from the website's
+menu structure. This must ship alongside the content.
+
+**Independent Test**: Navigate the website using the
+sidebar. Verify the Dewey getting-started guide appears
+in the getting-started section. Verify the Dewey tool
+page appears in the team section. Verify the ordering
+is logical relative to sibling pages.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the getting-started section,
+   **When** they view the sidebar, **Then** the Dewey
+   guide appears with a logical position (after the
+   role-specific guides, before contributing).
+2. **Given** a visitor on the team section, **When**
+   they view the sidebar, **Then** the Dewey tool page
+   appears alongside the hero pages.
+
+---
+
+### Edge Cases
+
+- What if Dewey is not yet released via Homebrew when
+  the docs go live? The getting-started guide should
+  include both `brew install` and `go install` as
+  installation options, with a note that Homebrew may
+  not be available yet.
+- What if a visitor reads the Dewey guide before any
+  other page? The guide should be self-contained --
+  it should explain what Dewey is without assuming
+  the reader has read the hero pages or the common
+  workflows page.
+- What about dark mode rendering? All new pages must
+  render correctly in both light and dark mode (Doks
+  theme supports auto/light/dark).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The website MUST include a Dewey
+  getting-started page at
+  `content/docs/getting-started/knowledge.md` covering
+  installation, initialization, source configuration,
+  indexing, and verification.
+- **FR-002**: The Dewey getting-started page MUST
+  include YAML configuration examples for all three
+  source types (local disk, GitHub API, web crawl).
+- **FR-003**: The Dewey getting-started page MUST
+  explain the 3-tier graceful degradation (full Dewey,
+  graph-only, no Dewey) so developers understand Dewey
+  is optional.
+- **FR-004**: The website MUST include a Dewey tool page
+  at `content/docs/team/dewey.md` describing Dewey's
+  role, capabilities, and relationship to graphthulhu.
+- **FR-005**: The common workflows page MUST be updated
+  to reference Dewey's role in providing semantic
+  context to hero agents during the workflow.
+- **FR-006**: The developer guide MUST be updated to
+  describe how Cobalt-Crush uses Dewey for toolstack
+  documentation and implementation patterns.
+- **FR-007**: The product owner guide MUST be updated
+  to describe how Muti-Mind uses Dewey for cross-repo
+  backlog patterns and issue discovery.
+- **FR-008**: The product manager guide MUST be updated
+  to describe how Mx F uses Dewey for cross-repo
+  velocity trends and retrospective data.
+- **FR-009**: The tester guide MUST be updated to
+  describe how Gaze uses Dewey for cross-repo quality
+  patterns and test baselines.
+- **FR-010**: The sidebar navigation MUST include the
+  new Dewey pages with appropriate ordering.
+- **FR-011**: All new and updated pages MUST render
+  correctly in both light and dark mode.
+- **FR-012**: All new pages MUST follow the website's
+  frontmatter conventions (title, description, lead,
+  date, weight, toc, draft).
+- **FR-013**: The site MUST build without errors after
+  all changes (`npm run build`).
+- **FR-014**: The getting-started section index
+  (`content/docs/getting-started/_index.md`) MUST be
+  updated to include a link to the Dewey knowledge
+  retrieval guide.
+- **FR-015**: The team section index
+  (`content/docs/team/_index.md`) MUST be updated to
+  include Dewey as an infrastructure tool, distinct
+  from the hero personas.
+
+## Assumptions
+
+- The Dewey design paper
+  (`../dewey-design-paper.md`) and architectural spec
+  (Spec 014 in the meta repo) are the primary content
+  sources. Content should be adapted for a website
+  audience -- less raw technical detail, more "why
+  should I care" framing.
+- The existing page style and tone (conversational,
+  developer-focused, practical) should be maintained
+  for consistency.
+- The Dewey binary may or may not be available via
+  Homebrew when the docs go live. Installation
+  instructions should include both Homebrew and
+  `go install` options.
+- The getting-started guide is the primary entry point
+  for Dewey documentation. The tool page is a deeper
+  reference.
+- No changes to the homepage layout (`layouts/home.html`)
+  are needed -- Dewey is not a project, it's
+  infrastructure.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: The website has a dedicated Dewey
+  getting-started page reachable from the sidebar
+  navigation with installation, configuration, and
+  usage instructions.
+- **SC-002**: All 4 role-specific guides (developer,
+  product owner, product manager, tester) reference
+  Dewey's role in their hero's workflow.
+- **SC-003**: The common workflows page describes
+  Dewey's role in the hero lifecycle.
+- **SC-004**: `npm run build` succeeds with zero
+  errors after all changes.
+- **SC-005**: All new and updated pages have readable
+  code blocks (YAML examples), visible table borders,
+  and no text-on-same-color-background issues in both
+  light and dark mode (verified via `npm run dev` with
+  manual inspection of each page in both modes).
+- **SC-006**: Zero broken internal links across all
+  new and updated pages (verified by clicking each
+  link in the dev server and confirming no 404s).

--- a/specs/007-dewey-docs/tasks.md
+++ b/specs/007-dewey-docs/tasks.md
@@ -1,0 +1,151 @@
+# Tasks: Dewey Documentation
+
+**Input**: Design documents from `/specs/007-dewey-docs/`
+**Prerequisites**: plan.md, spec.md, research.md, quickstart.md
+
+**Tests**: No automated tests -- this is a Hugo static site. Validation is `npm run build` (must succeed) and `npm run dev` (visual verification).
+
+**Organization**: US1 and US2 are both P1 but can be written in parallel (different files). US3 and US4 are P2 and can also be parallelized.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+- Include exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: Verify the project builds and understand the existing page structure before adding content.
+
+- [x] T001 Run `npm run build` to verify the site builds cleanly before any changes
+- [x] T002 Read the existing getting-started pages (`content/docs/getting-started/*.md`) and team pages (`content/docs/team/*.md`) to understand the current frontmatter conventions, heading styles, and content tone
+
+---
+
+## Phase 2: User Story 1 - Dewey Getting Started Guide (Priority: P1)
+
+**Goal**: A new developer can find, read, and follow the Dewey getting-started guide to install, configure, and verify Dewey.
+
+**Independent Test**: Navigate to `/docs/getting-started/knowledge/` in the dev server. Verify the page covers installation, initialization, source configuration, indexing, verification, 3-tier degradation, and OpenCode integration. Verify it appears in the sidebar.
+
+- [x] T003 [US1] Create `content/docs/getting-started/knowledge.md` with frontmatter: title "Knowledge Retrieval with Dewey", description, lead, date, weight 80, toc true, draft false
+- [x] T004 [US1] Write the "What is Dewey?" section in `content/docs/getting-started/knowledge.md`: 1-2 paragraphs explaining Dewey as a semantic knowledge layer that gives AI agents cross-repo context. Mention it replaces graphthulhu. Frame around "why should I care" per Constitution Principle III
+- [x] T005 [US1] Write the "Installation" section in `content/docs/getting-started/knowledge.md`: Homebrew install command (`brew install unbound-force/tap/dewey`), Ollama + embedding model pull, and `go install` fallback with note that Homebrew may not yet be available
+- [x] T006 [US1] Write the "Getting Started" section in `content/docs/getting-started/knowledge.md`: `dewey init`, editing `.dewey/config.yaml`, `dewey index`, `dewey status` walkthrough
+- [x] T007 [US1] Write the "Source Configuration" section in `content/docs/getting-started/knowledge.md`: YAML examples for all 3 source types (local disk, GitHub API with whitelisted repos, web crawl with depth and refresh). Use the examples from the design paper Section 4
+- [x] T008 [US1] Write the "OpenCode Integration" section in `content/docs/getting-started/knowledge.md`: the `opencode.json` MCP config entry for Dewey, note that `uf init` generates this automatically
+- [x] T009 [US1] Write the "Graceful Degradation" section in `content/docs/getting-started/knowledge.md`: 3-tier table (Full Dewey, Graph-only, No Dewey) explaining what works at each tier and that Dewey is always optional
+- [x] T010 [US1] Run `npm run build` to verify the new page builds without errors
+
+**Checkpoint**: The Dewey getting-started guide exists, builds, and covers all sections from the quickstart outline.
+
+---
+
+## Phase 3: User Story 2 - Updated Workflow Pages (Priority: P1)
+
+**Goal**: All 4 role-specific guides and the common workflows page reference Dewey's role in the hero lifecycle.
+
+**Independent Test**: Visit each updated page in the dev server. Verify Dewey is mentioned in the context of the hero's role. Verify no page implies Dewey is required.
+
+- [x] T011 [P] [US2] Update `content/docs/getting-started/common-workflows.md`: add a "Knowledge Context" subsection after the "Swarm Delegation" section explaining that Dewey provides semantic context to all heroes during their stages. Mention the 3-tier degradation briefly. Link to the Dewey getting-started guide
+- [x] T012 [P] [US2] Update `content/docs/getting-started/developer.md`: add a "Knowledge Retrieval with Dewey" subsection (or expand the existing "Swarm Delegation" section) explaining how Cobalt-Crush uses `dewey_semantic_search` for toolstack API docs and implementation patterns from other repos. Include 2-3 example queries. Note the fallback behavior
+- [x] T013 [P] [US2] Update `content/docs/getting-started/product-owner.md`: add a "Knowledge Retrieval with Dewey" subsection explaining how Muti-Mind uses Dewey for cross-repo backlog patterns, past acceptance criteria, and issue discovery across whitelisted repos
+- [x] T014 [P] [US2] Update `content/docs/getting-started/product-manager.md`: add a "Knowledge Retrieval with Dewey" subsection explaining how Mx F uses Dewey for cross-repo velocity trends, retrospective outcomes, and coaching patterns
+- [x] T015 [P] [US2] Update `content/docs/getting-started/tester.md`: add a "Knowledge Retrieval with Dewey" subsection explaining how Gaze uses Dewey for test quality patterns, CRAP score baselines from other repos, and known failure modes
+- [x] T016 [US2] Run `npm run build` to verify all updated pages build without errors
+
+**Checkpoint**: All 5 pages reference Dewey with role-specific context and fallback information.
+
+---
+
+## Phase 4: User Story 3 - Dewey Tool Page (Priority: P2)
+
+**Goal**: The team section has a Dewey page describing its architecture, capabilities, and ecosystem role.
+
+**Independent Test**: Navigate to `/docs/team/dewey/` in the dev server. Verify it explains what Dewey is, its relationship to graphthulhu, query capabilities, content sources, embedding model, and how heroes use it.
+
+- [x] T017 [US3] Create `content/docs/team/dewey.md` with frontmatter: title "Dewey", description "Semantic knowledge layer for AI agent context", lead, date, weight 70, toc true, draft false
+- [x] T018 [US3] Write the "What Dewey Does" section in `content/docs/team/dewey.md`: semantic knowledge layer combining structured knowledge graph with vector-based semantic search. Mention the graphthulhu heritage (hard fork, superset of capabilities)
+- [x] T019 [US3] Write the "Query Capabilities" section in `content/docs/team/dewey.md`: structured queries (keyword search, tag lookup, wikilink traversal, property queries) and semantic queries (conceptual similarity, similar documents, filtered semantic search). Use the MCP tool names from Spec 014 contracts
+- [x] T020 [US3] Write the "Content Sources" section in `content/docs/team/dewey.md`: local disk (Markdown files), GitHub API (issues, PRs, READMEs from whitelisted repos), web crawl (toolstack documentation). Explain the pluggable architecture
+- [x] T021 [US3] Write the "Embedding Model" section in `content/docs/team/dewey.md`: IBM Granite (Apache 2.0, permissible training data, 63 MB model). Explain why enterprise licensing provenance matters. Note the model is configurable
+- [x] T022 [US3] Write the "How Heroes Use Dewey" section in `content/docs/team/dewey.md`: brief per-hero overview table (PO: backlog patterns, Dev: toolstack docs, Tester: quality baselines, Reviewer: review patterns, Manager: velocity trends). Link to each hero's getting-started page
+- [x] T023 [US3] Run `npm run build` to verify the tool page builds without errors
+
+**Checkpoint**: The Dewey tool page exists with all sections from the quickstart outline.
+
+---
+
+## Phase 5: User Story 4 - Navigation Updates (Priority: P2)
+
+**Goal**: New pages appear in the sidebar navigation with logical ordering.
+
+**Independent Test**: Navigate the dev server sidebar. Verify the Dewey getting-started guide appears in the getting-started section and the Dewey tool page appears in the team section.
+
+- [x] T024 [US4] Verify sidebar ordering in `content/docs/getting-started/knowledge.md` frontmatter: weight 80 should place it after common-workflows.md (weight 70). Adjust if needed after visual check with `npm run dev`
+- [x] T025 [US4] Verify sidebar ordering in `content/docs/team/dewey.md` frontmatter: weight 70 should place it after mx-f.md (weight 60). Adjust if needed after visual check with `npm run dev`
+- [x] T026 [US4] Update `content/docs/getting-started/_index.md`: add a link to the Dewey knowledge retrieval guide in the page list, consistent with how other guides are listed
+- [x] T027 [US4] Update `content/docs/team/_index.md`: add Dewey as an infrastructure tool below the heroes listing. Do not change the "five AI agent personas" description -- Dewey is infrastructure, not a persona. Add a brief description and link.
+- [x] T028 [US4] Check `config/_default/menus/menus.en.toml` -- if top-level navigation entries are needed for the new pages, add them. If Doks auto-generates sidebar from content structure, no menu changes needed
+
+**Checkpoint**: Both new pages appear in the sidebar at logical positions.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final build, link checking, dark mode verification.
+
+- [x] T029 Run `npm run build` to verify the complete site builds with zero errors
+- [x] T030 Run `npm run dev` and visually verify all new and updated pages: check that code blocks (YAML examples) have readable text in both light and dark mode, tables have visible borders/separators, and no text-on-same-color-background issues exist
+- [x] T031 Check all internal links on new pages by clicking each one in the dev server: verify links to hero pages, common workflows, Dewey getting-started guide from the tool page, and section index pages all resolve. Report any 404s.
+- [x] T032 Verify no page contains "Coming Soon", placeholder text, or TODO markers (Constitution Principle I: no placeholder content)
+- [x] T033 Cross-reference all factual claims in new pages (MCP tool names, source types, embedding model name, CLI commands) against the Dewey repo's README and actual CLI help output. Verify no capability is overstated and no implemented feature is missing (Constitution Principle I).
+- [x] T034 Update `AGENTS.md` Content Sources table: add a Dewey row with repository `unbound-force/dewey`, key files `README.md`, design paper
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **US1 (Phase 2)**: Depends on Phase 1 -- new page
+- **US2 (Phase 3)**: Can run in parallel with Phase 2 (different files)
+- **US3 (Phase 4)**: Can run in parallel with Phases 2-3 (different file)
+- **US4 (Phase 5)**: Depends on Phases 2+4 (pages must exist before navigation is verified)
+- **Polish (Phase 6)**: Depends on all phases
+
+### Parallel Opportunities
+
+- T011, T012, T013, T014, T015 can all run in parallel (different files)
+- Phases 2, 3, and 4 can run in parallel (different files)
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Phase 1: Verify build
+2. Phase 2: Write Dewey getting-started guide
+3. **STOP and VALIDATE**: `npm run build` passes, page renders in dev server
+4. Core value delivered -- developers can learn about Dewey
+
+### Incremental Delivery
+
+1. US1 → Getting-started guide → Primary adoption enabler
+2. US2 → Role guide updates → Heroes reference Dewey
+3. US3 → Tool page → Deep reference for architecture
+4. US4 → Navigation → Discoverability
+5. Polish → Build, dark mode, links → Ship it
+
+---
+
+## Notes
+
+- Content is derived from `../dewey-design-paper.md` and Spec 014 (meta repo). Adapt for website audience: less technical depth, more "why should I care"
+- Use `##` headings (H2) for body content -- the `title` frontmatter generates H1
+- Use ATX-style headings (`##`, not underlines)
+- No placeholder or "Coming Soon" content (Constitution Principle I)
+- Check Doks docs before adding any custom CSS or HTML (Constitution Principle II)


### PR DESCRIPTION
## Summary

Add comprehensive Dewey documentation to the Unbound Force website. Two new pages, 7 updated pages, and navigation updates so developers can learn about and adopt the semantic knowledge layer.

## New Pages

### Knowledge Retrieval with Dewey (getting-started/knowledge.md)
- What is Dewey and why you'd want it
- Installation (Homebrew + go install fallback)
- Initialization and source configuration (YAML examples for disk, GitHub API, web crawl)
- OpenCode integration (opencode.json config)
- 3-tier graceful degradation table (Full Dewey, Graph-only, No Dewey)

### Dewey Tool Page (team/dewey.md)
- Architecture: semantic knowledge layer replacing graphthulhu
- Query capabilities: 6 structured + 3 semantic MCP tools
- Content sources: local disk, GitHub API, web crawl
- Embedding model: IBM Granite (Apache 2.0, 63 MB)
- Per-hero usage table linking to each role guide

## Updated Pages (7)

| Page | Addition |
|------|----------|
| common-workflows.md | "Knowledge Context" section after Swarm Delegation |
| developer.md | "Knowledge Retrieval with Dewey" for toolstack docs and patterns |
| product-owner.md | Dewey for cross-repo backlog patterns and issue discovery |
| product-manager.md | Dewey for velocity trends and retrospective data |
| tester.md | Dewey for quality patterns and CRAP baselines |
| getting-started/_index.md | Link to Dewey guide in page listing |
| team/_index.md | Infrastructure section with Dewey entry |

## Verification

- npm run build succeeds (58 pages, zero errors)
- All internal links verified
- Zero placeholder content
- Content cross-referenced against Dewey design paper and repo README
- Spec 007: 34/34 tasks complete, review council APPROVE WITH ADVISORIES
