### PR TITLE
docs: sync website documentation with upstream v0.5.0 changes

### DIFF
--- a/content/docs/contributing/_index.md
+++ b/content/docs/contributing/_index.md
@@ -28,7 +28,7 @@ We follow the standard GitHub pull request workflow:
 4. Submit a pull request against the `main` branch
 5. Address any review feedback from The Divisor council
 
-All pull requests are reviewed by The Divisor — a council of three sub-personas (The Guard, The Architect, and The Adversary) that evaluate intent, structure, and resilience. Collective approval from all three is required before merge.
+All pull requests are reviewed by The Divisor — a council of five sub-personas (The Guard, The Architect, The Adversary, The Operator (SRE), and The Tester) that evaluate intent, structure, resilience, operational readiness, and test quality. Collective approval from all five is required before merge.
 
 ## Conventional Commits
 

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -136,6 +136,42 @@ For projects without Dewey configured, the define stage runs in manual mode (`[h
 
 The swarm still runs implementation through review autonomously -- the only difference is who drives the specification.
 
+### Workflow Commands
+
+To seed a feature from a single description (autonomous define):
+
+```text
+/workflow seed "Add CSV export for the quality dashboard" [--spec-review]
+```
+
+This creates a backlog item and starts a workflow with `define=swarm` in one operation. Add `--spec-review` to enable the optional specification review checkpoint.
+
+For explicit control over the define mode, use `/workflow start` with flags:
+
+```text
+/workflow start --define-mode=swarm --spec-review
+```
+
+| Flag            | Values           | Default | Description                                  |
+| --------------- | ---------------- | ------- | -------------------------------------------- |
+| `--define-mode` | `human`, `swarm` | `human` | Who drives specification creation            |
+| `--spec-review` | _(flag)_         | off     | Pause for human review after spec is drafted |
+
+### Workflow Configuration
+
+Set project-level defaults in `.unbound-force/config.yaml` so you don't need to pass flags on every workflow start:
+
+```yaml
+workflow:
+  execution_modes:
+    define: swarm # or "human" (default)
+  spec_review: false
+```
+
+Config values are the base defaults; CLI flags override them. For spec review, OR logic applies -- either the config or the CLI flag being true enables it.
+
+This file is created by `uf init` with all values commented out (defaults apply). Edit it to set your team's preferred workflow behavior.
+
 ### Knowledge Context
 
 [Dewey](/docs/getting-started/knowledge/) is what makes autonomous define possible. By providing org-wide semantic context -- past specifications, GitHub issues from across the organization, toolstack documentation, and learning feedback -- Dewey gives Muti-Mind enough information to draft specifications without asking the human for context. This is the key capability that reduces human checkpoints from two to one.
@@ -164,6 +200,8 @@ This creates `openspec/changes/fix-auth-timeout/` with:
 - `design.md` -- Technical approach
 - `tasks.md` -- Implementation steps
 
+This creates an `opsx/fix-auth-timeout` branch and checks it out automatically. The `opsx/` prefix distinguishes OpenSpec branches from Speckit branches (`NNN-<short-name>`) in `git branch` output.
+
 ### 2. Apply
 
 Implement the tasks:
@@ -172,7 +210,7 @@ Implement the tasks:
 /opsx-apply
 ```
 
-Works through each task in the tasks.md file, making code changes and marking tasks complete.
+Works through each task in the tasks.md file, making code changes and marking tasks complete. Before proceeding, `/opsx-apply` validates that you are on the correct `opsx/<name>` branch -- this is a hard gate to prevent implementing changes on the wrong branch.
 
 ### 3. Review
 
@@ -192,7 +230,7 @@ After the fix is merged, archive the change:
 /opsx-archive
 ```
 
-Moves the change to `openspec/changes/archive/` with a date prefix for historical reference.
+Moves the change to `openspec/changes/archive/` with a date prefix for historical reference, then returns to the `main` branch.
 
 ## Code Review
 
@@ -246,37 +284,31 @@ brew install unbound-force/tap/unbound-force
 uf setup
 ```
 
-This installs everything in one command:
+This installs the full toolchain in one command:
 
-- Detects your version managers (goenv, nvm, pyenv, Homebrew)
-- Installs OpenCode (via Homebrew or curl)
-- Installs Gaze (via Homebrew)
-- Installs the Swarm plugin (via npm)
-- Configures `opencode.json` with the Swarm plugin
-- Initializes `.hive/` for work tracking
-- Runs `uf init` to scaffold project files
+- **Core tools** -- OpenCode (AI coding environment), Gaze (quality analysis), Mx F (manager hero), GitHub CLI
+- **Development tools** -- Node.js, Bun, OpenSpec CLI, Swarm plugin (multi-agent coordination), Swarm configuration and `.hive/` initialization
+- **Knowledge layer** -- Ollama (local model runtime), Dewey (semantic search), IBM Granite embedding model, Dewey workspace initialization and index build
+- **Project scaffolding** -- `uf init` to deploy agents, commands, convention packs, templates, and workflow configuration
 
-Use `--dry-run` to preview what would be installed without making changes.
+Setup detects your version managers (goenv, nvm, fnm, Homebrew) and installs through them. Use `--dry-run` to preview what would be installed without making changes.
 
-### 3. Install Dewey (Knowledge Retrieval)
+If you previously ran `uf setup` before v0.5.0, re-run it to pick up the new tools (Mx F, GitHub CLI, OpenSpec CLI, Ollama, and Dewey). Existing installations are detected and skipped.
 
-Install [Dewey](/docs/getting-started/knowledge/) for semantic knowledge retrieval across your repositories:
+After setup completes, add these environment variables to your shell profile (e.g., `~/.zshrc` or `~/.bashrc`) for embedding model alignment between the swarm and Dewey:
 
 ```bash
-# Install Dewey
-brew install --cask unbound-force/tap/dewey
-
-# Install Ollama and pull the embedding model
-brew install --cask ollama
-ollama pull granite-embedding:30m
-
-# Initialize Dewey in your project
-dewey init
+export OLLAMA_MODEL=granite-embedding:30m
+export OLLAMA_EMBED_DIM=256
 ```
 
-Dewey is optional — all heroes function without it. See the [knowledge retrieval guide](/docs/getting-started/knowledge/) for source configuration and OpenCode integration.
+`uf setup` sets these during installation, but they must be in your shell profile for processes spawned outside of setup (e.g., `dewey serve`, manual `swarm init`).
 
-### 4. Verify
+Dewey is optional -- all heroes function without it. See the [knowledge retrieval guide](/docs/getting-started/knowledge/) for source configuration and OpenCode integration.
+
+As the final step of setup, `uf init` scaffolds your project files and performs sub-tool initialization: it creates `.unbound-force/config.yaml` for [workflow configuration](#workflow-configuration) and runs `dewey init` + `dewey index` when Dewey is available.
+
+### 3. Verify
 
 ```bash
 uf doctor
@@ -284,7 +316,7 @@ uf doctor
 
 Doctor checks 7 areas and shows pass/warn/fail for each with install hints. Fix any failures by copying the suggested command from the output.
 
-### 5. Start Working
+### 4. Start Working
 
 Open OpenCode and try your first task:
 

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -17,12 +17,12 @@ brew install unbound-force/tap/unbound-force
 uf setup
 ```
 
-`uf setup` detects your existing version managers (goenv, nvm, pyenv, Homebrew) and installs through them:
+`uf setup` detects your existing version managers (goenv, nvm, fnm, Homebrew) and installs through them:
 
-- **OpenCode** -- the AI coding environment where you work
-- **Gaze** -- quality analysis for your Go code
-- **Swarm plugin** -- multi-agent coordination for parallel work
-- **Project scaffolding** -- agents, commands, convention packs, and templates
+- **Core tools** -- OpenCode (AI coding environment), Gaze (quality analysis), Mx F (manager hero), GitHub CLI
+- **Development tools** -- Node.js, Bun, OpenSpec CLI, Swarm plugin (multi-agent coordination)
+- **Knowledge layer** -- Ollama (local model runtime), Dewey (semantic search), IBM Granite embedding model
+- **Project scaffolding** -- agents, commands, convention packs, templates, and workflow configuration via `uf init`
 
 After setup, verify everything is working:
 
@@ -70,6 +70,8 @@ Each stage produces artifacts that feed the next. Specs must be committed and pu
 | Needs formal review                 | Quick tactical changes |
 
 **OpenSpec** is the tactical workflow for smaller changes. It uses `/opsx-propose` to create a change with proposal, design, and tasks artifacts, then `/opsx-apply` to implement. See [Common Workflows](/docs/getting-started/common-workflows/) for the full flow.
+
+Both workflows enforce branch conventions: Speckit uses `NNN-<short-name>` branches (created by `/speckit.specify`), and OpenSpec uses `opsx/<change-name>` branches (created by `/opsx-propose`). Branch validation is a hard gate at each pipeline step.
 
 ## Working with Swarm
 

--- a/content/docs/getting-started/knowledge.md
+++ b/content/docs/getting-started/knowledge.md
@@ -31,6 +31,17 @@ ollama pull granite-embedding:30m
 
 The `granite-embedding:30m` model is IBM's Granite Embedding — a 63 MB model licensed under Apache 2.0 with full training data transparency. It runs locally via Ollama; no data leaves your machine.
 
+### Embedding Model Alignment
+
+The Unbound Force swarm and Dewey are aligned on the same embedding model (IBM Granite `granite-embedding:30m`). To ensure consistency for processes spawned outside of `uf setup` (e.g., `dewey serve`, manual `swarm init`), add these environment variables to your shell profile (`~/.zshrc` or `~/.bashrc`):
+
+```bash
+export OLLAMA_MODEL=granite-embedding:30m
+export OLLAMA_EMBED_DIM=256
+```
+
+`uf setup` sets these automatically during installation. The shell profile entries ensure they persist across terminal sessions. Without them, child processes may use different embedding models, causing inconsistent search results between the swarm and Dewey.
+
 If the Homebrew formula is not yet available, install from source:
 
 ```bash

--- a/content/docs/getting-started/product-owner.md
+++ b/content/docs/getting-started/product-owner.md
@@ -66,6 +66,14 @@ Good seeds are specific enough to convey intent but don't need to be detailed:
 
 The swarm handles everything from here -- specification, planning, implementation, testing, and review -- pausing only at the accept stage for your decision.
 
+To seed a feature, use the `/workflow seed` command:
+
+```text
+/workflow seed "Add CSV export for the quality dashboard"
+```
+
+This creates a backlog item and starts a workflow with `define=swarm` in one operation. Add `--spec-review` to enable the optional specification review checkpoint. This is equivalent to creating a backlog item and running `/workflow start --define-mode=swarm`.
+
 #### Manual Define Mode
 
 For projects without [Dewey](/docs/getting-started/knowledge/) configured, the define stage runs in manual mode. You drive specification creation directly:

--- a/content/docs/projects/dewey.md
+++ b/content/docs/projects/dewey.md
@@ -14,7 +14,7 @@ AI agents make better decisions when they have better context. Dewey is an MCP s
 
 A search for "authentication timeout" finds an issue titled "login session expiry" because Dewey understands meaning, not just keywords. Agents start with a vague concept and refine their understanding through structured navigation, discovering related specifications, past decisions, and connected documentation they did not know to ask for.
 
-Dewey is a hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu), preserving all 37 existing MCP tools and adding persistent storage, semantic search, and pluggable content sources.
+Dewey is a hard fork of [graphthulhu](https://github.com/skridlevsky/graphthulhu), building on its knowledge graph foundation and adding persistent storage, semantic search, and pluggable content sources. Dewey now provides 40 MCP tools across 10 categories.
 
 ## Installation
 
@@ -35,9 +35,9 @@ go install github.com/unbound-force/dewey@latest
 
 ## Key Features
 
-### 40 MCP Tools Across 9 Categories
+### 40 MCP Tools Across 10 Categories
 
-Dewey exposes tools for navigate, search, analyze, write, decision, journal, flashcard, whiteboard, and semantic search. Agents use these tools through the standard MCP protocol — no custom integrations required.
+Dewey exposes tools for navigate, search, analyze, write, decision, journal, flashcard, whiteboard, semantic search, and health. Agents use these tools through the standard MCP protocol — no custom integrations required.
 
 ### Semantic Search
 

--- a/content/docs/team/_index.md
+++ b/content/docs/team/_index.md
@@ -28,7 +28,7 @@ _The Quality Sentinel and Predictive Validation Engine._ Gaze protects the produ
 
 ### [The Divisor](/docs/team/the-divisor/) — PR Reviewer Council
 
-_The Architectural Conscience and Code Integrity Guardian._ The Divisor operates as a council of three sub-personas — The Guard, The Architect, and The Adversary — providing comprehensive, multi-faceted validation of every code submission.
+_The Architectural Conscience and Code Integrity Guardian._ The Divisor operates as a council of five sub-personas — The Guard, The Architect, The Adversary, The Operator (SRE), and The Tester — providing comprehensive, multi-faceted validation of every code submission.
 
 ### [Mx F](/docs/team/mx-f/) — Manager
 

--- a/content/docs/team/dewey.md
+++ b/content/docs/team/dewey.md
@@ -32,7 +32,7 @@ Existing agent configurations that use graphthulhu can migrate to Dewey by chang
 
 ## Query Capabilities
 
-Dewey exposes 40+ MCP tools across 10 categories. For knowledge retrieval, agents primarily use 9 query tools across two search modes.
+Dewey exposes 40 MCP tools across 10 categories. For knowledge retrieval, agents primarily use 9 query tools across two search modes.
 
 ### Structured Queries
 
@@ -83,7 +83,7 @@ Fetches issues, pull requests, READMEs, and documentation directories from white
 
 Fetches and indexes documentation from toolstack websites — Go standard library docs, framework documentation, tool references. Crawls respect `robots.txt`, impose configurable rate limiting, and cache content locally. HTML is converted to Markdown for consistent indexing.
 
-See the [getting-started guide](/docs/getting-started/knowledge/#source-configuration) for YAML configuration examples for each source type.
+See the [getting-started guide](/docs/getting-started/knowledge/#configure-content-sources) for YAML configuration examples for each source type.
 
 ## Embedding Model
 

--- a/content/docs/team/the-divisor.md
+++ b/content/docs/team/the-divisor.md
@@ -1,6 +1,6 @@
 ---
 title: "The Divisor"
-description: "The Divisor is the PR Reviewer Council — three sub-personas (The Guard, The Architect, The Adversary) serving as the Code Integrity Guardian."
+description: "The Divisor is the PR Reviewer Council — five sub-personas (Guard, Architect, Adversary, SRE, Testing) serving as the Code Integrity Guardian."
 lead: "The Architectural Conscience and Code Integrity Guardian"
 date: 2026-02-23T00:00:00+00:00
 draft: false
@@ -14,7 +14,7 @@ toc: true
 
 The Divisor is the PR Reviewer of the Unbound Force swarm — the architectural conscience and code integrity guardian. Their mission is to ensure that all code changes proposed by Cobalt-Crush, once validated by Gaze, adhere strictly to established architectural standards, best practices, security policies, and maintainability requirements.
 
-The Divisor acts as the final technical gate before integration, translating high-level architectural standards into actionable review criteria. What makes The Divisor unique is its structure: it operates as a **council of three distinct sub-personas**, each providing a different lens on every code submission.
+The Divisor acts as the final technical gate before integration, translating high-level architectural standards into actionable review criteria. What makes The Divisor unique is its structure: it operates as a **council of five dynamically discovered personas** -- five canonical roles ship by default, with users able to add or remove personas freely. Each provides a different lens on every code submission.
 
 ## The Council
 
@@ -45,15 +45,35 @@ The Adversary focuses on _"Where it breaks."_ They act as a skeptical auditor:
 - Finding performance bottlenecks (O(n^2) loops, excessive API calls)
 - Enforcing behavioral constraints and robust error handling
 
+### The Operator (SRE) — Deployment and Operational Readiness
+
+The Operator focuses on _"Can it ship and run?"_ They ensure the code is deployable, maintainable, and operable:
+
+- Reviewing release pipeline integrity and reproducible builds
+- Assessing dependency health (pinned versions, known CVEs, unused dependencies)
+- Verifying configuration hygiene (no hardcoded paths, externalized secrets)
+- Ensuring runtime observability (meaningful exit codes, actionable error messages, structured output)
+- Evaluating upgrade and migration paths for breaking changes
+
+### The Tester — Test Quality and Testability
+
+The Tester focuses on _"Are the tests meaningful?"_ They ensure tests are not just present but valuable:
+
+- Evaluating test architecture (arrange/act/assert structure, self-contained fixtures, table-driven tests)
+- Assessing coverage strategy (contract surface over line coverage, observable side effects verified)
+- Checking assertion depth (specific expected values, not just "no error" or nil checks)
+- Verifying test isolation (no shared mutable state, no execution order dependencies, no external network access)
+- Ensuring regression protection (spec-critical behavior locked down, known-good and known-bad scenarios covered)
+
 ## Collective Approval
 
 The Divisor holds the ultimate authority to approve and merge code into the main branch. Approval requires collective consensus — **no outstanding REQUEST CHANGES from any persona** is mandatory. Gaze's functional validation serves as a prerequisite: the CI pipeline must be green before The Divisor begins review.
 
-This structure ensures that only code which passes all three lenses — intent, architecture, and resilience — is deployed.
+This structure ensures that only code which passes all five lenses — intent, architecture, resilience, operational readiness, and test quality — is deployed.
 
 ## How The Divisor Serves the Team
 
-**For Developers (Cobalt-Crush):** Cobalt-Crush relies on The Divisor for the final technical sign-off. The multi-faceted feedback from the three personas provides a holistic critique covering intent, structure, security, and robustness. Clear architectural standards minimize uncertainty, allowing Cobalt-Crush to code with confidence.
+**For Developers (Cobalt-Crush):** Cobalt-Crush relies on The Divisor for the final technical sign-off. The multi-faceted feedback from the five personas provides a holistic critique covering intent, structure, security, operational readiness, and test quality. Clear architectural standards minimize uncertainty, allowing Cobalt-Crush to code with confidence.
 
 **For the Tester (Gaze):** Gaze relies on The Divisor to establish the architectural and non-functional requirements against which testability must be measured. Gaze's green light on functional tests is the entry criterion for The Divisor's review, ensuring review time is spent on high-level risk and structure rather than defect finding.
 

--- a/specs/010-v050-docs-sync/checklists/requirements.md
+++ b/specs/010-v050-docs-sync/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: v0.5.0 Documentation Sync
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The spec references specific file names (e.g., `common-workflows.md`, `team/the-divisor.md`) because this is a documentation update -- these are the content being modified, not implementation details.
+- FR-014 and FR-015 reference `npm run build` and dark mode rendering as validation steps, which is appropriate for a static site documentation change (these are the project's equivalent of "tests pass").
+- The assumption about `mxf` CLI bundling vs. separate formula should be verified during planning by checking the v0.5.0 setup.go source.

--- a/specs/010-v050-docs-sync/plan.md
+++ b/specs/010-v050-docs-sync/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: v0.5.0 Documentation Sync
+
+**Branch**: `010-v050-docs-sync` | **Date**: 2026-03-26 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/010-v050-docs-sync/spec.md`
+
+## Summary
+
+Synchronize the Unbound Force website documentation with changes introduced in the upstream `unbound-force` repository between v0.4.0 and v0.5.0. This is a content-only change affecting Markdown files and one HTML template. Key updates: expanded `uf setup` documentation (16 steps), new workflow commands (`/workflow seed`, `/workflow start` flags, `.unbound-force/config.yaml`), corrected Divisor persona count (3 → 5), embedding model alignment documentation, branch convention documentation, and Dewey MCP tool count reconciliation.
+
+## Technical Context
+
+**Language/Version**: Hugo (Go-based SSG) via `@thulite` npm packages; Node.js >= 20.11.0; Go >= 1.23  
+**Primary Dependencies**: `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`  
+**Storage**: N/A (static Markdown files)  
+**Testing**: Manual -- `npm run build` must succeed; visual verification in dev server  
+**Target Platform**: GitHub Pages (static site)  
+**Project Type**: Static documentation website  
+**Performance Goals**: N/A (build-time only)  
+**Constraints**: All content must follow Doks/Hugo conventions; Markdown frontmatter required; start body with H2  
+**Scale/Scope**: ~10 Markdown files + 1 HTML template modified
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### I. Content Accuracy -- PASS
+
+This feature exists specifically to bring website content into alignment with the v0.5.0 upstream repository. Every change is sourced from the actual v0.5.0 codebase (`setup.go`, `scaffold.go`, `unbound-force.md`, agent files, Dewey README). No features are fabricated or overstated.
+
+### II. Minimal Footprint -- PASS
+
+All changes are Markdown content updates and one HTML template update (Divisor description). No new dependencies, no custom CSS, no new layouts, no JavaScript. The Doks theme handles all rendering.
+
+### III. Visitor Clarity -- PASS
+
+Updates improve visitor clarity by:
+
+- Making setup documentation match actual tool behavior (users get what the docs describe)
+- Documenting commands users need to invoke new capabilities
+- Resolving cross-page inconsistencies (Divisor persona count, Dewey tool count)
+- Adding embedding alignment instructions users need for optimal operation
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-v050-docs-sync/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+content/docs/getting-started/
+├── _index.md               # Minor -- no changes needed (already updated in spec 009)
+├── common-workflows.md     # Major -- setup section, workflow commands, config, branch conventions
+├── developer.md            # Medium -- uf setup description, branch conventions
+├── product-owner.md        # Medium -- /workflow seed command
+├── knowledge.md            # Medium -- embedding alignment env vars
+├── tester.md               # No changes expected
+└── product-manager.md      # No changes expected
+
+content/docs/team/
+├── _index.md               # Minor -- Divisor persona count fix
+├── the-divisor.md          # Major -- 3 personas → 5 personas
+└── dewey.md                # Minor -- MCP tool count reconciliation
+
+content/docs/projects/
+├── dewey.md                # Minor -- MCP tool count reconciliation
+└── _index.md               # Minor -- no changes needed (already accurate)
+
+layouts/
+└── home.html               # No changes expected
+```
+
+**Structure Decision**: Content-only updates to existing Markdown files. No new files created in the content tree. No new directories. No layout or style changes.
+
+## File Change Matrix
+
+| File                                               | Priority | FRs Covered                                            | Change Summary                                                                                 |
+| -------------------------------------------------- | -------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `content/docs/getting-started/common-workflows.md` | P1       | FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-010 | Rewrite setup section; add workflow command docs; add config file docs; add branch conventions |
+| `content/docs/getting-started/developer.md`        | P1       | FR-012, FR-010                                         | Update uf setup description; add branch convention note                                        |
+| `content/docs/getting-started/product-owner.md`    | P1       | FR-013                                                 | Add `/workflow seed` command reference                                                         |
+| `content/docs/getting-started/knowledge.md`        | P2       | FR-009                                                 | Add embedding alignment env vars section                                                       |
+| `content/docs/team/the-divisor.md`                 | P2       | FR-007                                                 | Rewrite council section: 3 → 5 personas with descriptions                                      |
+| `content/docs/team/_index.md`                      | P2       | FR-008                                                 | Fix Divisor description: "three" → "five" personas                                             |
+| `content/docs/team/dewey.md`                       | P3       | FR-011                                                 | Fix MCP tool count to "40 tools across 10 categories"                                          |
+| `content/docs/projects/dewey.md`                   | P3       | FR-011                                                 | Fix MCP tool count to "40 tools across 10 categories"                                          |
+
+## Complexity Tracking
+
+No constitution violations. No complexity tracking needed.

--- a/specs/010-v050-docs-sync/quickstart.md
+++ b/specs/010-v050-docs-sync/quickstart.md
@@ -1,0 +1,54 @@
+# Quickstart: v0.5.0 Documentation Sync
+
+## Overview
+
+Update 8 Markdown files and verify consistency across the website to reflect v0.5.0 upstream changes.
+
+## Implementation Order
+
+Work through files in dependency order -- pages that other pages link to should be updated first.
+
+### Phase 1: Setup and Workflow Docs (P1)
+
+These pages are the foundation -- other pages reference them.
+
+1. **`common-workflows.md`** -- The most changes. Update:
+   - Environment Setup section (uf setup steps, uf init behavior, Dewey now included)
+   - Add `/workflow seed` and `/workflow start` flag documentation
+   - Add `.unbound-force/config.yaml` documentation
+   - Add `opsx/` branch convention to OpenSpec section
+   - Add embedding alignment env vars note
+
+2. **`developer.md`** -- Update uf setup description and add branch convention note.
+
+3. **`product-owner.md`** -- Add `/workflow seed` command reference.
+
+### Phase 2: Team and Knowledge Pages (P2)
+
+4. **`team/the-divisor.md`** -- Rewrite council section (3 → 5 personas).
+
+5. **`team/_index.md`** -- Fix "three" → "five" in Divisor description.
+
+6. **`knowledge.md`** -- Add embedding model alignment section.
+
+### Phase 3: Consistency Fixes (P3)
+
+7. **`team/dewey.md`** -- Fix MCP tool count.
+
+8. **`projects/dewey.md`** -- Fix MCP tool count.
+
+## Verification
+
+After all changes:
+
+```bash
+npm run build          # Must succeed with zero errors
+npm run dev            # Visual check: all updated pages render correctly
+```
+
+Cross-page consistency checks:
+
+- Search for "sub-persona" / "persona" counts -- all must say "five"
+- Search for MCP tool counts -- all must say "40 tools across 10 categories"
+- Search for "uf setup" descriptions -- all must reflect v0.5.0 behavior
+- Verify all internal links still resolve

--- a/specs/010-v050-docs-sync/research.md
+++ b/specs/010-v050-docs-sync/research.md
@@ -1,0 +1,192 @@
+# Research: v0.5.0 Documentation Sync
+
+**Date**: 2026-03-26  
+**Feature**: [spec.md](spec.md) | [plan.md](plan.md)
+
+## R1: `uf setup` Step Inventory (v0.5.0)
+
+**Decision**: Document `uf setup` as performing the following steps in order.
+
+**Source**: `internal/setup/setup.go` at tag v0.5.0.
+
+Before any steps, `uf setup` sets environment variables `OLLAMA_MODEL=granite-embedding:30m` and `OLLAMA_EMBED_DIM=256` for child processes.
+
+| Step | Tool / Action                | Install Method                                                                          |
+| ---- | ---------------------------- | --------------------------------------------------------------------------------------- |
+| 1    | OpenCode (AI coding agent)   | Homebrew (`brew install anomalyco/tap/opencode`), fallback curl                         |
+| 2    | Gaze (quality analysis)      | Homebrew (`brew install unbound-force/tap/gaze`)                                        |
+| 3    | Mx F (manager hero)          | Homebrew (`brew install unbound-force/tap/mxf`)                                         |
+| 4    | GitHub CLI (`gh`)            | Homebrew (`brew install gh`)                                                            |
+| 5    | Node.js (>= 18)              | nvm, fnm, or Homebrew                                                                   |
+| 6    | Bun (JS runtime)             | npm (`npm install -g bun`)                                                              |
+| 7    | OpenSpec CLI                 | Bun preferred (`bun add -g @fission-ai/openspec@latest`), fallback npm                  |
+| 8    | Swarm plugin                 | Bun preferred (`bun add -g opencode-swarm-plugin@latest`), fallback npm                 |
+| 9    | Run `swarm setup`            | Subprocess                                                                              |
+| 10   | Configure `opencode.json`    | Direct file write (adds Swarm plugin)                                                   |
+| 11   | Initialize `.hive/`          | `swarm init` subprocess                                                                 |
+| 12   | Ollama (local model runtime) | Homebrew (`brew install ollama`)                                                        |
+| 13   | Dewey + embedding model      | Homebrew (`brew install unbound-force/tap/dewey`) + `ollama pull granite-embedding:30m` |
+| 14   | Initialize `.dewey/`         | `dewey init` subprocess                                                                 |
+| 15   | Build Dewey index            | `dewey index` subprocess                                                                |
+| 16   | Run `uf init` (scaffold)     | In-process function call                                                                |
+
+After completion, setup advises adding to shell profile:
+
+```
+export OLLAMA_MODEL=granite-embedding:30m
+export OLLAMA_EMBED_DIM=256
+```
+
+**Rationale**: The website currently lists 7 actions. The v0.5.0 setup performs 16 steps. The documentation must reflect all 16 steps accurately.
+
+**Documentation approach**: The website should NOT list all 16 internal steps (too granular for a website audience). Instead, group them into user-visible categories:
+
+- Core tools (OpenCode, Gaze, Mx F, GitHub CLI)
+- Development tools (Node.js, Bun, OpenSpec CLI, Swarm plugin)
+- Knowledge layer (Ollama, Dewey, embedding model, Dewey initialization)
+- Project scaffolding (`uf init`)
+
+**Alternatives considered**: Listing all 16 steps individually was rejected as too implementation-focused for a website audience (Constitution III: Visitor Clarity).
+
+## R2: `uf init` Expanded Behavior (v0.5.0)
+
+**Decision**: Document that `uf init` now performs sub-tool initialization after file scaffolding.
+
+**Source**: `internal/scaffold/scaffold.go` at tag v0.5.0.
+
+New `initSubTools()` behavior:
+
+1. Creates `.unbound-force/config.yaml` (workflow configuration file) -- skipped if already exists
+2. Runs `dewey init` + `dewey index` if Dewey binary is available and `.dewey/` doesn't exist
+
+The config file contains commented-out defaults for workflow execution modes and spec review settings.
+
+**Rationale**: Users need to know that `uf init` creates the config file so they can customize it. The Dewey initialization is a convenience -- it runs automatically when Dewey is available.
+
+## R3: Dewey MCP Tool Count
+
+**Decision**: Use "40 tools across 10 categories" as the canonical count.
+
+**Source**: Dewey README.md (authoritative) states "40 tools across 10 categories." Actual tool tables enumerate 41 distinct tools (one tool was added after the header was written). `server.go` confirms 41 registrations plus a `reload` utility.
+
+The 10 categories are: Navigate (6), Search (4), Analyze (5), Write (10), Decision (5), Journal (2), Flashcard (3), Whiteboard (2), Semantic Search (3), Health (1).
+
+**Rationale**: The README header is the authoritative human-facing statement. The 41 vs 40 discrepancy is minor and internal to the Dewey project. The website should use the README's stated number. The graphthulhu heritage "37 tools" number is historical and should be removed or contextualized.
+
+**Alternatives considered**: Using "41 tools" was rejected because the Dewey README itself says 40. Using "40+" was rejected as imprecise. Using "37" (graphthulhu original) was rejected as outdated.
+
+**Current website inconsistencies to fix**:
+
+- `projects/dewey.md`: "preserving all 37 existing MCP tools" → update to reflect current count; "40 MCP Tools Across 9 Categories" → "40 MCP Tools Across 10 Categories"
+- `team/dewey.md`: "40+ MCP tools across 10 categories" → "40 MCP tools across 10 categories"
+
+## R4: The Divisor Sub-Personas (v0.5.0)
+
+**Decision**: Document five sub-personas with the following details.
+
+**Source**: `unbound-force.md` and `.opencode/agents/divisor-*.md` at tag v0.5.0.
+
+| Persona            | Subtitle                             | Focus                                                         | Agent File             |
+| ------------------ | ------------------------------------ | ------------------------------------------------------------- | ---------------------- |
+| The Guard          | Intent and Cohesion                  | The "Why" -- intent drift, constitution alignment, zero-waste | `divisor-guard.md`     |
+| The Architect      | Structure and Sustainability         | The "How" -- conventions, patterns, plan alignment, DRY       | `divisor-architect.md` |
+| The Adversary      | Resilience and Security              | "Where it Breaks" -- error handling, security, efficiency     | `divisor-adversary.md` |
+| The Operator (SRE) | Deployment and Operational Readiness | Shipping and running -- pipelines, config, observability      | `divisor-sre.md`       |
+| The Tester         | Test Quality and Testability         | Observable quality -- coverage, assertion depth, isolation    | `divisor-testing.md`   |
+
+Key details for each persona (for the team page):
+
+**The Guard** -- Ensures the business value remains intact. Detects intent drift from the specification, verifies constitution alignment, enforces the Zero-Waste Mandate (no unused code or spec artifacts), and applies the Neighborhood Rule (changes to shared standards must not break adjacent modules).
+
+**The Architect** -- Verifies code is clean, sustainable, and aligned with the approved plan. Enforces architectural patterns, coding conventions from convention packs, DRY principles, and plan consistency. Provides an Architectural Alignment Score (1-10).
+
+**The Adversary** -- Skeptical auditor that finds where code breaks under stress. Covers error handling, security vulnerabilities (hardcoded secrets, injection vectors, path traversal), performance bottlenecks, and test safety. Universal security checks always run regardless of convention pack.
+
+**The Operator (SRE)** -- Ensures the code is deployable, maintainable, and operable. Reviews release pipeline integrity, dependency health, configuration hygiene, runtime observability (exit codes, error messages), upgrade paths, and operational documentation.
+
+**The Tester** -- Ensures tests are meaningful, not just present. Reviews test architecture (arrange/act/assert), coverage strategy (contract surface, not just line coverage), assertion depth (specific values, not just "no error"), test isolation, and regression protection.
+
+**Rationale**: The website's `team/the-divisor.md` page describes only 3 personas (Guard, Architect, Adversary). The v0.5.0 source has 5 agent files and explicitly states "five canonical roles." The team page must be updated to match.
+
+**Note on naming**: `unbound-force.md` uses "SRE" for the fourth persona, but the agent file (`divisor-sre.md`) titles it "The Operator." The website should use "SRE" as the primary label with "(The Operator)" as a subtitle, matching the upstream naming convention used in the roster description.
+
+## R5: Embedding Model Alignment
+
+**Decision**: Document the `OLLAMA_MODEL` and `OLLAMA_EMBED_DIM` environment variables.
+
+**Source**: `internal/setup/setup.go` at tag v0.5.0; `AGENTS.md` "Embedding Model Alignment" section.
+
+v0.5.0 aligns the swarm (via Swarm plugin) and Dewey on IBM Granite Embedding:
+
+- Model: `granite-embedding:30m`
+- Embedding dimension: `256`
+- License: Apache 2.0
+
+Environment variables to add to shell profile:
+
+```bash
+export OLLAMA_MODEL=granite-embedding:30m
+export OLLAMA_EMBED_DIM=256
+```
+
+**Rationale**: Without these variables, child processes spawned outside of `uf setup` (e.g., `dewey serve`, `swarm init`) may use different embedding models, causing search quality inconsistencies.
+
+**Documentation approach**: Add a brief section to the knowledge retrieval page (`knowledge.md`) explaining the alignment requirement and the two environment variables. Also mention in the setup section of `common-workflows.md` as a post-setup step.
+
+## R6: Branch Conventions
+
+**Decision**: Document `opsx/<change-name>` branch naming in user-facing content.
+
+**Source**: `.opencode/command/opsx-propose.md`, `.opencode/command/opsx-apply.md`, `.opencode/command/opsx-archive.md` at tag v0.5.0; `AGENTS.md` "Branch Conventions" section.
+
+Behavior:
+
+- `/opsx-propose <name>` creates and checks out an `opsx/<name>` branch (guard: skips if already on correct branch, errors if on different `opsx/*` branch)
+- `/opsx-apply` validates you're on the correct `opsx/<name>` branch before proceeding (hard gate)
+- `/opsx-archive` returns to `main` branch after archiving
+
+The `opsx/` prefix ensures visual distinction from Speckit branches (`NNN-<short-name>`) in `git branch` output.
+
+**Rationale**: This is a behavioral change that affects the developer's daily workflow. If a developer tries `/opsx-apply` on the wrong branch, it will error. They need to know this.
+
+**Documentation approach**: Add a brief note in the bug fix / OpenSpec section of `common-workflows.md` mentioning branch creation and validation. Also add to `developer.md` under the Speckit vs OpenSpec section.
+
+## R7: `/workflow seed` and `/workflow start` Commands
+
+**Decision**: Document these commands and the `.unbound-force/config.yaml` configuration file.
+
+**Source**: `.opencode/command/workflow-seed.md`, `unbound-force.md`, and `internal/orchestration/config.go` at tag v0.5.0.
+
+**`/workflow seed`**: Convenience command that creates a backlog item and starts a workflow with `define=swarm` in one operation. Usage: `/workflow seed "description" [--spec-review]`.
+
+**`/workflow start`**: Existing command with new flags:
+
+- `--define-mode=human|swarm` (default: human)
+- `--spec-review` (default: false)
+
+**`.unbound-force/config.yaml`**: Project-level defaults:
+
+```yaml
+workflow:
+  execution_modes:
+    define: swarm # or "human" (default)
+  spec_review: false
+```
+
+Merge semantics: Config values are the base; CLI flags override. For spec review, OR logic applies (either config or CLI being true enables it).
+
+**Rationale**: The website already describes the seed concept narratively (from spec 009) but doesn't mention the commands. Users need the actual invocation syntax.
+
+**Documentation approach**: Add command reference to `common-workflows.md` in the Swarm Delegation section. Add `/workflow seed` reference to `product-owner.md` alongside the seed narrative. Add config file documentation to `common-workflows.md`.
+
+## R8: `mxf` CLI Installation
+
+**Decision**: Document Mx F as a separate Homebrew formula installed by `uf setup`.
+
+**Source**: `internal/setup/setup.go` at tag v0.5.0, line 346: `brew install unbound-force/tap/mxf`.
+
+The `mxf` binary is NOT bundled with the `uf` CLI. It is a separate Homebrew formula (`unbound-force/tap/mxf`) installed as step 3 of `uf setup`.
+
+**Rationale**: The website's `product-manager.md` page currently says "Install via Homebrew (included with the `unbound-force` package, the `uf` CLI)." This is inaccurate -- `mxf` is a separate formula. However, since `uf setup` installs it automatically, the practical user experience doesn't change. The documentation should note that `uf setup` handles the installation.
+
+**Documentation approach**: Update the install note in `product-manager.md` if it conflicts, but since `uf setup` handles everything, the primary fix is in the setup documentation itself.

--- a/specs/010-v050-docs-sync/spec.md
+++ b/specs/010-v050-docs-sync/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: v0.5.0 Documentation Sync
+
+**Feature Branch**: `010-v050-docs-sync`  
+**Created**: 2026-03-26  
+**Status**: Draft  
+**Input**: User description: "Update website documentation to reflect v0.5.0 changes from the unbound-force upstream repository"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Setup Documentation Reflects Full Toolchain (Priority: P1)
+
+A new user reads the environment setup section of the website to install and configure the Unbound Force swarm. The setup documentation must accurately describe what `uf setup` installs (now 16 steps including Mx F, GitHub CLI, OpenSpec CLI, Ollama, and Dewey initialization) so the user understands what to expect and does not need to install tools manually that are already handled by setup.
+
+**Why this priority**: Incorrect setup documentation is the most damaging gap -- new users following outdated instructions will have a different experience than described, eroding trust immediately. The website currently describes 7 actions for `uf setup` when v0.5.0 performs 16 steps. It also presents Dewey and Ollama as separate manual installations when they are now included in setup.
+
+**Independent Test**: Can be fully tested by reading the setup section and comparing each described step against the actual `uf setup` output in v0.5.0. The documentation must match the actual tool behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user reading the environment setup section, **When** they follow the documented `uf setup` steps, **Then** every tool installed by v0.5.0's setup is mentioned in the documentation (OpenCode, Gaze, Swarm plugin, Mx F, GitHub CLI, OpenSpec CLI, Ollama, Dewey init, Dewey index, project scaffolding via `uf init`).
+2. **Given** a user reading the environment setup section, **When** they look for Dewey installation instructions, **Then** the documentation explains that `uf setup` now handles Dewey and Ollama installation automatically, with manual installation only needed for projects where `uf setup` was run before v0.5.0.
+3. **Given** a user reading the environment setup section, **When** they look for `uf init` behavior, **Then** the documentation explains that `uf init` now creates `.unbound-force/config.yaml` and runs `dewey init` + `dewey index` when Dewey is available.
+
+---
+
+### User Story 2 - Workflow Commands and Configuration Documented (Priority: P1)
+
+A user reads the common workflows or product owner pages to understand how to start a feature workflow. The documentation must describe the new `/workflow seed` command, the `--define-mode` and `--spec-review` flags on `/workflow start`, and the project-level `.unbound-force/config.yaml` configuration file, so the user knows how to control autonomous vs. manual define behavior.
+
+**Why this priority**: These are the primary new capabilities in v0.5.0. The website already describes the seed concept and autonomous define in narrative form (from spec 009), but does not document the actual commands and configuration that users need to invoke these capabilities. Without this, users understand the concept but cannot execute it.
+
+**Independent Test**: Can be tested by searching the website for `/workflow seed`, `/workflow start`, `--define-mode`, `--spec-review`, and `.unbound-force/config.yaml` -- all must appear with accurate descriptions of their behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user reading the common workflows page, **When** they look for how to seed a feature, **Then** they find the `/workflow seed` command with usage syntax and a description of what it does (creates a backlog item and starts a workflow with `define=swarm` in one operation).
+2. **Given** a user reading the common workflows page, **When** they look for workflow configuration, **Then** they find documentation of `/workflow start` with `--define-mode=human|swarm` and `--spec-review` flags, plus the `.unbound-force/config.yaml` file for setting project-level defaults.
+3. **Given** a user reading the product owner page, **When** they look for how to seed a feature, **Then** they find the `/workflow seed` command referenced alongside the seed concept already documented there.
+
+---
+
+### User Story 3 - The Divisor Accurately Described as Five Personas (Priority: P2)
+
+A user reads the team page for The Divisor to understand the review council structure. The documentation must accurately describe five sub-personas (Guard, Architect, Adversary, Testing, SRE) rather than three, matching the v0.5.0 upstream definition.
+
+**Why this priority**: The team page and team index currently describe only three sub-personas, contradicting the getting-started guides which already reference five. This inconsistency confuses users about the review council's actual structure. The fix is straightforward but important for factual accuracy.
+
+**Independent Test**: Can be tested by reading `team/the-divisor.md` and `team/_index.md` and verifying they describe five personas matching the v0.5.0 `unbound-force.md` source document.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user reading the Divisor team page, **When** they look at the council structure, **Then** they see five sub-personas listed: Guard (Intent and Cohesion), Architect (Structure and Sustainability), Adversary (Resilience and Security), Testing (Test Quality and Coverage), and SRE (Operational Readiness).
+2. **Given** a user reading the team index page, **When** they see The Divisor's description, **Then** it references five sub-personas instead of three.
+3. **Given** a user reading any page on the site that mentions The Divisor's personas, **When** they compare across pages, **Then** the persona count and names are consistent everywhere.
+
+---
+
+### User Story 4 - Embedding Model Alignment Documented (Priority: P2)
+
+A user configures their environment for optimal semantic search performance. The documentation must explain that v0.5.0 aligns the swarm and Dewey on IBM Granite Embedding (`granite-embedding:30m`) and that users should set `OLLAMA_MODEL` and `OLLAMA_EMBED_DIM` environment variables in their shell profile.
+
+**Why this priority**: Without these environment variables, users may experience degraded or inconsistent embedding behavior. The website already documents Granite as the model but does not mention the alignment requirement or the environment variables.
+
+**Independent Test**: Can be tested by searching the knowledge retrieval or environment setup pages for `OLLAMA_MODEL` and `OLLAMA_EMBED_DIM` environment variable documentation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user reading the environment setup or knowledge retrieval pages, **When** they look for embedding model configuration, **Then** they find instructions to add `export OLLAMA_MODEL=granite-embedding:30m` and `export OLLAMA_EMBED_DIM=256` to their shell profile.
+2. **Given** a user who has already installed Dewey, **When** they read the embedding alignment section, **Then** they understand why these variables are needed (swarm and Dewey alignment on the same model).
+
+---
+
+### User Story 5 - Branch Conventions in User-Facing Docs (Priority: P3)
+
+A developer reads the workflow documentation to understand how feature branches are managed. The documentation must describe the `opsx/<change-name>` branch naming convention for OpenSpec workflows and the branch enforcement behavior (automatic creation on `/opsx-propose`, validation on `/opsx-apply`).
+
+**Why this priority**: This is a new v0.5.0 workflow enforcement that affects the developer's daily experience. While the information exists in AGENTS.md, it is absent from user-facing content pages where developers would look for it.
+
+**Independent Test**: Can be tested by reading the developer guide or common workflows page for branch naming conventions and verifying `opsx/` branch documentation is present.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reading the bug fix / OpenSpec workflow section, **When** they look for how branches work, **Then** they see that `/opsx-propose` creates an `opsx/<change-name>` branch and `/opsx-apply` validates the current branch before proceeding.
+
+---
+
+### User Story 6 - Dewey MCP Tool Count Consistency (Priority: P3)
+
+A user compares the Dewey project page and team page. The MCP tool counts and category counts must be consistent across all pages that reference them.
+
+**Why this priority**: Inconsistent numbers (37, 40, 40+ tools; 9 vs 10 categories) undermine credibility. The fix is small but addresses a pre-existing inconsistency that should be reconciled against the v0.5.0 Dewey repository.
+
+**Independent Test**: Can be tested by searching the site for mentions of MCP tool counts and verifying they all state the same number.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user reading any page that mentions Dewey's MCP tool count, **When** they compare across pages, **Then** all pages report the same number of tools and categories.
+
+---
+
+### Edge Cases
+
+- What happens when the website references v0.5.0 features that require Dewey but the user does not have Dewey? Documentation must clearly indicate fallback behavior for every Dewey-dependent feature.
+- What happens when a user has a pre-v0.5.0 `uf setup` installation? The setup documentation should note that existing installations can re-run `uf setup` to pick up new tools.
+- What happens when a user reads the Divisor team page after reading the getting-started guides? The persona count must be consistent to avoid confusion.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The environment setup section of `common-workflows.md` MUST list all tools installed by `uf setup` in v0.5.0 (OpenCode, Gaze, Swarm plugin, Mx F, GitHub CLI, OpenSpec CLI, Ollama, Dewey initialization, project scaffolding).
+- **FR-002**: The environment setup section MUST explain that Dewey and Ollama are now installed automatically by `uf setup`, replacing the separate manual installation step.
+- **FR-003**: The environment setup section MUST document that `uf init` now creates `.unbound-force/config.yaml` and runs `dewey init` + `dewey index` when Dewey is available.
+- **FR-004**: The common workflows page MUST document the `/workflow seed` command with usage syntax and behavior description.
+- **FR-005**: The common workflows page MUST document the `/workflow start` command's `--define-mode=human|swarm` and `--spec-review` flags.
+- **FR-006**: The common workflows or product owner page MUST document the `.unbound-force/config.yaml` project-level workflow configuration file, including its structure and merge semantics with CLI flags.
+- **FR-007**: The `team/the-divisor.md` page MUST describe five sub-personas: Guard, Architect, Adversary, Testing, and SRE.
+- **FR-008**: The `team/_index.md` page MUST reference five sub-personas for The Divisor instead of three.
+- **FR-009**: The knowledge retrieval or environment setup page MUST document the `OLLAMA_MODEL=granite-embedding:30m` and `OLLAMA_EMBED_DIM=256` environment variables for embedding model alignment.
+- **FR-010**: The developer guide or common workflows page MUST document the `opsx/<change-name>` branch naming convention and branch enforcement behavior for OpenSpec workflows.
+- **FR-011**: All pages referencing Dewey's MCP tool count MUST use a consistent number of tools and categories, reconciled against the v0.5.0 Dewey repository.
+- **FR-012**: The `developer.md` page MUST update its description of what `uf setup` installs to match v0.5.0 behavior.
+- **FR-013**: The `product-owner.md` page MUST reference the `/workflow seed` command alongside the existing seed narrative.
+- **FR-014**: All documentation changes MUST pass `npm run build` without errors.
+- **FR-015**: All documentation changes MUST render correctly in both light and dark mode.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Every tool installed by `uf setup` in v0.5.0 is documented on the website -- zero undocumented tools.
+- **SC-002**: Every new command or flag introduced in v0.5.0 (`/workflow seed`, `--define-mode`, `--spec-review`, `.unbound-force/config.yaml`) appears on at least one user-facing documentation page.
+- **SC-003**: The Divisor persona count is consistent across all pages -- five personas everywhere, zero contradictions.
+- **SC-004**: Dewey MCP tool counts are identical across all pages that reference them.
+- **SC-005**: `npm run build` succeeds with zero errors after all documentation changes.
+- **SC-006**: Zero cross-page factual contradictions remain in the documentation (verified by cross-referencing key claims across all updated pages).
+
+## Clarifications
+
+### Session 2026-03-26
+
+- Q: Is `mxf` bundled with the `uf` CLI or a separate Homebrew formula? → A: Separate formula (`unbound-force/tap/mxf`), verified in v0.5.0 `setup.go`.
+
+## Assumptions
+
+- The v0.5.0 `unbound-force.md` and agent files are the authoritative source for persona descriptions, tool capabilities, and workflow behavior.
+- The Dewey MCP tool count should be reconciled against the actual Dewey v0.5.0 codebase or README, not assumed from any single website page.
+- The `mxf` CLI is a separate Homebrew formula (`brew install unbound-force/tap/mxf`), not bundled with the `uf` CLI. Verified against v0.5.0 `setup.go` -- `uf setup` installs it as a distinct step via `brew install unbound-force/tap/mxf`.
+- The OpenSpec CLI (`@fission-ai/openspec@latest`) is a separate npm/bun package installed by `uf setup`, not bundled with `uf`.
+- The website's primary audience is developers and technical product owners who will use these commands directly.

--- a/specs/010-v050-docs-sync/tasks.md
+++ b/specs/010-v050-docs-sync/tasks.md
@@ -1,0 +1,219 @@
+# Tasks: v0.5.0 Documentation Sync
+
+**Input**: Design documents from `/specs/010-v050-docs-sync/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, quickstart.md
+
+**Tests**: No automated tests -- this is a static documentation site. Validation is `npm run build` + visual verification.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No setup needed -- all target files already exist. This is a content-only update to existing Markdown files.
+
+_(No tasks in this phase)_
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No foundational blocking work. All user stories modify independent files and can proceed immediately. The only cross-cutting concern is that `common-workflows.md` is modified by multiple stories, but the changes target different sections of the file.
+
+_(No tasks in this phase)_
+
+**Checkpoint**: All user stories can begin immediately.
+
+---
+
+## Phase 3: User Story 1 - Setup Documentation Reflects Full Toolchain (Priority: P1)
+
+**Goal**: Update `uf setup` documentation to accurately reflect the v0.5.0 16-step setup process, update `uf init` documentation, and consolidate the Dewey/Ollama installation into the setup flow.
+
+**Independent Test**: Read the environment setup section of `common-workflows.md` and `developer.md` and verify every tool from research.md R1 is mentioned. Verify the separate "Install Dewey" step is replaced with a note that `uf setup` now handles it.
+
+### Implementation for User Story 1
+
+- [x] T001 [US1] Rewrite the "2. Run Setup" section in content/docs/getting-started/common-workflows.md to list all tools installed by v0.5.0's `uf setup`, grouped into categories: core tools (OpenCode, Gaze, Mx F, GitHub CLI), development tools (Node.js, Bun, OpenSpec CLI, Swarm plugin + config), knowledge layer (Ollama, Dewey, embedding model, Dewey initialization), and project scaffolding (`uf init`). Source: research.md R1.
+- [x] T002 [US1] Replace the separate "3. Install Dewey" section in content/docs/getting-started/common-workflows.md with a note explaining that `uf setup` now handles Dewey and Ollama installation automatically. Keep a brief mention that for pre-v0.5.0 installations, users can re-run `uf setup` to pick up new tools. Add the embedding alignment env vars (`OLLAMA_MODEL`, `OLLAMA_EMBED_DIM`) as a post-setup shell profile step. Renumber subsequent sections (current "4. Verify" becomes "3. Verify", current "5. Start Working" becomes "4. Start Working").
+- [x] T003 [US1] Add a brief note after the setup section in content/docs/getting-started/common-workflows.md explaining that `uf init` (run as the final step of setup) now creates `.unbound-force/config.yaml` for workflow configuration and initializes Dewey when available. Source: research.md R2.
+- [x] T004 [P] [US1] Update the `uf setup` description in content/docs/getting-started/developer.md (currently lists 4 things: OpenCode, Gaze, Swarm plugin, project scaffolding) to match v0.5.0 behavior. Add Mx F, GitHub CLI, OpenSpec CLI, Ollama, and Dewey to the list. Keep it concise -- this is a summary, not the full breakdown. Source: research.md R1.
+
+**Checkpoint**: Setup documentation accurately reflects v0.5.0. `npm run build` passes.
+
+---
+
+## Phase 4: User Story 2 - Workflow Commands and Configuration Documented (Priority: P1)
+
+**Goal**: Document the `/workflow seed` command, `/workflow start` flags, and `.unbound-force/config.yaml` configuration file so users can invoke the autonomous define capabilities.
+
+**Independent Test**: Search `common-workflows.md` and `product-owner.md` for `/workflow seed`, `--define-mode`, `--spec-review`, and `.unbound-force/config.yaml` -- all must appear with accurate descriptions.
+
+### Implementation for User Story 2
+
+- [x] T005 [US2] Add a "Workflow Commands" subsection to the "Swarm Delegation" section in content/docs/getting-started/common-workflows.md documenting: (a) `/workflow seed "description" [--spec-review]` -- creates a backlog item and starts a workflow with define=swarm in one operation; (b) `/workflow start --define-mode=human|swarm --spec-review` -- starts a workflow with explicit mode selection. Source: research.md R7.
+- [x] T006 [US2] Add a "Workflow Configuration" subsection after the Workflow Commands in content/docs/getting-started/common-workflows.md documenting `.unbound-force/config.yaml`: show the YAML structure (`workflow.execution_modes.define`, `workflow.spec_review`), explain that config values are defaults and CLI flags override, and note that the file is created by `uf init` with all values commented out. Source: research.md R7.
+- [x] T007 [P] [US2] Add a `/workflow seed` command reference to content/docs/getting-started/product-owner.md in the "Stage 1: Seed" section. After the seed examples, add a brief command reference showing the syntax: `/workflow seed "description" [--spec-review]`. Note that this is a convenience command equivalent to creating a backlog item + `/workflow start --define-mode=swarm`. Source: research.md R7.
+
+**Checkpoint**: All workflow commands and configuration are documented. `npm run build` passes.
+
+---
+
+## Phase 5: User Story 3 - The Divisor Accurately Described as Five Personas (Priority: P2)
+
+**Goal**: Update The Divisor team page and team index to accurately describe five sub-personas instead of three.
+
+**Independent Test**: Read `team/the-divisor.md` and `team/_index.md` and verify five personas are listed. Cross-reference against `common-workflows.md` (already has five) to ensure consistency.
+
+### Implementation for User Story 3
+
+- [x] T008 [US3] Rewrite the council section in content/docs/team/the-divisor.md to describe five sub-personas instead of three. Update: (a) the intro paragraph ("council of three" → "council of five dynamically discovered personas -- five canonical roles ship by default"); (b) keep the existing Guard, Architect, Adversary subsections with their current content; (c) add new subsections for "The Operator (SRE) -- Deployment and Operational Readiness" and "The Tester -- Test Quality and Testability" with descriptions from research.md R4; (d) update the "Collective Approval" section to reference "all five lenses" instead of "all three lenses"; (e) update the "How The Divisor Serves the Team" section's Cobalt-Crush paragraph to reference "five personas" instead of "three personas"; (f) update the frontmatter description to reference five sub-personas. Source: research.md R4.
+- [x] T009 [P] [US3] Update content/docs/team/\_index.md: change The Divisor's description from "council of three sub-personas -- The Guard, The Architect, and The Adversary" to "council of five sub-personas -- The Guard, The Architect, The Adversary, The Operator (SRE), and The Tester". Source: research.md R4.
+
+**Checkpoint**: The Divisor is consistently described as five personas across all pages. `npm run build` passes.
+
+---
+
+## Phase 6: User Story 4 - Embedding Model Alignment Documented (Priority: P2)
+
+**Goal**: Document the `OLLAMA_MODEL` and `OLLAMA_EMBED_DIM` environment variables for embedding model alignment between the swarm and Dewey.
+
+**Independent Test**: Search `knowledge.md` for `OLLAMA_MODEL` and `OLLAMA_EMBED_DIM` -- both must appear with shell profile instructions and an explanation of why alignment matters.
+
+### Implementation for User Story 4
+
+- [x] T010 [US4] Add an "Embedding Model Alignment" section to content/docs/getting-started/knowledge.md after the "Embedding Model" section. Explain that v0.5.0 aligns the swarm and Dewey on the same embedding model (IBM Granite `granite-embedding:30m`). Include the shell profile instructions: `export OLLAMA_MODEL=granite-embedding:30m` and `export OLLAMA_EMBED_DIM=256`. Explain that `uf setup` sets these during installation, but they must be in the shell profile for processes spawned outside of setup (e.g., `dewey serve`, manual `swarm init`). Source: research.md R5.
+
+**Checkpoint**: Embedding alignment is documented. `npm run build` passes.
+
+---
+
+## Phase 7: User Story 5 - Branch Conventions in User-Facing Docs (Priority: P3)
+
+**Goal**: Document the `opsx/<change-name>` branch naming convention and branch enforcement behavior for OpenSpec workflows.
+
+**Independent Test**: Read the bug fix / OpenSpec sections of `common-workflows.md` and `developer.md` for `opsx/` branch documentation.
+
+### Implementation for User Story 5
+
+- [x] T011 [US5] Add branch convention documentation to the "Bug Fix (Tactical)" / OpenSpec section of content/docs/getting-started/common-workflows.md. After the existing `/opsx-propose` description, add a note that `/opsx-propose` creates and checks out an `opsx/<name>` branch, `/opsx-apply` validates the current branch before proceeding (hard gate), and `/opsx-archive` returns to `main` after archiving. Mention the `opsx/` prefix ensures visual distinction from Speckit branches (`NNN-<short-name>`). Source: research.md R6.
+- [x] T012 [P] [US5] Add a brief branch convention note to content/docs/getting-started/developer.md under the "Speckit vs OpenSpec" section. Note that Speckit uses `NNN-<short-name>` branches (created by `/speckit.specify`) and OpenSpec uses `opsx/<change-name>` branches (created by `/opsx-propose`). Both enforce branch validation at each pipeline step. Source: research.md R6.
+
+**Checkpoint**: Branch conventions documented in user-facing content. `npm run build` passes.
+
+---
+
+## Phase 8: User Story 6 - Dewey MCP Tool Count Consistency (Priority: P3)
+
+**Goal**: Reconcile Dewey MCP tool counts across all pages to use the canonical "40 tools across 10 categories" from the Dewey README.
+
+**Independent Test**: Search the entire site for MCP tool count mentions and verify consistency.
+
+### Implementation for User Story 6
+
+- [x] T013 [P] [US6] Fix MCP tool count in content/docs/team/dewey.md: change "40+ MCP tools across 10 categories" to "40 MCP tools across 10 categories" (remove the "+"). Source: research.md R3.
+- [x] T014 [P] [US6] Fix MCP tool count in content/docs/projects/dewey.md: (a) update "preserving all 37 existing MCP tools" to contextualize the graphthulhu heritage while noting the current count; (b) change "40 MCP Tools Across 9 Categories" heading to "40 MCP Tools Across 10 Categories". Source: research.md R3.
+
+**Checkpoint**: All MCP tool count references are consistent. `npm run build` passes.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Build verification, cross-page consistency validation, and visual check.
+
+- [x] T015 Run `npm run build` and verify zero errors after all documentation changes
+- [x] T016 Run cross-page consistency checks: search for Divisor persona count references (all must say "five"), MCP tool counts (all must say "40 tools across 10 categories"), and `uf setup` descriptions (all must reflect v0.5.0 behavior). Fix any remaining inconsistencies.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: N/A -- no setup tasks
+- **Foundational (Phase 2)**: N/A -- no foundational tasks
+- **User Stories (Phases 3-8)**: All can begin immediately, no blocking prerequisites
+- **Polish (Phase 9)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies -- can start immediately
+- **User Story 2 (P1)**: No dependencies -- can start immediately (modifies different sections of common-workflows.md than US1)
+- **User Story 3 (P2)**: No dependencies -- modifies team pages only
+- **User Story 4 (P2)**: No dependencies -- modifies knowledge.md only
+- **User Story 5 (P3)**: No dependencies -- modifies different sections than US1/US2
+- **User Story 6 (P3)**: No dependencies -- modifies Dewey pages only
+
+### Within Each User Story
+
+- Tasks without [P] must be executed sequentially (they modify the same file in dependent sections)
+- Tasks with [P] can run in parallel with other [P] tasks in the same phase
+- Complete all tasks in a phase before moving to the next
+
+### Parallel Opportunities
+
+- T004 (developer.md) can run in parallel with T001-T003 (common-workflows.md)
+- T007 (product-owner.md) can run in parallel with T005-T006 (common-workflows.md)
+- T009 (team/\_index.md) can run in parallel with T008 (team/the-divisor.md)
+- T012 (developer.md) can run in parallel with T011 (common-workflows.md)
+- T013 (team/dewey.md) and T014 (projects/dewey.md) can run in parallel with each other
+- All user stories (Phases 3-8) can run in parallel if staffed
+
+---
+
+## Parallel Example: All P1 Stories
+
+```bash
+# US1 and US2 can run fully in parallel since they modify different sections:
+
+# US1 tasks (common-workflows.md setup section + developer.md):
+Task: "Rewrite uf setup section in common-workflows.md"
+Task: "Update developer.md setup description"  # [P] with above
+
+# US2 tasks (common-workflows.md delegation section + product-owner.md):
+Task: "Add workflow commands to common-workflows.md"
+Task: "Add /workflow seed to product-owner.md"  # [P] with above
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2 Only)
+
+1. Complete Phase 3: User Story 1 (setup docs)
+2. Complete Phase 4: User Story 2 (workflow commands)
+3. **STOP and VALIDATE**: `npm run build` + verify setup and workflow pages
+4. Deploy if ready -- users can now follow accurate setup docs and use new commands
+
+### Incremental Delivery
+
+1. Phases 3-4 (P1): Setup + Workflow Docs → Build + Verify → Deploy
+2. Phases 5-6 (P2): Divisor + Embedding → Build + Verify → Deploy
+3. Phases 7-8 (P3): Branches + Tool Counts → Build + Verify → Deploy
+4. Phase 9: Final consistency check → Deploy
+
+### Parallel Team Strategy
+
+With two workers:
+
+1. Worker A: US1 (common-workflows.md setup) + US3 (divisor pages) + US5 (branch conventions)
+2. Worker B: US2 (workflow commands) + US4 (knowledge.md) + US6 (dewey tool counts)
+3. Both complete → Phase 9 consistency check
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- All source data for content changes is in research.md (R1-R8)
+- common-workflows.md is the most-modified file (US1, US2, US5 modify different sections)
+- Commit after each phase to maintain clean history
+- Run `npm run build` after each phase as a checkpoint


### PR DESCRIPTION
## Summary

- Update setup documentation to reflect v0.5.0 expanded 16-step uf setup (now installs Mx F, GitHub CLI, OpenSpec CLI, Ollama, and Dewey automatically)
- Document /workflow seed, /workflow start --define-mode --spec-review flags, and .unbound-force/config.yaml project-level workflow configuration
- Expand The Divisor from 3 to 5 sub-personas (add SRE/The Operator and Testing/The Tester) across all pages
- Document OLLAMA_MODEL and OLLAMA_EMBED_DIM embedding alignment environment variables
- Add opsx/ branch conventions to developer and common workflow docs
- Reconcile Dewey MCP tool count to 40 tools across 10 categories across all pages
- Fix broken #source-configuration anchor in team/dewey.md (pre-existing)
- Include spec artifacts for 010-v050-docs-sync (spec, plan, research, tasks, quickstart, checklist)

## Review Council

All 5 Divisor personas reviewed. Blocking findings addressed: heading separator inconsistency, broken anchor, bare code blocks, category count mismatch.