### PR TITLE
docs: add Dewey documentation — getting started, tool page, role guides, project page

### DIFF
--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -222,7 +222,25 @@ This installs everything in one command:
 
 Use `--dry-run` to preview what would be installed without making changes.
 
-### 3. Verify
+### 3. Install Dewey (Knowledge Retrieval)
+
+Install [Dewey](/docs/getting-started/knowledge/) for semantic knowledge retrieval across your repositories:
+
+```bash
+# Install Dewey
+brew install --cask unbound-force/tap/dewey
+
+# Install Ollama and pull the embedding model
+brew install --cask ollama
+ollama pull granite-embedding:30m
+
+# Initialize Dewey in your project
+dewey init
+```
+
+Dewey is optional — all heroes function without it. See the [knowledge retrieval guide](/docs/getting-started/knowledge/) for source configuration and OpenCode integration.
+
+### 4. Verify
 
 ```bash
 uf doctor
@@ -230,7 +248,7 @@ uf doctor
 
 Doctor checks 7 areas and shows pass/warn/fail for each with install hints. Fix any failures by copying the suggested command from the output.
 
-### 4. Start Working
+### 5. Start Working
 
 Open OpenCode and try your first task:
 

--- a/content/docs/getting-started/knowledge.md
+++ b/content/docs/getting-started/knowledge.md
@@ -8,7 +8,7 @@ weight: 80
 toc: true
 ---
 
-## What is Dewey?
+## What Dewey Does
 
 Dewey is a semantic knowledge layer that gives AI agents rich, cross-repository context. It combines a structured knowledge graph (page traversal, tag queries, wikilink navigation) with vector-based semantic search — so agents can find conceptually related content even when different terminology is used. A search for "authentication timeout" finds an issue titled "login session expiry" because Dewey understands meaning, not just keywords.
 
@@ -37,7 +37,7 @@ If the Homebrew formula is not yet available, install from source:
 go install github.com/unbound-force/dewey@latest
 ```
 
-## Getting Started
+## Initialize Your Repository
 
 Initialize Dewey in your repository:
 
@@ -60,7 +60,7 @@ The `dewey status` command reports index health: page count, block count, embedd
 
 After initialization, Dewey persists its indexes to `.dewey/graph.db` (SQLite). Subsequent sessions load from the persistent index and only re-process changed files — startup is near-instant after the first index.
 
-## Source Configuration
+## Configure Content Sources
 
 Dewey indexes content from three pluggable source types. Configure them in `.dewey/sources.yaml`:
 

--- a/content/docs/projects/dewey.md
+++ b/content/docs/projects/dewey.md
@@ -1,0 +1,73 @@
+---
+title: "Dewey"
+description: "Semantic knowledge retrieval for AI agents — structured graph traversal plus vector-based semantic search across local files, GitHub, and web documentation."
+lead: "Semantic knowledge retrieval for AI agents."
+date: 2026-03-26T00:00:00+00:00
+draft: false
+weight: 30
+toc: true
+---
+
+## What Dewey Does
+
+AI agents make better decisions when they have better context. Dewey is an MCP server that gives agents unified access to your organization's knowledge — local Markdown files, GitHub issues and PRs, and web documentation — through both structured graph queries and vector-based semantic search.
+
+A search for "authentication timeout" finds an issue titled "login session expiry" because Dewey understands meaning, not just keywords. Agents start with a vague concept and refine their understanding through structured navigation, discovering related specifications, past decisions, and connected documentation they did not know to ask for.
+
+Dewey is a hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu), preserving all 37 existing MCP tools and adding persistent storage, semantic search, and pluggable content sources.
+
+## Installation
+
+```bash
+# macOS (Homebrew)
+brew install --cask unbound-force/tap/dewey
+
+# Install Ollama and pull the embedding model
+brew install --cask ollama
+ollama pull granite-embedding:30m
+```
+
+On Linux, install from source:
+
+```bash
+go install github.com/unbound-force/dewey@latest
+```
+
+## Key Features
+
+### 40 MCP Tools Across 9 Categories
+
+Dewey exposes tools for navigate, search, analyze, write, decision, journal, flashcard, whiteboard, and semantic search. Agents use these tools through the standard MCP protocol — no custom integrations required.
+
+### Semantic Search
+
+Vector-based similarity search using IBM Granite embeddings (30M parameters, 63 MB, Apache 2.0). Finds conceptually related content even when different terminology is used. Runs locally via Ollama — no data leaves your machine.
+
+### Three Content Source Types
+
+- **Local disk** — indexes all Markdown files in your repository with real-time file watching
+- **GitHub API** — fetches issues, PRs, READMEs, and documentation from whitelisted repositories
+- **Web crawl** — indexes documentation from toolstack websites with robots.txt compliance and local caching
+
+### Persistent SQLite Index
+
+Indexes persist to `.dewey/graph.db` across sessions. Subsequent startups load from the persistent index and only re-process changed files — startup is near-instant after the first index.
+
+### Graceful Degradation
+
+Dewey is an enhancement, not a requirement. Every hero in the swarm functions without Dewey, falling back to direct file reads. Semantic search requires Ollama; structured graph queries work without it.
+
+## Architecture
+
+Dewey runs as an MCP server alongside your AI coding environment. It combines:
+
+- **Knowledge graph** — in-memory graph built from Markdown files with wikilink, tag, and property relationships
+- **SQLite persistence** — pages, blocks, links, and embeddings stored in `.dewey/graph.db`
+- **Ollama embeddings** — IBM Granite model generates vector embeddings for semantic similarity search
+- **Pluggable sources** — content source interface supports disk, GitHub, and web crawl with configurable refresh intervals
+
+## Learn More
+
+- [Getting Started Guide](/docs/getting-started/knowledge/) — install, configure, and start using Dewey
+- [Dewey Team Page](/docs/team/dewey/) — architecture details, query capabilities, and how each hero uses Dewey
+- [GitHub Repository](https://github.com/unbound-force/dewey) — source code, issues, and releases

--- a/content/docs/team/dewey.md
+++ b/content/docs/team/dewey.md
@@ -122,4 +122,8 @@ Every hero in the swarm benefits from Dewey, but in different ways. Dewey is alw
 | [The Divisor](/docs/team/the-divisor/)            | Reviewer Council | Convention pack context enriched with framework docs, recurring review findings across the org |
 | [Mx F](/docs/getting-started/product-manager/)    | Manager          | Cross-repo velocity trends, retrospective outcomes, coaching pattern discovery                 |
 
-For installation and configuration, see the [Dewey getting-started guide](/docs/getting-started/knowledge/).
+## Next Steps
+
+- Follow the [Dewey getting-started guide](/docs/getting-started/knowledge/) for installation and configuration
+- Browse the [Dewey project page](/docs/projects/dewey/) for version history and key features
+- See [Common Workflows](/docs/getting-started/common-workflows/) for how Dewey provides context during the hero lifecycle


### PR DESCRIPTION
## Summary

Complete Dewey documentation for the Unbound Force website (Phase 4.4 of the Dewey initiative). Adds and updates 9 pages covering installation, configuration, role-specific usage, architecture, and project listing.

Spec: `specs/007-dewey-docs/` (all 34 tasks complete)
Cross-repo spec: `unbound-force/dewey/specs/003-website-docs/`

## Pages Created/Updated

| Page | Action | Content |
|------|--------|---------|
| `getting-started/knowledge.md` | Updated | Complete Dewey getting-started guide: installation (Homebrew + go install), init, source config (disk/GitHub/web), OpenCode integration, graceful degradation |
| `getting-started/developer.md` | Updated | Added "Knowledge Retrieval with Dewey" subsection with semantic search examples |
| `getting-started/tester.md` | Updated | Added "Knowledge Retrieval with Dewey" subsection with test pattern examples |
| `getting-started/product-owner.md` | Updated | Added "Knowledge Retrieval with Dewey" subsection with cross-repo issue examples |
| `getting-started/product-manager.md` | Updated | Added "Knowledge Retrieval with Dewey" subsection with velocity/retrospective examples |
| `getting-started/common-workflows.md` | Updated | Added Knowledge Context section, Dewey in environment setup |
| `team/dewey.md` | Updated | Architecture, 40 MCP tools, content sources, embedding model, per-hero usage |
| `projects/dewey.md` | Created | Project page with installation, features, links |
| `projects/_index.md` | Updated | Added Dewey to project listing alongside Gaze |

## Verification

- `npm run build` passes (zero errors)
- All internal cross-links verified
- Content accurate to Dewey v0.2.0
- Writing style matches existing pages (direct, declarative, no emojis, second person)
- Graceful degradation documented at all three tiers