### PR TITLE
docs: surface /unleash as flagship capability with blog post, cross-references, and page restructuring

### DIFF
--- a/.opencode/agents/divisor-pr.md
+++ b/.opencode/agents/divisor-pr.md
@@ -1,0 +1,153 @@
+---
+description: "Public perception and messaging auditor ensuring the website builds trust, avoids overclaims, and tells a compelling story."
+mode: subagent
+model: google-vertex-anthropic/claude-opus-4-6@default
+temperature: 0.1
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: false
+  webfetch: false
+---
+
+# Role: The PR Officer
+
+You are a public relations officer reviewing this project's public-facing content. Your job is to ensure the website builds credibility, avoids overclaims, and tells a compelling story that resonates with the target audience. You catch what engineers celebrate but stakeholders question: aspirational claims presented as current capabilities, technical depth that obscures the value proposition, missing social proof, and content that would embarrass the project if shared on Hacker News.
+
+**You operate in one of two modes depending on how the caller invokes you: Code Review Mode (default) or Spec Review Mode.** The caller will tell you which mode to use.
+
+---
+
+## Source Documents
+
+Before reviewing, read:
+
+1. `AGENTS.md` -- Behavioral Constraints (especially Content Accuracy: "never fabricate features or overstate maturity"), Project Overview, Content Sources
+2. `.specify/memory/constitution.md` -- Constitution (if present)
+3. The relevant spec, plan, and tasks files under `specs/` for the current work
+4. `.opencode/unbound/packs/` -- Convention pack for this project (if present). Skip pack-dependent checklist items marked with **[PACK]** if no pack is loaded.
+
+---
+
+## Code Review Mode
+
+This is the default mode. Use this when the caller asks you to review content changes.
+
+### Review Scope
+
+Evaluate all changed content files (staged, unstaged, and untracked). Use `git diff` and `git status` to identify what has changed. Focus exclusively on how the content would be perceived by the public -- leave code architecture, security, and test coverage to other Divisor personas.
+
+### Audit Checklist
+
+#### 1. Credibility and Trust
+
+- **Overclaims**: Does any content describe aspirational capabilities as current features? Flag any claim that cannot be verified by installing the tool today. The project's own constitution mandates: "never fabricate features or overstate maturity."
+- **Specificity vs. vagueness**: Are capability claims backed by specific, verifiable details (metrics, command names, output examples)? Or are they generic marketing assertions ("powerful," "revolutionary," "game-changing")? Specific claims build trust; vague claims erode it.
+- **Honesty about limitations**: Does the content acknowledge current limitations alongside capabilities? An honest "Current Limitations" section builds more credibility than a polished feature list with no caveats. Flag pages that only present strengths.
+- **Consistency between pages**: If one page claims a specific capability (e.g., "84.7% accuracy"), do all other pages referencing it agree? Inconsistency suggests carelessness or dishonesty to an outside reader.
+- **Maturity signaling**: Does the content accurately signal the project's maturity level? An early-stage project claiming enterprise-grade reliability is a credibility risk. Flag any maturity signals that don't match the actual project state.
+
+#### 2. Value Proposition Clarity
+
+- **Headline test**: If someone read only the page title, lead text, and first paragraph, would they understand what the project does and why they should care? Flag pages where the value proposition requires reading multiple paragraphs to discover.
+- **So-what test**: For every feature described, is the benefit to the reader clear? "Gaze detects side effects" is a feature. "Gaze tells you which tests are actually verifying behavior, not just running code" is a benefit. Flag feature descriptions that lack the "so what."
+- **Differentiation**: Does the content explain what makes this project different from alternatives? Not by disparaging competitors, but by clearly stating the unique approach. Flag content that describes capabilities without differentiating them.
+- **Buried lede**: Is the most compelling capability the first thing a visitor encounters, or is it buried in a subsection? The most newsworthy content should be the most prominent.
+
+#### 3. Audience and Messaging
+
+- **Target audience clarity**: Is it clear who this content is for? Mixing messages for different audiences (developers, product owners, executives, open source contributors) on the same page dilutes impact. Each page should serve one primary audience.
+- **Tone consistency**: Is the voice consistent across the site? An open source project should sound confident but not corporate, technical but not academic, enthusiastic but not breathless. Flag tonal shifts between pages.
+- **Jargon risk**: Would a developer who doesn't know the project's internal vocabulary understand the content? Internal terms like "hero lifecycle," "convention pack," or "backlog-item artifact" need enough context for a first-time reader.
+- **Call to action**: Does each page give the reader a clear next step? A page that informs without directing is a missed opportunity. Flag pages that end without a path forward.
+
+#### 4. Shareability and External Perception
+
+- **Hacker News test**: If this page were submitted to Hacker News, would it generate interest or skepticism? Flag content that would invite "this is just a wrapper around Claude" or "these are just prompt templates" responses. The content should preemptively address likely skeptical reactions.
+- **Social media snippet**: Would the page title and description make a compelling social media post? The frontmatter `description` field is what appears in link previews (Open Graph). Flag descriptions that are too generic, too long, or don't communicate value.
+- **Blog post potential**: Is there content on documentation pages that would be more impactful as a standalone blog post? Narrative content (origin stories, design decisions, real-world results) performs better as blog posts than as documentation sections.
+- **Quote-worthy lines**: Are there 1-2 sentences per page that someone could quote in a tweet or article? Great projects produce quotable insights. Flag pages that lack any memorable framing.
+
+#### 5. Risk Assessment
+
+- **Loaded terminology**: Does the content use terms that carry unintended weight? "AGI," "autonomous," "intelligent," "self-improving" -- these terms invite scrutiny from AI safety communities and tech journalists. Use them only when defensible and precisely defined.
+- **Legal exposure**: Are there implied warranties, guarantees of behavior, or claims that could create liability? "The Divisor catches all security vulnerabilities" is different from "The Divisor reviews code for common security patterns."
+- **Competitive positioning**: Does the content disparage or unfavorably compare to other tools? Open source projects build goodwill through positive positioning, not competitive attacks.
+- **Outdated claims**: Are there version numbers, dates, or temporal references ("recently," "new," "just launched") that will become stale? Flag time-sensitive language that needs a maintenance plan.
+
+#### 6. Visual and Structural Impact
+
+- **Above-the-fold content**: What does a visitor see before scrolling on the homepage and key landing pages? Is it the most compelling content, or filler?
+- **Scan path**: Can a reader extract the key message by reading only headings and bold text? Flag pages where the scan path doesn't tell the story.
+- **CTA placement**: Are calls-to-action placed where a motivated reader would want them (after a compelling section, not before the reader has context)?
+- **Content density**: Is there enough white space and visual breaks? Dense pages signal "this will be hard to read" before a reader starts.
+
+---
+
+## Spec Review Mode
+
+Use this mode when the caller instructs you to review specification artifacts instead of content.
+
+### Review Scope
+
+Read **all files** under `specs/` recursively. Also read the constitution and `AGENTS.md` for constraint context.
+
+Do NOT use `git diff` or review code files. Your scope is exclusively the specification artifacts.
+
+### Audit Checklist
+
+#### 1. Messaging Strategy
+
+- Does the spec consider how the deliverable will be perceived by external audiences?
+- If the spec includes a blog post or public-facing content, does it have a clear narrative arc (problem -> approach -> result -> call to action)?
+- Does the spec consider the "so what" for each feature being documented?
+- Are there opportunities the spec misses for telling a compelling story?
+
+#### 2. Overclaim Prevention
+
+- Does the spec source all claims from verified upstream repositories? Flag any requirement that could lead to documenting aspirational features as current capabilities.
+- Does the spec distinguish between what the tool does today and what is planned?
+- Are there maturity claims that need caveats?
+
+#### 3. Audience Targeting
+
+- Does the spec identify the right audience for each deliverable?
+- Is the tone appropriate for the delivery vehicle (blog post vs. getting-started guide vs. reference page)?
+- Does the spec consider how the content will be discovered (search, social sharing, site navigation)?
+
+#### 4. Competitive Positioning
+
+- Does the spec's language position the project effectively without overclaiming?
+- Are there opportunities to highlight unique differentiators that the spec misses?
+- Does the spec avoid language that could be perceived as dismissive of alternatives?
+
+#### 5. Shareability
+
+- Does the spec produce content that could be shared on social media, developer forums, or newsletters?
+- Are there blog post opportunities that the spec misses?
+- Does the spec specify SEO-relevant metadata (title, description) for new pages?
+
+---
+
+## Output Format
+
+For each finding, provide:
+
+```
+### [SEVERITY] Finding Title
+
+**File**: `path/to/file:line` (or `specs/NNN-feature/artifact.md` in spec review mode)
+**Principle**: Which PR principle is violated (Credibility, Value Proposition, Audience, Shareability, Risk, Structure)
+**Description**: What the issue is and how it would be perceived by external audiences
+**Recommendation**: How to fix it, with specific suggested messaging where appropriate
+```
+
+Severity levels: CRITICAL, HIGH, MEDIUM, LOW
+
+## Decision Criteria
+
+- **APPROVE** only if the content builds credibility, communicates value clearly, avoids overclaims, and would represent the project well to an external audience.
+- **REQUEST CHANGES** if you find any overclaim, buried value proposition, loaded terminology risk, or messaging gap of MEDIUM severity or above.
+
+End your review with a clear **APPROVE** or **REQUEST CHANGES** verdict and a summary of findings.

--- a/.opencode/agents/divisor-techwriter.md
+++ b/.opencode/agents/divisor-techwriter.md
@@ -1,0 +1,154 @@
+---
+description: "Documentation clarity and usability auditor ensuring content is accurate, discoverable, and serves the reader's actual task."
+mode: subagent
+model: google-vertex-anthropic/claude-opus-4-6@default
+temperature: 0.1
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: false
+  webfetch: false
+---
+
+# Role: The Tech Writer
+
+You are a senior technical writer reviewing this project's documentation. Your job is to ensure every page serves the reader's actual task -- that content is accurate, structured for scanning, internally consistent, and written at the right level of abstraction for its audience. You catch what engineers miss: buried ledes, jargon without context, inconsistent terminology, missing cross-references, and content that answers the wrong question.
+
+**You operate in one of two modes depending on how the caller invokes you: Code Review Mode (default) or Spec Review Mode.** The caller will tell you which mode to use.
+
+---
+
+## Source Documents
+
+Before reviewing, read:
+
+1. `AGENTS.md` -- Behavioral Constraints, Content Conventions, Markdown Rules, Project Structure
+2. `.specify/memory/constitution.md` -- Constitution (if present)
+3. The relevant spec, plan, and tasks files under `specs/` for the current work
+4. `.opencode/unbound/packs/` -- Convention pack for this project (if present). Skip pack-dependent checklist items marked with **[PACK]** if no pack is loaded.
+
+---
+
+## Code Review Mode
+
+This is the default mode. Use this when the caller asks you to review documentation or content changes.
+
+### Review Scope
+
+Evaluate all changed Markdown content files (staged, unstaged, and untracked). Use `git diff` and `git status` to identify what has changed. Focus exclusively on user-facing documentation quality -- leave code architecture, security, and test coverage to other Divisor personas.
+
+### Audit Checklist
+
+#### 1. Information Architecture
+
+- **Lede placement**: Does each page lead with the most important information? Can a reader understand the page's purpose within the first 2 sentences? Flag any page where the primary value proposition is buried below secondary content.
+- **Heading hierarchy**: Do headings form a scannable outline? Can a reader navigate the page by headings alone and find what they need? Are heading levels used semantically (H2 for major sections, H3 for subsections) or decoratively?
+- **Section ordering**: Does content flow from general to specific? From most common use case to edge cases? From simplest path to advanced options? Flag pages where the reader must wade through complexity before reaching the common case.
+- **Page length**: Is the page trying to cover too many topics? Would the reader be better served by multiple focused pages, or does the content belong together?
+- **Cross-references**: When a concept is explained in detail on another page, does this page link to it rather than duplicating content? Are there "orphan" pages with no inbound links from other pages?
+
+#### 2. Audience Alignment
+
+- **Reading level**: Is the content appropriate for the stated audience? A getting-started guide should be accessible to a mid-level developer. A team persona page should be accessible to a non-technical stakeholder. An architecture page can assume deeper technical knowledge.
+- **Jargon**: Is every technical term either self-evident from context, defined inline, or linked to a definition? Flag acronyms used without expansion, internal project terms used without explanation, or assumed knowledge that the stated audience may not have.
+- **Prerequisites**: Does the page assume knowledge that the reader may not have? Are prerequisite concepts linked or explained?
+- **Task orientation**: Is the content organized around what the reader wants to _do_, or around how the system is _structured_? Prefer task-oriented framing ("To start a workflow, run...") over system-oriented framing ("The workflow subsystem consists of...").
+
+#### 3. Accuracy and Consistency
+
+- **Factual accuracy**: Do all claims match the current state of the tools? Flag specific version numbers, file counts, command outputs, or capability claims that may be stale. Cross-reference claims against other pages on the site for contradictions.
+- **Terminology consistency**: Is the same concept always called by the same name across all pages? Flag cases where a concept is called different things on different pages (e.g., "convention pack" vs. "coding standards" vs. "pack files").
+- **Numerical consistency**: Do counts, percentages, and metrics match across all pages that reference them?
+- **Command accuracy**: Are CLI commands, flags, and code examples correct and copy-pasteable? Would they actually work if a reader pasted them into a terminal?
+
+#### 4. Completeness
+
+- **Missing context**: Are there instructions that skip steps? Commands shown without prerequisite setup? Features described without explaining how to access them?
+- **Missing outcomes**: Does the reader know what success looks like? After following instructions, will they know they succeeded?
+- **Missing error guidance**: When something can go wrong, does the documentation acknowledge it and provide resolution steps?
+- **Discoverability**: Can a reader find this content? Is it linked from the pages they would naturally visit first? Flag features or capabilities that exist in the docs but have no inbound discovery path.
+
+#### 5. Formatting and Conventions
+
+- **Markdown standards**: ATX-style headings, fenced code blocks with language identifiers, em-dashes for parenthetical clauses, body starting with H2 (title frontmatter generates H1).
+- **Code block quality**: Do code blocks have language identifiers (`bash`, `text`, `yaml`, `json`)? Are inline code spans used for commands, filenames, and flags?
+- **Table formatting**: Are tables properly formatted with aligned pipes and header separators? Do tables have enough columns to be useful but not so many that they're hard to scan?
+- **Link quality**: Do internal links use relative paths? Do they point to existing pages? Are anchor links valid (matching actual heading slugs)?
+
+#### 6. Anti-Patterns
+
+- **Wall of text**: Blocks of prose longer than 5 sentences without a break (heading, list, code block, table). Dense text is hostile to scanning.
+- **Passive voice**: Excessive passive voice obscures who does what. "The spec is reviewed" vs. "The Divisor reviews the spec."
+- **Weasel words**: "Simply," "just," "easily," "obviously" -- these dismiss the reader's difficulty. Flag them.
+- **Placeholder content**: "Coming soon," "TBD," "TODO," or empty sections.
+- **Duplicated content**: The same explanation appearing verbatim on multiple pages instead of cross-linking.
+
+---
+
+## Spec Review Mode
+
+Use this mode when the caller instructs you to review specification artifacts instead of content.
+
+### Review Scope
+
+Read **all files** under `specs/` recursively. Also read the constitution and `AGENTS.md` for constraint context.
+
+Do NOT use `git diff` or review code files. Your scope is exclusively the specification artifacts.
+
+### Audit Checklist
+
+#### 1. Spec as Documentation
+
+- Is the spec written clearly enough that a non-author could implement from it without asking questions?
+- Are user stories described in terms a product owner would understand, or do they assume engineering knowledge?
+- Are acceptance scenarios specific enough to write tests from, or are they vague ("works correctly")?
+
+#### 2. Content Strategy
+
+- Does the spec identify the right audience for each deliverable? A blog post has a different audience than a getting-started guide.
+- Does the spec acknowledge existing content and specify whether to create, modify, or replace?
+- Are content placement decisions (which page, which section, what weight) justified?
+
+#### 3. Terminology Governance
+
+- Does the spec use consistent terminology throughout?
+- Does the spec introduce new terms? If so, are they defined and consistent with existing site vocabulary?
+- Are there naming collisions with existing content (same term used for different concepts)?
+
+#### 4. Completeness of Content Specs
+
+- For new pages: is the frontmatter fully specified (title, description, lead, weight, toc)?
+- For modified pages: are the exact sections to modify identified?
+- Are cross-references specified (which pages should link to the new content)?
+- Is the navigation impact documented (sidebar ordering, menu changes)?
+
+#### 5. Reader Journey
+
+- Does the spec consider how a reader arrives at this content? (Homepage -> Getting Started -> specific page? Search? Blog post shared on social media?)
+- Does the spec ensure every new feature has at least one discovery path from an existing high-traffic page?
+- Are "Next Steps" or "Learn More" sections specified for new pages?
+
+---
+
+## Output Format
+
+For each finding, provide:
+
+```
+### [SEVERITY] Finding Title
+
+**File**: `path/to/file:line` (or `specs/NNN-feature/artifact.md` in spec review mode)
+**Principle**: Which documentation principle is violated (Information Architecture, Audience Alignment, Accuracy, Completeness, Formatting, Anti-Pattern)
+**Description**: What the issue is and why it matters for the reader
+**Recommendation**: How to fix it, with specific suggested text where appropriate
+```
+
+Severity levels: CRITICAL, HIGH, MEDIUM, LOW
+
+## Decision Criteria
+
+- **APPROVE** only if the content is accurate, well-structured, discoverable, and serves the reader's task at the right level of abstraction.
+- **REQUEST CHANGES** if you find any buried lede, factual inaccuracy, missing cross-reference, audience mismatch, or formatting violation of MEDIUM severity or above.
+
+End your review with a clear **APPROVE** or **REQUEST CHANGES** verdict and a summary of findings.

--- a/.opencode/unbound/packs/markdown-custom.md
+++ b/.opencode/unbound/packs/markdown-custom.md
@@ -1,0 +1,20 @@
+---
+pack_id: markdown-custom
+language: Markdown
+version: 1.0.0
+---
+
+# Custom Rules: Markdown
+
+Project-specific Markdown and content conventions that
+extend the canonical Markdown convention pack. Rules in
+this file are loaded alongside `markdown.md` by
+Cobalt-Crush (during implementation) and all Divisor
+persona agents (during review).
+
+Use the `CR-NNN` prefix for all custom rules. Use `[MUST]`,
+`[SHOULD]`, or `[MAY]` severity indicators per RFC 2119.
+
+## Custom Rules
+
+<!-- Add project-specific rules below this line -->

--- a/.opencode/unbound/packs/markdown.md
+++ b/.opencode/unbound/packs/markdown.md
@@ -1,0 +1,298 @@
+---
+pack_id: markdown
+language: Markdown
+version: 1.0.0
+---
+
+# Convention Pack: Markdown (Documentation, Website Content, Blog Posts)
+
+This is the Markdown-specific convention pack for The
+Divisor PR reviewer framework. It contains rules for
+writing documentation pages, website content, and blog
+posts in Hugo/Doks static site projects. It complements
+the language-agnostic `default.md` pack with
+content-specific standards.
+
+When this pack is active, personas load both packs --
+this pack takes precedence on overlapping concerns
+related to content structure, writing quality, and
+Markdown formatting.
+
+---
+
+## Frontmatter
+
+- **FM-001** [MUST] Every `.md` file in `content/` MUST
+  have YAML frontmatter with at minimum: `title`,
+  `description`, `date`, `draft`, and `weight`.
+
+- **FM-002** [MUST] The `title` field MUST be concise
+  (under 60 characters preferred) and describe the page's
+  topic, not its section. The title generates the H1
+  heading -- body content MUST NOT start with H1.
+
+- **FM-003** [MUST] The `description` field MUST be a
+  complete sentence of 110-160 characters that works as
+  an SEO meta description and Open Graph preview. It MUST
+  communicate the page's value proposition, not just its
+  topic.
+
+- **FM-004** [SHOULD] The `lead` field SHOULD provide a
+  1-2 sentence hook that appears at the top of the page.
+  It SHOULD be distinct from `description` -- the lead
+  speaks to readers already on the page, while the
+  description speaks to readers in search results.
+
+- **FM-005** [MUST] The `weight` field MUST control
+  sidebar ordering within the section. Lower weight =
+  higher position. New pages MUST use weights consistent
+  with sibling pages.
+
+- **FM-006** [MUST] Blog posts MUST include additional
+  frontmatter: `slug`, `categories`, `tags`, and
+  `contributors`. The `slug` MUST be kebab-case and
+  match the filename.
+
+- **FM-007** [MUST] Section index pages MUST be named
+  `_index.md` (with leading underscore).
+
+---
+
+## Content Structure
+
+- **ST-001** [MUST] Body content MUST start with an H2
+  (`##`) heading. The `title` frontmatter generates H1.
+  Never use H1 (`#`) in body content.
+
+- **ST-002** [MUST] Headings MUST use ATX style (`##`,
+  `###`) not underline style (`===`, `---`). Headings
+  MUST follow a strict hierarchy -- no skipping levels
+  (e.g., H2 to H4 without H3).
+
+- **ST-003** [MUST] The first paragraph after the opening
+  H2 MUST establish what the page is about and why the
+  reader should care. A reader who stops after this
+  paragraph MUST understand the page's purpose.
+
+- **ST-004** [SHOULD] Pages SHOULD progress from general
+  to specific: concept overview, then practical usage,
+  then reference details, then edge cases. The most
+  common reader task SHOULD be addressable without
+  scrolling past uncommon content.
+
+- **ST-005** [SHOULD] Pages longer than 5 H2 sections
+  SHOULD set `toc: true` in frontmatter to generate a
+  table of contents for navigation.
+
+- **ST-006** [MUST] Every documentation page MUST end
+  with a "Next Steps" or "Learn More" section that gives
+  the reader at least 2-3 cross-links to related pages.
+  No page is a dead end.
+
+- **ST-007** [SHOULD] Sections SHOULD be self-contained
+  enough that a reader arriving via a direct link to a
+  heading anchor can understand the content without
+  reading preceding sections.
+
+---
+
+## Writing Quality
+
+- **WQ-001** [MUST] Content MUST be task-oriented -- it
+  answers "how do I do X?" before "how does X work
+  internally?" Prefer imperative instructions ("Run
+  `uf setup`") over passive descriptions ("The setup
+  process can be initiated").
+
+- **WQ-002** [MUST] Content MUST NOT contain placeholder
+  text, TODO markers, "Coming Soon," "TBD," or empty
+  sections. Only publish pages with real, complete
+  content.
+
+- **WQ-003** [MUST] All factual claims (metrics,
+  capabilities, file counts, version numbers) MUST be
+  sourced from the actual tool's current state. Never
+  fabricate features, overstate maturity, or present
+  aspirational capabilities as current functionality.
+
+- **WQ-004** [MUST] Terminology MUST be consistent across
+  all pages. The same concept MUST use the same term
+  everywhere. If a concept has multiple common names,
+  choose one canonical term and use it consistently.
+  Introduce the canonical term on first use with any
+  necessary context.
+
+- **WQ-005** [SHOULD] Prose paragraphs SHOULD be 3-5
+  sentences. Blocks of text longer than 5 sentences
+  without a visual break (heading, list, code block,
+  table) SHOULD be split for scannability.
+
+- **WQ-006** [MUST] Content MUST NOT use weasel words
+  that dismiss the reader's effort: "simply," "just,"
+  "easily," "obviously," "of course." These words
+  signal that the writer has not considered the reader's
+  perspective.
+
+- **WQ-007** [SHOULD] Active voice SHOULD be preferred
+  over passive voice. "Gaze detects side effects" is
+  stronger than "Side effects are detected by Gaze."
+  Passive voice is acceptable when the actor is
+  genuinely unknown or unimportant.
+
+- **WQ-008** [SHOULD] Every feature description SHOULD
+  pass the "so what" test: the benefit to the reader
+  SHOULD be explicit, not implied. "Gaze detects side
+  effects" is a feature. "Gaze tells you which tests
+  are actually verifying behavior" is a benefit.
+
+- **WQ-009** [MUST] Technical jargon, acronyms, and
+  project-specific terms MUST be explained on first use
+  or linked to a page that explains them. Assume the
+  reader is a mid-level developer encountering the
+  project for the first time.
+
+- **WQ-010** [MUST] Numerical claims (counts, percentages,
+  scores) MUST be consistent across all pages that
+  reference them. If accuracy is "84.7%" on one page, it
+  MUST be "84.7%" on every other page that mentions it.
+
+---
+
+## Markdown Formatting
+
+- **MF-001** [MUST] Use fenced code blocks (triple
+  backticks) with a language identifier for all code
+  examples: ` ```bash `, ` ```yaml `, ` ```json `,
+  ` ```text `, ` ```go `, etc. Never use bare fenced
+  blocks without a language identifier.
+
+- **MF-002** [MUST] Use inline code spans (single
+  backticks) for commands (`uf setup`), filenames
+  (`spec.md`), flags (`--verbose`), and identifiers.
+  Do not use inline code for emphasis -- use bold or
+  italics instead.
+
+- **MF-003** [MUST] Markdown tables MUST have aligned
+  pipes, header separators with at least 3 dashes per
+  column (`|---|`), and spaces around cell content
+  (`| Content |` not `|Content|`).
+
+- **MF-004** [MUST] Use em-dashes (`---` rendered as
+  `---`) for parenthetical clauses, consistent with the
+  site's established style. Do not use double hyphens
+  (`--`) where em-dashes are the convention.
+
+- **MF-005** [SHOULD] Lists SHOULD use consistent markers
+  within a section: either all `-` or all `*` or all
+  numbered. Mixed markers within the same list are a
+  formatting violation.
+
+- **MF-006** [MUST] Internal links MUST use relative
+  paths (`/docs/getting-started/quick-start/`) not
+  absolute URLs (`https://unboundforce.dev/docs/...`).
+  Links MUST point to existing pages. Anchor links MUST
+  match actual heading slugs.
+
+- **MF-007** [SHOULD] Images SHOULD have alt text that
+  describes the content for accessibility. Decorative
+  images SHOULD use an empty alt attribute.
+
+---
+
+## Blog Posts
+
+- **BP-001** [MUST] Blog posts MUST have a narrative arc:
+  problem statement, approach, evidence or walkthrough,
+  and a conclusion with a call to action. Posts that are
+  lists of features without context do not engage readers.
+
+- **BP-002** [MUST] Blog post titles MUST be specific and
+  descriptive. "Update on Progress" is too vague.
+  "Why Contract Coverage: How Gaze Redefines What It
+  Means to Have Good Tests" communicates the topic and
+  value proposition.
+
+- **BP-003** [SHOULD] Blog posts SHOULD include real-world
+  examples, actual output, or concrete data rather than
+  abstract descriptions. Show, then explain.
+
+- **BP-004** [MUST] Blog posts MUST NOT contain
+  time-sensitive language that becomes stale ("recently,"
+  "new," "just launched," "this week") unless absolutely
+  necessary. Use specific dates if temporality matters.
+
+- **BP-005** [SHOULD] Blog posts SHOULD be self-contained
+  -- a reader arriving from search or social media SHOULD
+  understand the post without reading other site content.
+  Link to detailed documentation for reference, but don't
+  require it for comprehension.
+
+- **BP-006** [MUST] The blog post's `description`
+  frontmatter MUST work as a social media preview. It
+  appears in Open Graph link cards. It MUST be a
+  compelling 1-2 sentence summary, not a generic topic
+  label.
+
+---
+
+## Cross-Referencing
+
+- **XR-001** [MUST] When a concept is explained in depth
+  on another page, the current page MUST link to it
+  rather than duplicating the explanation. Brief context
+  (1-2 sentences) is acceptable; full reproduction is
+  not.
+
+- **XR-002** [SHOULD] Significant features or capabilities
+  SHOULD be reachable from at least 2 entry-point pages
+  (homepage, Quick Start, getting-started landing, role
+  guides). A feature mentioned on only 1 page has a
+  discoverability problem.
+
+- **XR-003** [MUST] When introducing a slash command
+  (e.g., `/unleash`, `/finale`), the introduction MUST
+  include the command's purpose in one sentence and a
+  link to the full documentation. Do not assume the
+  reader knows what the command does.
+
+- **XR-004** [SHOULD] "Next Steps" links SHOULD lead to
+  pages that logically follow the current page's topic.
+  A getting-started guide's Next Steps SHOULD link to
+  the relevant role guide, project page, or workflow
+  documentation -- not to unrelated sections.
+
+---
+
+## Credibility and Trust
+
+- **CT-001** [MUST] Content MUST NOT present aspirational
+  capabilities as current features. Describing what a
+  tool "will do" or "is designed to do" as what it "does"
+  is a credibility violation. Use "Current Limitations"
+  sections to honestly scope the tool's current state.
+
+- **CT-002** [MUST] Content MUST NOT use loaded AI
+  terminology ("AGI," "intelligent," "self-improving,"
+  "sentient") without precise definition and
+  justification. These terms invite skepticism from
+  technical audiences.
+
+- **CT-003** [SHOULD] Pages describing tool capabilities
+  SHOULD include a "Current Limitations" or "What's Not
+  Supported" section when applicable. Honesty about
+  boundaries builds more trust than a polished feature
+  list.
+
+- **CT-004** [MUST] Content MUST accurately signal the
+  project's maturity level. An early-stage project MUST
+  NOT claim enterprise-grade reliability. Version numbers
+  and limitation sections serve as maturity signals.
+
+---
+
+## Custom Rules
+
+<!-- This section is intentionally empty in the canonical
+     pack. Project-specific custom rules belong in
+     markdown-custom.md alongside this file. Custom rules
+     use the CR-NNN identifier prefix. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,7 @@ GitHub Pages deployment via `.github/workflows/deploy-gh-pages.yml`:
 3. Always verify both light and dark mode rendering after style changes.
 
 ## Active Technologies
+- Hugo (Go-based SSG) via `@thulite` npm packages + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3` (013-unleash-visibility)
 
 - Hugo (via npm/thulite) + Go 1.23 (module resolution) + Node.js >= 20.11.0 + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`, `@thulite/images ^3.3.1`, `@thulite/inline-svg ^1.2.0`, `@thulite/seo ^2.4.1`, `@tabler/icons ^3.34.1` (001-site-scaffold)
 - N/A (static site, no database) (001-site-scaffold)

--- a/content/blog/unleash-in-practice.md
+++ b/content/blog/unleash-in-practice.md
@@ -1,0 +1,180 @@
+---
+title: "From Spec to Demo in One Command: How /unleash Works"
+description: "Most AI coding workflows need a human pressing 'next' at every step. /unleash runs the entire pipeline — from spec to demo-ready code — autonomously."
+lead: "One command. Eight stages. The swarm handles clarification, planning, implementation, testing, and review autonomously."
+slug: "unleash-in-practice"
+date: 2026-03-31T00:00:00+00:00
+draft: false
+weight: 80
+toc: true
+categories: ["Engineering"]
+tags: ["unleash", "swarm", "autonomous", "pipeline", "speckit"]
+contributors: ["Unbound Force"]
+---
+
+## The Manual Pipeline Problem
+
+AI coding agents are powerful, but they are not self-directing. A typical agent-assisted development workflow looks like this:
+
+1. Write a specification
+2. Clarify ambiguous requirements (manually search for context)
+3. Generate an implementation plan
+4. Generate a task breakdown
+5. Review the spec for consistency
+6. Implement each task
+7. Run code review
+8. Fix review findings, re-review
+9. Reflect on what was learned
+10. Commit, push, create a PR, merge
+
+Each step requires a human to invoke the next command, evaluate the output, and decide whether to proceed. The agent does the heavy lifting at each stage, but the human drives the sequencing. For a feature with 20 tasks, that means dozens of manual interventions across hours of wall-clock time.
+
+The question is not whether each step is valuable — it is. The question is whether a human needs to be the one pressing "next" at every transition.
+
+## What /unleash Does
+
+`/unleash` is a single command that takes a Speckit specification and runs the entire pipeline autonomously — from clarification through implementation, testing, review, and demo. It handles the transitions, evaluates the outputs, and makes the proceed/stop decisions at each stage.
+
+When it encounters something that genuinely requires human judgment — an unanswerable question, a critical spec finding, a persistent code review issue — it exits cleanly with context about what happened and what to do next. When you re-run `/unleash`, it detects which stages are complete and resumes from where it left off.
+
+The result: you write a spec, run `/unleash`, and come back to demo-ready code with a summary of what was built and how to verify it.
+
+## The Pipeline
+
+`/unleash` orchestrates these stages in sequence:
+
+### 1. Clarify
+
+The pipeline scans your spec for `[NEEDS CLARIFICATION]` markers — questions that were flagged during specification but not answered.
+
+If [Dewey](/docs/getting-started/knowledge/) (the swarm's knowledge retrieval system) is available, `/unleash` attempts to resolve each question automatically by searching across your organization's documentation, GitHub issues, and related specs. Questions that Dewey can answer are resolved silently and recorded in the spec.
+
+Questions that Dewey cannot answer are collected and presented to you as an exit point. You answer them in the spec and re-run `/unleash`.
+
+If Dewey is not configured, all clarification questions exit for human input. The pipeline is the same — you answer more questions yourself.
+
+### 2. Plan
+
+Generates a technical implementation plan (`plan.md`) with:
+
+- Technical context (stack, dependencies, constraints)
+- Constitution alignment check (every plan must pass)
+- Research phase (resolving unknowns from the spec)
+- Design decisions with rationale and alternatives considered
+
+### 3. Tasks
+
+Generates a dependency-ordered task list (`tasks.md`) organized by user story. Each task has:
+
+- A unique ID and priority label
+- A `[P]` marker if it can run in parallel with other tasks
+- The exact file path to modify
+- A description specific enough to implement without additional context
+
+### 4. Spec Review
+
+Runs [The Divisor](/docs/team/the-divisor/) review council in spec review mode. The council's personas evaluate the spec artifacts for completeness, testability, ambiguity, governance gaps, and cross-spec consistency.
+
+LOW and MEDIUM findings are auto-fixed. If HIGH or CRITICAL findings remain, the pipeline exits with the findings and suggests running `/speckit.clarify` to address them.
+
+### 5. Implement
+
+Executes tasks phase by phase. Within each phase:
+
+- **Sequential tasks** run in order via the [Cobalt-Crush](/docs/team/cobalt-crush/) developer agent
+- **Parallel tasks** (marked `[P]`) spawn independent [Swarm](/docs/getting-started/developer/#working-with-swarm) workers, each in a dedicated git worktree, up to 4 concurrent workers
+
+After each phase, the pipeline runs the CI build and test commands (derived from `.github/workflows/`, not hardcoded). If anything fails, it exits with the failure details.
+
+If Swarm worktrees are not available, parallel tasks fall back to sequential execution. The pipeline adapts to whatever tools are installed.
+
+### 6. Code Review
+
+Runs the Divisor review council in code review mode. This includes:
+
+- CI hard gate (lint, vulnerability checks)
+- Gaze quality analysis (if installed) — contract coverage, CRAP scores
+- The Divisor review council evaluating the implementation
+
+If findings exist, the pipeline attempts to fix them and re-review, up to 3 iterations. Persistent findings exit for human resolution.
+
+### 7. Retrospective
+
+Analyzes the session — what was built, what the review council found, what patterns emerged — and stores learnings in semantic memory via [Hivemind](https://github.com/unbound-force/unbound-force). These learnings surface in future sessions when similar problems arise.
+
+If Hivemind is not available, learnings are displayed in the output instead of stored.
+
+### 8. Demo
+
+Presents structured output:
+
+- **What was built** — summary from the spec's user stories
+- **How to verify** — steps from the quickstart or acceptance scenarios
+- **Key files changed** — grouped by directory
+- **Test results** — pass/fail summary
+- **Next steps** — run `/finale` to ship, or `/speckit.clarify` to iterate
+
+## Where It Pauses
+
+`/unleash` is autonomous, not unattended. It exits cleanly at five specific points where human judgment is needed:
+
+| Exit Point                  | Why It Pauses                                 | What You Do                                       |
+| --------------------------- | --------------------------------------------- | ------------------------------------------------- |
+| Unanswerable clarification  | Dewey could not resolve a spec question       | Answer the question in spec.md, re-run `/unleash` |
+| HIGH/CRITICAL spec findings | Review council found serious spec issues      | Run `/speckit.clarify`, re-run `/unleash`         |
+| Build/test failure          | CI commands failed after a phase              | Fix the failure, re-run `/unleash`                |
+| Merge conflict              | Parallel workers produced conflicting changes | Resolve conflicts, re-run `/unleash`              |
+| Exhausted code review       | 3 review iterations without full approval     | Fix remaining findings, re-run `/unleash`         |
+
+Every exit message tells you what happened, what to do next, and how to resume. Re-running `/unleash` after fixing the issue skips all completed stages and picks up exactly where it left off.
+
+## The Complete Loop
+
+`/unleash` builds. [`/finale`](/docs/getting-started/common-workflows/#end-of-branch-workflow-finale) ships.
+
+After `/unleash` presents demo instructions, run `/finale` to automate the end-of-branch workflow: stage all changes, generate a conventional commit message, push, create a PR, watch CI checks, rebase-merge, and return to `main`. The full developer loop is two commands:
+
+```text
+/unleash       # spec → demo-ready code
+/finale        # commit → push → PR → merge → main
+```
+
+## Every Tool Is Optional
+
+`/unleash` is designed for graceful degradation. Every external tool it uses has a fallback:
+
+| Tool     | If Available                          | If Not Available               |
+| -------- | ------------------------------------- | ------------------------------ |
+| Dewey    | Auto-resolves clarification questions | Questions exit for human input |
+| Swarm    | Parallel task execution in worktrees  | Sequential execution           |
+| Gaze     | Quality analysis in code review       | Code review skips quality data |
+| Hivemind | Stores retrospective learnings        | Displays learnings in output   |
+
+The pipeline works with all four tools, with none of them, or with any combination. You get the most autonomous experience with the full stack, but the pipeline never fails because a tool is missing.
+
+## Where It Works Best
+
+`/unleash` works best for well-scoped features with clear specifications — the kind of work where a senior developer could describe the approach in a few sentences. Complex cross-cutting refactors, ambiguous requirements, and large-scale architectural changes still benefit from the step-by-step [Speckit commands](/docs/getting-started/developer/#working-with-speckit) where you control each transition. The exit-and-resume design means you can start with `/unleash` and drop to manual control if the pipeline pauses at a point where you want finer-grained direction.
+
+## Getting Started
+
+Install the Unbound Force toolchain:
+
+```bash
+brew install unbound-force/tap/unbound-force
+uf setup
+```
+
+Create a feature specification:
+
+```text
+/speckit.specify
+```
+
+Describe what you want to build. Then unleash the swarm:
+
+```text
+/unleash
+```
+
+See the [Quick Start guide](/docs/getting-started/quick-start/) for detailed installation and setup instructions, or read the [Common Workflows](/docs/getting-started/common-workflows/) reference for the full pipeline documentation.

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -46,7 +46,7 @@ Ready to dive in? Start with the [Quick Start](/docs/getting-started/quick-start
 - **[Tester](/docs/getting-started/tester/)** -- Gaze quality analysis, CRAP scores, coverage ratchets, CI integration
 - **[Product Owner](/docs/getting-started/product-owner/)** -- Muti-Mind backlog management, priority scoring, acceptance decisions
 - **[Product Manager](/docs/getting-started/product-manager/)** -- Mx F metrics, dashboards, coaching, retrospectives
-- **[Common Workflows](/docs/getting-started/common-workflows/)** -- End-to-end flows for features, bug fixes, code reviews, and setup
+- **[Common Workflows](/docs/getting-started/common-workflows/)** -- The `/unleash` autonomous pipeline, `/finale` shipping workflow, manual feature flows, bug fixes, and code reviews
 - **[Hero Artifacts](/docs/getting-started/artifacts/)** -- Inter-hero communication: envelope format, artifact types, and lifecycle data flow
 - **[Knowledge Retrieval with Dewey](/docs/getting-started/knowledge/)** -- Install and configure Dewey for semantic search across your repositories
 - **[Constitution](/docs/getting-started/constitution/)** -- The 4 core principles that govern all heroes and the governance model

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -1,6 +1,6 @@
 ---
 title: "Common Workflows"
-description: "Step-by-step reference for common Unbound Force workflows: new features, bug fixes, code reviews, and environment setup."
+description: "The /unleash autonomous pipeline, /finale shipping workflow, manual feature flows, bug fixes, code reviews, and environment setup."
 lead: "End-to-end workflows that show how all five heroes collaborate across the development lifecycle."
 date: 2026-03-22T00:00:00+00:00
 draft: false
@@ -8,7 +8,71 @@ weight: 70
 toc: true
 ---
 
-## New Feature (End-to-End)
+## Autonomous Pipeline (`/unleash`)
+
+`/unleash` is the autonomous Speckit pipeline execution command. It takes a spec from draft to demo-ready code in a single command, orchestrating the full pipeline with graceful exit points and full resumability.
+
+### The Pipeline
+
+| Step | Name              | Description                                                                                                                                                                   |
+| ---- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | **Clarify**       | Scans spec.md for `[NEEDS CLARIFICATION]` markers. Uses Dewey semantic search to auto-resolve. Exits to human only for unanswerable questions.                                |
+| 2    | **Plan**          | Delegates to Cobalt-Crush to generate `plan.md` via `/speckit.plan`                                                                                                           |
+| 3    | **Tasks**         | Delegates to Cobalt-Crush to generate `tasks.md` via `/speckit.tasks`                                                                                                         |
+| 4    | **Spec Review**   | Runs the review council in Spec Review Mode. Auto-fixes LOW/MEDIUM findings. Exits on HIGH/CRITICAL.                                                                          |
+| 5    | **Implement**     | Parses `tasks.md` for phases. `[P]` parallel tasks run via Swarm worktrees (up to 4 concurrent workers). Phase checkpoints run CI commands derived from `.github/workflows/`. |
+| 6    | **Code Review**   | Runs the review council in Code Review Mode. Includes Phase 1a CI hard gate, Phase 1b Gaze quality analysis, and Divisor agent reviews. Up to 3 fix iterations.               |
+| 7    | **Retrospective** | Analyzes the session and stores learnings in Hivemind semantic memory.                                                                                                        |
+| 8    | **Demo**          | Presents structured demo instructions: what was built, how to verify, key files changed, and next steps.                                                                      |
+
+### Key Capabilities
+
+- **Dewey-powered clarification**: Auto-resolves spec ambiguities using semantic search. Falls back to human input when Dewey is unavailable or results are insufficient.
+- **Parallel Swarm workers**: `[P]`-marked tasks execute in parallel via git worktrees (up to 4 concurrent). Falls back to sequential when the Swarm plugin is not installed.
+- **Resumability**: Probes filesystem state on startup to detect completed steps. Resumes from the first incomplete step. All progress is persisted in spec artifacts (plan.md, tasks.md checkboxes, spec-review marker).
+- **Graceful exit points**: Every exit (unanswerable questions, HIGH/CRITICAL findings, worker failures, merge conflicts, test failures, review exhaustion) includes actionable next steps and resume instructions.
+- **CI command derivation**: Build and test commands are derived from `.github/workflows/` files, not hardcoded.
+
+### Branch Safety
+
+`/unleash` requires a Speckit feature branch (`NNN-*`). It never runs on `main` and rejects `opsx/*` branches (use `/opsx-apply` instead). It validates that `spec.md` exists before proceeding.
+
+After `/unleash` completes, the demo step suggests running `/finale` to commit, push, create a PR, and merge.
+
+See also: [From Spec to Demo in One Command](/blog/unleash-in-practice/) — a narrative walkthrough of the pipeline.
+
+## End-of-Branch Workflow (`/finale`)
+
+`/finale` automates the end-of-branch workflow — one command to stage, commit, push, create a PR, watch CI, merge, and return to main.
+
+### The 9-Step Workflow
+
+| Step | Name                        | Description                                                                         |
+| ---- | --------------------------- | ----------------------------------------------------------------------------------- |
+| 1    | **Branch Safety Gate**      | Verifies not on `main`. Notes the branch name.                                      |
+| 2    | **Check for Changes**       | Inspects working tree. If clean, checks for unpushed commits or existing PR.        |
+| 3    | **Generate Commit Message** | Analyzes staged changes, generates conventional commit message, shows for approval. |
+| 4    | **Push to Remote**          | Sets upstream if needed (`git push -u origin <branch>`).                            |
+| 5    | **Create or Find PR**       | Creates PR via `gh pr create` or finds existing one.                                |
+| 6    | **Watch CI Checks**         | `gh pr checks --watch`. Stops on failure with options.                              |
+| 7    | **Merge PR**                | `gh pr merge --rebase --delete-branch`. Always uses rebase merge strategy.          |
+| 8    | **Return to Main**          | `git checkout main && git pull`.                                                    |
+| 9    | **Summary**                 | Displays completion report: branch, commit, PR, checks, status.                     |
+
+### Guardrails
+
+- Never runs on `main`
+- Never merges with failing CI checks
+- Never stages secret files (`.env`, `credentials.json`, `*.key`, `*.pem`) without warning
+- Never commits without user approval of the commit message
+- Always uses rebase merge strategy (no squash or merge commits)
+- If any step fails, stops immediately with context and options
+
+`/finale` works with both Speckit (`NNN-*`) and OpenSpec (`opsx/*`) branches. It is the natural complement to `/unleash` — `/unleash` builds, `/finale` ships.
+
+## New Feature (End-to-End) {#new-feature-end-to-end}
+
+> For autonomous execution of this entire workflow in one command, use [`/unleash`](#autonomous-pipeline-unleash). The manual flow below gives you step-by-step control over each stage.
 
 The full hero lifecycle for a new feature follows six stages. Each stage is owned by a specific hero, and each produces artifacts consumed by the next. Every stage has an **execution mode** -- either `[human]` (driven by the operator) or `[swarm]` (run autonomously by the agent swarm).
 
@@ -243,7 +307,7 @@ For bug fixes and small changes (fewer than 3 user stories), use the OpenSpec ta
 
 Create a change with proposal, design, and task artifacts in one step:
 
-```
+```text
 /opsx-propose fix-auth-timeout
 ```
 
@@ -259,7 +323,7 @@ This creates an `opsx/fix-auth-timeout` branch and checks it out automatically. 
 
 Implement the tasks:
 
-```
+```text
 /opsx-apply
 ```
 
@@ -269,7 +333,7 @@ Works through each task in the tasks.md file, making code changes and marking ta
 
 Run the review council to validate the fix:
 
-```
+```text
 /review-council
 ```
 
@@ -279,71 +343,11 @@ The five Divisor personas review the changes. Address any REQUEST CHANGES findin
 
 After the fix is merged, archive the change:
 
-```
+```text
 /opsx-archive
 ```
 
 Moves the change to `openspec/changes/archive/` with a date prefix for historical reference, then returns to the `main` branch.
-
-## Autonomous Pipeline (`/unleash`)
-
-`/unleash` is the autonomous Speckit pipeline execution command. It takes a spec from draft to demo-ready code in a single command, orchestrating 8 steps with graceful exit points and full resumability.
-
-### The 8-Step Pipeline
-
-| Step | Name              | Description                                                                                                                                                                   |
-| ---- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1    | **Clarify**       | Scans spec.md for `[NEEDS CLARIFICATION]` markers. Uses Dewey semantic search to auto-resolve. Exits to human only for unanswerable questions.                                |
-| 2    | **Plan**          | Delegates to Cobalt-Crush to generate `plan.md` via `/speckit.plan`                                                                                                           |
-| 3    | **Tasks**         | Delegates to Cobalt-Crush to generate `tasks.md` via `/speckit.tasks`                                                                                                         |
-| 4    | **Spec Review**   | Runs the review council in Spec Review Mode. Auto-fixes LOW/MEDIUM findings. Exits on HIGH/CRITICAL.                                                                          |
-| 5    | **Implement**     | Parses `tasks.md` for phases. `[P]` parallel tasks run via Swarm worktrees (up to 4 concurrent workers). Phase checkpoints run CI commands derived from `.github/workflows/`. |
-| 6    | **Code Review**   | Runs the review council in Code Review Mode. Includes Phase 1a CI hard gate, Phase 1b Gaze quality analysis, and Divisor agent reviews. Up to 3 fix iterations.               |
-| 7    | **Retrospective** | Analyzes the session and stores learnings in Hivemind semantic memory.                                                                                                        |
-| 8    | **Demo**          | Presents structured demo instructions: what was built, how to verify, key files changed, and next steps.                                                                      |
-
-### Key Capabilities
-
-- **Dewey-powered clarification**: Auto-resolves spec ambiguities using semantic search. Falls back to human input when Dewey is unavailable or results are insufficient.
-- **Parallel Swarm workers**: `[P]`-marked tasks execute in parallel via git worktrees (up to 4 concurrent). Falls back to sequential when the Swarm plugin is not installed.
-- **Resumability**: Probes filesystem state on startup to detect completed steps. Resumes from the first incomplete step. All progress is persisted in spec artifacts (plan.md, tasks.md checkboxes, spec-review marker).
-- **Graceful exit points**: Every exit (unanswerable questions, HIGH/CRITICAL findings, worker failures, merge conflicts, test failures, review exhaustion) includes actionable next steps and resume instructions.
-- **CI command derivation**: Build and test commands are derived from `.github/workflows/` files, not hardcoded.
-
-### Branch Safety
-
-`/unleash` requires a Speckit feature branch (`NNN-*`). It never runs on `main` and rejects `opsx/*` branches (use `/opsx-apply` instead). It validates that `spec.md` exists before proceeding.
-
-After `/unleash` completes, the demo step suggests running `/finale` to commit, push, create a PR, and merge.
-
-## End-of-Branch Workflow (`/finale`)
-
-`/finale` automates the end-of-branch workflow — one command to stage, commit, push, create a PR, watch CI, merge, and return to main.
-
-### The 9-Step Workflow
-
-| Step | Name                        | Description                                                                         |
-| ---- | --------------------------- | ----------------------------------------------------------------------------------- |
-| 1    | **Branch Safety Gate**      | Verifies not on `main`. Notes the branch name.                                      |
-| 2    | **Check for Changes**       | Inspects working tree. If clean, checks for unpushed commits or existing PR.        |
-| 3    | **Generate Commit Message** | Analyzes staged changes, generates conventional commit message, shows for approval. |
-| 4    | **Push to Remote**          | Sets upstream if needed (`git push -u origin <branch>`).                            |
-| 5    | **Create or Find PR**       | Creates PR via `gh pr create` or finds existing one.                                |
-| 6    | **Watch CI Checks**         | `gh pr checks --watch`. Stops on failure with options.                              |
-| 7    | **Merge PR**                | `gh pr merge --rebase --delete-branch`. Always uses rebase merge strategy.          |
-| 8    | **Return to Main**          | `git checkout main && git pull`.                                                    |
-| 9    | **Summary**                 | Displays completion report: branch, commit, PR, checks, status.                     |
-
-### Guardrails
-
-- Never runs on `main`
-- Never merges with failing CI checks
-- Never stages secret files (`.env`, `credentials.json`, `*.key`, `*.pem`) without warning
-- Never commits without user approval of the commit message
-- Always uses rebase merge strategy (no squash or merge commits)
-- If any step fails, stops immediately with context and options
-
-`/finale` works with both Speckit (`NNN-*`) and OpenSpec (`opsx/*`) branches. It is the natural complement to `/unleash` — `/unleash` builds, `/finale` ships.
 
 ## Code Review
 
@@ -351,7 +355,7 @@ The review council brings five specialized perspectives to every code review.
 
 ### Invoking the Council
 
-```
+```text
 /review-council
 ```
 
@@ -442,13 +446,13 @@ Doctor checks 7 areas and shows pass/warn/fail for each with install hints. Fix 
 
 Open OpenCode and try your first task:
 
-```
+```text
 /swarm "your first task description"
 ```
 
 Or start with the Speckit pipeline for a new feature:
 
-```
+```text
 /speckit.specify
 ```
 

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -34,21 +34,37 @@ Doctor checks 7 areas: your detected environment (version managers), core tools,
 
 ## Daily Workflow
 
-A typical development session follows this progression:
+A typical development session follows the specify-unleash-finale loop:
 
-1. **Check your environment**: Run `uf doctor` to verify all tools are healthy
-2. **Open OpenCode**: Start your AI coding environment
-3. **Check for work**: Run `hive_ready()` to see what tasks are available
-4. **Work**: Use `/swarm "task"` for parallel task execution, or code directly with Cobalt-Crush
-5. **End your session**: Run `hive_sync()` then `git push`
+1. **Specify**: Describe what you want to build
 
-The session lifecycle is critical -- **the plane is not landed until `git push` succeeds**. This ensures your work items, learnings, and file reservations are persisted for the next session.
+   ```text
+   /speckit.specify
+   ```
+
+2. **Unleash**: The swarm takes it from here -- clarification, planning, implementation, testing, and review
+
+   ```text
+   /unleash
+   ```
+
+   If `/unleash` pauses (unanswerable question, spec finding, build failure), fix the issue and re-run. If the spec needs refinement, run `/speckit.clarify` then `/unleash` again.
+
+3. **Finale**: Ship it -- commit, push, PR, merge, return to main
+
+   ```text
+   /finale
+   ```
+
+That is the complete loop. For smaller changes that don't need the full Speckit pipeline, use the [OpenSpec tactical workflow](/docs/getting-started/common-workflows/#bug-fix-tactical) (`/opsx-propose` -> `/opsx-apply` -> `/finale`). For parallel task execution without a spec, use `/swarm "task description"` directly.
 
 ## Working with Speckit
 
-Speckit is the strategic specification pipeline for features that need architectural planning. It follows a strict sequential flow:
+Speckit is the strategic specification pipeline for features that need architectural planning. For autonomous execution of the entire pipeline, run [`/unleash`](/docs/getting-started/common-workflows/#autonomous-pipeline-unleash) -- it handles clarification, planning, implementation, testing, and review in a single command, pausing only when human judgment is needed.
 
-```
+For step-by-step control, use the individual commands:
+
+```text
 /speckit.specify    Create the feature specification
 /speckit.clarify    Reduce ambiguity (interactive Q&A)
 /speckit.plan       Generate the technical implementation plan
@@ -108,7 +124,7 @@ Example queries Cobalt-Crush makes during implementation:
 - `dewey_similar("specs/005-getting-started-guides/plan.md")` — finds related planning artifacts to inform the current implementation approach
 - `dewey_semantic_search_filtered("error handling patterns", source: "github")` — finds error handling discussions in GitHub issues and PRs across the organization
 
-When Dewey is not available, Cobalt-Crush falls back to direct file reads and CLI queries. The implementation workflow is the same — just with narrower context. See the [graceful degradation tiers](/docs/getting-started/knowledge/#graceful-degradation) for details.
+When Dewey is not available, Cobalt-Crush falls back to direct file reads and CLI queries. The implementation workflow is the same — with narrower context. See the [graceful degradation tiers](/docs/getting-started/knowledge/#graceful-degradation) for details.
 
 ### File Reservations
 

--- a/content/docs/getting-started/product-owner.md
+++ b/content/docs/getting-started/product-owner.md
@@ -64,7 +64,7 @@ Good seeds are specific enough to convey intent but don't need to be detailed:
 - "Refactor the webhook handler to support configurable retry logic with exponential backoff"
 - "Create a getting-started guide for new contributors to the website project"
 
-The swarm handles everything from here -- specification, planning, implementation, testing, and review -- pausing only at the accept stage for your decision.
+The swarm handles everything from here -- specification, planning, implementation, testing, and review -- pausing only at the accept stage for your decision. Developers can run the full pipeline with [`/unleash`](/docs/getting-started/common-workflows/#autonomous-pipeline-unleash), which orchestrates all stages autonomously and exits when human judgment is needed.
 
 To seed a feature, use the `/workflow seed` command:
 

--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -36,16 +36,25 @@ Doctor checks 7 areas and shows pass/warn/fail for each with install hints. Fix 
 
 ## Start Working
 
-Open OpenCode and try your first task:
+For the fastest path -- one command from spec to demo-ready code:
 
 ```text
-/swarm "your first task description"
+/speckit.specify    # describe what you want to build
+/unleash            # the swarm takes it from here
 ```
 
-Or start with the Speckit pipeline for a new feature:
+`/unleash` runs the entire pipeline autonomously: clarify, plan, implement, test, and review. It pauses when it needs you and resumes where it left off. See the [blog post](/blog/unleash-in-practice/) for a walkthrough of the pipeline.
+
+For step-by-step control over each stage:
 
 ```text
-/speckit.specify
+/speckit.specify    # then /speckit.plan, /speckit.tasks, /speckit.implement
+```
+
+For parallel task execution without the full pipeline:
+
+```text
+/swarm "your task description"
 ```
 
 ## The Stack

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -143,11 +143,12 @@
               <path d="M3 12h4l3 8l4 -16l3 8h4" />
             </svg>
           </div>
-          <h3 class="h5 fw-semibold">Speckit Workflow</h3>
+          <h3 class="h5 fw-semibold">Spec to Demo in One Command</h3>
           <p class="text-body-secondary mb-0">
-            A structured spec-to-implementation pipeline. From specification
-            through planning, task generation, and implementation with quality
-            gates at every step.
+            Run <code>/unleash</code> to go from spec to demo-ready code
+            autonomously. The swarm handles clarification, planning,
+            implementation, testing, and review — pausing only when it needs
+            you.
           </p>
         </div>
       </div>

--- a/specs/013-unleash-visibility/checklists/requirements.md
+++ b/specs/013-unleash-visibility/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Unleash Visibility
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The spec covers 4 user stories: blog post (P1), cross-references (P1), restructuring (P2), homepage CTA (P2).
+- 19 functional requirements map to 4 user stories with 12 acceptance scenarios.
+- The blog post story (US1) is deliberately the highest priority because it creates an external discovery path through search and social sharing, complementing the internal discovery work in US2-US4.
+- Edge cases cover anchor link preservation, blog durability across versions, and cross-linking vs duplication.

--- a/specs/013-unleash-visibility/plan.md
+++ b/specs/013-unleash-visibility/plan.md
@@ -1,0 +1,44 @@
+# Implementation Plan: Unleash Visibility
+
+**Branch**: `013-unleash-visibility` | **Date**: 2026-03-31 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Surface `/unleash` as the flagship capability across the website. Create a blog post, add cross-references to 5 entry-point pages, restructure common-workflows.md, and update the homepage feature card. This takes `/unleash` from appearing on 1 of 22 pages to at least 7 pages plus a shareable blog post.
+
+## Technical Context
+
+**Language/Version**: Hugo (Go-based SSG) via `@thulite` npm packages
+**Primary Dependencies**: `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3`
+**Testing**: `npm run build` must succeed; visual verification
+**Constraints**: Markdown content + 1 HTML template edit; no new dependencies
+
+## Constitution Check
+
+### I. Content Accuracy -- PASS
+
+All `/unleash` pipeline descriptions are sourced from the actual command file (`.opencode/command/unleash.md`). The blog post describes current behavior without version numbers.
+
+### II. Minimal Footprint -- PASS
+
+1 new blog post (Markdown), text edits to 5 existing pages, section reorder in 1 page, text edit in 1 HTML template. No new CSS, JS, or layouts.
+
+### III. Visitor Clarity -- PASS
+
+This feature exists specifically to fix a Visitor Clarity problem: the flagship capability is invisible on 21 of 22 pages. The restructuring places the most important content first.
+
+## File Change Matrix
+
+| File                                               | Priority | FRs                      | Change                                           |
+| -------------------------------------------------- | -------- | ------------------------ | ------------------------------------------------ |
+| `content/blog/unleash-in-practice.md`              | P1       | FR-001 to FR-006, FR-018 | New blog post                                    |
+| `layouts/home.html`                                | P1+P2    | FR-007, FR-016, FR-017   | Rewrite Speckit card, CTA already done           |
+| `content/docs/getting-started/quick-start.md`      | P1       | FR-008                   | Add /unleash to Start Working                    |
+| `content/docs/getting-started/developer.md`        | P1       | FR-009                   | Add /unleash note before Speckit commands        |
+| `content/docs/getting-started/_index.md`           | P1       | FR-010                   | Update Common Workflows description              |
+| `content/docs/getting-started/product-owner.md`    | P1       | FR-011                   | Name /unleash alongside /workflow seed           |
+| `content/docs/getting-started/common-workflows.md` | P2       | FR-012 to FR-015         | Reorder H2 sections, add note to manual workflow |
+
+## Complexity Tracking
+
+No constitution violations. No complexity tracking needed.

--- a/specs/013-unleash-visibility/quickstart.md
+++ b/specs/013-unleash-visibility/quickstart.md
@@ -1,0 +1,15 @@
+# Quickstart: Unleash Visibility
+
+## Verification Steps
+
+1. **Blog post renders**: `npm run dev`, navigate to `/blog/`, verify "From Spec to Demo in One Command" appears
+2. **Blog post content**: Read the post, verify all 8 pipeline steps are described, exit points are explained
+3. **Homepage card**: Visit `/`, verify "Why Unbound Force?" section mentions autonomous pipeline
+4. **Homepage CTA**: Scroll to bottom, verify primary CTA links to Quick Start
+5. **Quick Start**: Visit `/docs/getting-started/quick-start/`, verify `/unleash` is the first option in "Start Working"
+6. **Developer Guide**: Visit `/docs/getting-started/developer/`, verify `/unleash` note appears before Speckit command list
+7. **Getting Started landing**: Visit `/docs/getting-started/`, verify Common Workflows description mentions autonomous pipeline
+8. **Product Owner guide**: Visit `/docs/getting-started/product-owner/`, verify `/unleash` is named alongside `/workflow seed`
+9. **Common Workflows**: Visit `/docs/getting-started/common-workflows/`, verify Autonomous Pipeline is the first H2 section
+10. **Anchor preservation**: Verify `#new-feature-end-to-end` anchor still works on common-workflows page
+11. **Build**: `npm run build` passes with zero errors

--- a/specs/013-unleash-visibility/research.md
+++ b/specs/013-unleash-visibility/research.md
@@ -1,0 +1,158 @@
+# Research: Unleash Visibility
+
+**Date**: 2026-03-31
+**Feature**: [spec.md](spec.md) | [plan.md](plan.md)
+
+## R1: Blog Post Format and Tone (from existing posts)
+
+**Decision**: Follow the exact format of the two existing blog posts.
+
+**Source**: `content/blog/why-contract-coverage.md`, `content/blog/gaze-in-practice.md`
+
+**Pattern observed**:
+
+- Frontmatter: title, description, lead, slug, date, draft, weight, toc, categories, tags, contributors
+- Categories: `["Engineering"]`
+- Contributors: `["Unbound Force"]`
+- Body starts with H2 introducing the problem
+- Structure: Problem -> What the tool does instead -> Walkthrough/evidence -> Implications -> Getting started
+- Tone: Technical but accessible, confident but not promotional, uses real data/output not hypotheticals
+- Length: 150-180 lines of Markdown
+- No version numbers in prose (timeless)
+- No weasel words ("simply", "just", "easily")
+
+**Blog post structure for `/unleash`**:
+
+1. **The Problem**: Manual AI agent pipelines require 8+ commands with human decisions between each step. Most teams run `/speckit.specify`, then manually clarify, then manually plan, etc.
+2. **What /unleash Does**: Single command, 8-step pipeline. Exits when it needs you, resumes when you come back.
+3. **The 8 Steps**: Walk through each with a brief description (not full documentation -- link out)
+4. **Exit Points**: Where it pauses for human judgment (unanswerable clarification questions, HIGH/CRITICAL spec review findings, build failures, exhausted code review iterations)
+5. **What Makes It Autonomous**: Dewey clarifies questions, Swarm parallelizes work, Divisor reviews quality, Hivemind stores learnings
+6. **The Unleash + Finale Loop**: The complete developer workflow
+7. **Getting Started**: Install, setup, create spec, unleash
+
+## R2: Homepage Feature Card Current State
+
+**Decision**: Rewrite the "Speckit Workflow" card text rather than adding a 5th card.
+
+**Source**: `layouts/home.html` lines 128-152
+
+**Current card text**:
+
+```
+<h3 class="h5 fw-semibold">Speckit Workflow</h3>
+<p class="text-body-secondary mb-0">
+  A structured spec-to-implementation pipeline. From specification
+  through planning, task generation, and implementation with quality
+  gates at every step.
+</p>
+```
+
+**New card text** (lead with autonomous capability):
+
+```
+<h3 class="h5 fw-semibold">One-Command Pipeline</h3>
+<p class="text-body-secondary mb-0">
+  Run /unleash to go from spec to demo-ready code autonomously.
+  The swarm handles clarification, planning, implementation,
+  testing, and review — pausing only when it needs you.
+</p>
+```
+
+**Rationale**: The current card describes the pipeline as a multi-step process. The new card leads with the single-command capability -- the most compelling differentiator.
+
+## R3: Quick Start Current State
+
+**Decision**: Add `/unleash` as the first option in "Start Working", reframe `/speckit.specify` as the manual alternative.
+
+**Source**: `content/docs/getting-started/quick-start.md` lines 37-43
+
+**Current "Start Working" section** offers `/swarm` and `/speckit.specify`. Neither mentions `/unleash`.
+
+**New structure**:
+
+```
+For the fastest path — one command from spec to demo:
+/unleash
+
+For step-by-step control over each pipeline stage:
+/speckit.specify
+```
+
+## R4: Developer Guide Current State
+
+**Decision**: Add a prominent `/unleash` callout before the individual Speckit command listing.
+
+**Source**: `content/docs/getting-started/developer.md` "Working with Speckit" section
+
+The section currently lists individual commands (`/speckit.specify`, `/speckit.plan`, etc.) with no mention of `/unleash`. Add a note at the top: "For autonomous execution of the entire pipeline, run `/unleash`. The commands below give you step-by-step control."
+
+## R5: Common Workflows Section Order
+
+**Decision**: Reorder H2 sections to place `/unleash` first.
+
+**Source**: `content/docs/getting-started/common-workflows.md`
+
+**Current H2 order**:
+
+1. New Feature (End-to-End)
+2. Bug Fix (Tactical)
+3. Autonomous Pipeline (`/unleash`)
+4. End-of-Branch Workflow (`/finale`)
+5. Code Review
+6. Environment Setup
+7. Next Steps
+
+**New H2 order**:
+
+1. Autonomous Pipeline (`/unleash`) -- the headline capability
+2. End-of-Branch Workflow (`/finale`) -- unleash builds, finale ships
+3. New Feature (End-to-End) -- with added note: "for step-by-step control"
+4. Bug Fix (Tactical)
+5. Code Review
+6. Environment Setup
+7. Next Steps
+
+**Anchor preservation**: The "New Feature (End-to-End)" heading text stays the same, so the anchor `#new-feature-end-to-end` is preserved.
+
+## R6: /unleash Pipeline Details for Blog Post
+
+**Decision**: Source pipeline details from the /unleash command file and PR #68.
+
+**Source**: Dewey search results for `/unleash` command (upstream `.opencode/command/unleash.md`, GitHub PR #68)
+
+**8-step pipeline**:
+
+1. **Clarify**: Scans spec for `[NEEDS CLARIFICATION]` markers. If Dewey is available, auto-resolves by searching the knowledge graph. Unanswerable questions exit for human input.
+2. **Plan**: Generates `plan.md` with technical context, constitution check, research, and design decisions.
+3. **Tasks**: Generates `tasks.md` with phased, dependency-ordered task list. Sequential and parallel (`[P]`) tasks.
+4. **Spec Review**: Runs the Divisor review council in spec review mode. Auto-fixes LOW/MEDIUM findings. Exits on HIGH/CRITICAL.
+5. **Implement**: Executes tasks phase by phase. Parallel tasks spawn Swarm worktrees (max 4 concurrent). Phase checkpoints run CI commands.
+6. **Code Review**: Runs the Divisor review council in code review mode. Phase 1a CI gate + Phase 1b Gaze quality. Up to 3 fix iterations.
+7. **Retrospective**: Stores learnings in Hivemind semantic memory for future sessions.
+8. **Demo**: Presents what was built, how to verify, key files changed, and next steps (`/finale` or iterate).
+
+**Exit points** (pipeline pauses for human judgment):
+
+- Unanswerable clarification questions (Dewey couldn't resolve)
+- HIGH/CRITICAL spec review findings
+- Build/test failures after a phase
+- Parallel worker failures or merge conflicts
+- 3 code review iterations exhausted
+
+**Resumability**: On re-run, `/unleash` detects which steps are complete by checking filesystem state (plan.md exists? tasks.md has spec-review marker? all checkboxes done?) and skips forward.
+
+**Graceful degradation**: Every tool is optional:
+
+- Without Dewey: clarification questions require human input
+- Without Swarm: parallel tasks run sequentially
+- Without Gaze: code review skips quality analysis
+- Without Hivemind: retrospective displays learnings instead of storing them
+
+## R7: Getting Started Landing Page and Product Owner Guide
+
+**Decision**: Minor text updates to surface `/unleash`.
+
+**Getting Started `_index.md`**: Change Common Workflows description from "End-to-end flows for features, bug fixes, code reviews, and setup" to something that mentions the autonomous pipeline.
+
+**Product Owner `product-owner.md`**: Add `/unleash` alongside `/workflow seed` in the autonomous workflow section. The PO guide describes the swarm's autonomous behavior conceptually but never names the command.

--- a/specs/013-unleash-visibility/spec.md
+++ b/specs/013-unleash-visibility/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: Unleash Visibility
+
+**Feature Branch**: `013-unleash-visibility`
+**Created**: 2026-03-31
+**Status**: Ready
+**Input**: User description: "Surface /unleash as the flagship capability across the website. Implement all recommendations from the tech writer/PR review: blog post, homepage/Quick Start/developer guide cross-references, common-workflows restructuring, and homepage CTA update."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — Blog Post: From Spec to Demo in One Command (Priority: P1)
+
+A developer discovers the Unbound Force blog through search or social sharing. They read a post that walks through a real `/unleash` run -- from a 1-sentence seed to demo-ready code -- showing the actual 8-step pipeline with terminal output at each stage. The post explains how Dewey auto-clarifies questions, how Swarm runs parallel workers, and how the Divisor review council gates quality. By the end, the reader understands the full autonomous workflow and has a concrete command they can run immediately.
+
+**Why this priority**: A blog post is the highest-PR-value deliverable. It can be shared on Hacker News, dev.to, and social media independently of the rest of the website. The two existing blog posts (Gaze-focused) are the site's strongest content -- an `/unleash` post would broaden the audience from Go-testing enthusiasts to the entire AI-assisted development community. Blog posts also drive SEO, providing a durable discovery path.
+
+**Independent Test**: Navigate to the blog page and verify the post exists, renders correctly, includes a complete walkthrough of the 8-step pipeline, and has a clear call-to-action linking to the Quick Start page.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the blog index page, **When** they browse the latest articles, **Then** they see a post about the autonomous pipeline that explains what `/unleash` does in its title and description.
+2. **Given** a reader of the blog post, **When** they read the walkthrough, **Then** each of the 8 pipeline steps is explained with a description of what happens at that stage.
+3. **Given** a reader of the blog post, **When** they look for how to get started, **Then** they find a clear path: install instructions and a link to the Quick Start page.
+4. **Given** a reader of the blog post, **When** they look for exit points, **Then** they understand where the pipeline pauses for human judgment and how to resume with a re-run.
+
+---
+
+### User Story 2 — Surface /unleash on Entry-Point Pages (Priority: P1)
+
+A first-time visitor navigates through the site's entry-point pages (homepage, Quick Start, Developer Guide, Getting Started landing, Product Owner guide). Currently, none of these pages mention `/unleash`. After this change, every primary entry path surfaces the autonomous pipeline capability, ensuring visitors discover `/unleash` regardless of which page they land on first.
+
+**Why this priority**: The audit found that `/unleash` appears on 1 of 22 pages. This is the core discovery problem -- adding cross-references to 5 high-traffic entry pages immediately multiplies visibility. Combined with the blog post (US1), this ensures both external discovery (blog/search) and internal discovery (site navigation) are covered.
+
+**Independent Test**: Navigate to the homepage, Quick Start, Developer Guide, Getting Started landing page, and Product Owner guide. On each page, search for "unleash" and verify it appears with a link to the full documentation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the homepage, **When** they read the feature cards in the "Why Unbound Force?" section, **Then** they find the autonomous pipeline capability mentioned prominently, with `/unleash` named.
+2. **Given** a new user on the Quick Start page, **When** they reach the "Start Working" section, **Then** `/unleash` is presented as the first and simplest option, with `/speckit.specify` offered for manual control.
+3. **Given** a developer reading the Developer Guide, **When** they reach the Speckit pipeline section, **Then** they find a prominent note at the top indicating `/unleash` runs the entire pipeline autonomously, before the individual command listing.
+4. **Given** a visitor on the Getting Started landing page, **When** they read the Common Workflows description, **Then** it surfaces the autonomous pipeline capability rather than a generic description.
+5. **Given** a product owner reading their guide, **When** they read about the swarm's autonomous workflow, **Then** `/unleash` is named as the command alongside `/workflow seed`.
+
+---
+
+### User Story 3 — Restructure Common Workflows Page (Priority: P2)
+
+A developer opens the Common Workflows page to learn how to work with the swarm. Currently, `/unleash` is the 3rd of 7 sections, buried 277 lines deep behind the entire manual 6-stage lifecycle and the bug fix workflow. After restructuring, the autonomous pipeline is the first thing they see -- with the manual workflow presented as an alternative for when fine-grained control is needed.
+
+**Why this priority**: This is the only page that documents `/unleash`, so its position within the page determines discoverability for anyone who does navigate here. The restructuring reinforces the message from US2's cross-references: the autonomous pipeline is the recommended path, not a footnote.
+
+**Independent Test**: Open common-workflows.md and verify that the Autonomous Pipeline section appears before the manual New Feature section, and that the page narrative flows from "easiest path" to "manual control" to "tactical fixes."
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer opening the Common Workflows page, **When** they start reading, **Then** the first workflow section they encounter is the Autonomous Pipeline (`/unleash`), not the manual 6-stage lifecycle.
+2. **Given** a developer reading the restructured page, **When** they look at the table of contents, **Then** the section order communicates a clear narrative: autonomous pipeline first, end-of-branch workflow second, manual feature workflow third, bug fix workflow fourth, code review fifth, environment setup last.
+3. **Given** a developer who wants manual control, **When** they scroll past the `/unleash` section, **Then** they find the manual New Feature workflow with a note indicating it is the step-by-step alternative to `/unleash`.
+
+---
+
+### User Story 4 — Homepage CTA and Feature Card Update (Priority: P2)
+
+A visitor lands on the homepage and sees a compelling description of the autonomous pipeline capability alongside a direct call-to-action. Currently, the homepage's "Speckit Workflow" feature card describes a multi-step manual process, and the CTA sends visitors to either GitHub (code repo) or the Quick Start (generic setup). After this change, the homepage communicates the autonomous capability and provides a clear path to try it.
+
+**Why this priority**: The homepage is the highest-traffic page and sets the visitor's first impression. Currently it undersells the system's most compelling capability. This change is lower priority than the blog post (US1) and cross-references (US2) because those create new discovery paths, while this optimizes an existing one.
+
+**Independent Test**: Visit the homepage and verify: (a) the feature card section mentions autonomous pipeline capability, (b) the bottom CTA section invites visitors to try the swarm with a link to the Quick Start.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the homepage, **When** they read the "Why Unbound Force?" feature cards, **Then** the Speckit Workflow card or a new card communicates that one command takes a spec from draft to demo-ready code, not just that a structured pipeline exists.
+2. **Given** a visitor who reaches the bottom CTA, **When** they look for how to get started, **Then** they find a primary action that leads to the Quick Start (where `/unleash` is now the first option), not just to GitHub.
+
+---
+
+### Edge Cases
+
+- What happens when the blog post references pipeline stages that are documented in common-workflows.md? The blog post must link to the detailed documentation rather than duplicating it. The post should be self-contained enough to understand the concept but link out for reference details.
+- What happens when a reader arrives at the old common-workflows URL with an anchor link to the manual New Feature section? Anchor links change when sections are reordered. The manual New Feature section should keep the same anchor slug (`#new-feature-end-to-end`) despite its new position in the page to avoid breaking external links.
+- What happens when `/unleash` behavior changes in a future version? The blog post should describe the current capability without version-coupling the narrative. Use present tense and avoid specific version numbers in the post.
+- What happens when a visitor reads the homepage feature card but doesn't have the swarm installed? The card should describe the capability without assuming installation. The CTA should point to Quick Start, which handles installation first.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+**Blog Post (US1):**
+
+- **FR-001**: The website MUST have a blog post that walks through the `/unleash` pipeline from a feature seed to demo-ready output.
+- **FR-002**: The blog post MUST describe all 8 pipeline steps (clarify, plan, tasks, spec review, implement, code review, retrospective, demo) with what happens at each stage.
+- **FR-003**: The blog post MUST explain exit points -- where the pipeline pauses for human judgment -- and how resuming works.
+- **FR-004**: The blog post MUST describe the key capabilities that make `/unleash` autonomous: Dewey-powered clarification, parallel Swarm workers, Divisor review council, Hivemind learning storage.
+- **FR-005**: The blog post MUST include a "Getting Started" section with install instructions and a link to the Quick Start page.
+- **FR-006**: The blog post MUST follow the existing blog post conventions: YAML frontmatter with title, description, lead, slug, date, categories, tags, contributors; body starting with H2; fenced code blocks with language identifiers.
+
+**Entry-Point Cross-References (US2):**
+
+- **FR-007**: The homepage feature cards MUST mention the autonomous pipeline capability with `/unleash` named.
+- **FR-008**: The Quick Start "Start Working" section MUST present `/unleash` as the first and simplest option, followed by `/speckit.specify` for manual control.
+- **FR-009**: The Developer Guide Speckit section MUST include a prominent note indicating `/unleash` runs the entire pipeline autonomously, placed before the individual command listing.
+- **FR-010**: The Getting Started landing page MUST update the Common Workflows description to surface the autonomous pipeline.
+- **FR-011**: The Product Owner guide MUST name `/unleash` alongside `/workflow seed` when describing the swarm's autonomous workflow.
+
+**Common Workflows Restructuring (US3):**
+
+- **FR-012**: The common-workflows page MUST place the Autonomous Pipeline (`/unleash`) section before the manual New Feature (End-to-End) section.
+- **FR-013**: The End-of-Branch Workflow (`/finale`) section MUST immediately follow the Autonomous Pipeline section (unleash builds, finale ships).
+- **FR-014**: The manual New Feature section MUST include a note at the top indicating it is the step-by-step alternative to `/unleash` for when fine-grained control is needed.
+- **FR-015**: The manual New Feature section MUST preserve the anchor slug `#new-feature-end-to-end` to avoid breaking external links.
+
+**Homepage CTA (US4):**
+
+- **FR-016**: The homepage Speckit Workflow feature card MUST communicate that one command takes a spec from draft to demo-ready code.
+- **FR-017**: The homepage bottom CTA MUST lead visitors to the Quick Start page as the primary action.
+
+**Developer Guide Daily Workflow (US2, clarification):**
+
+- **FR-020**: The Developer Guide "Daily Workflow" section MUST be rewritten to center on the specify -> unleash -> (clarify if needed) -> finale loop, replacing the current generic session flow (`uf doctor`, `hive_ready()`, `/swarm`, `hive_sync()`, `git push`).
+
+**Cross-cutting:**
+
+- **FR-018**: The blog post MUST cross-link to common-workflows for detailed pipeline documentation rather than duplicating reference content.
+- **FR-019**: All documentation changes MUST pass `npm run build` without errors.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: `/unleash` is mentioned on at least 7 user-facing pages (blog post + homepage + Quick Start + Developer Guide + Getting Started landing + Product Owner guide + common-workflows) -- up from 1 page currently.
+- **SC-002**: A visitor starting from the homepage can discover `/unleash` documentation within 2 clicks (homepage -> Quick Start -> `/unleash` is first option).
+- **SC-003**: The blog post exists at a discoverable URL (`/blog/unleash-in-practice/`) and its frontmatter `title` and `description` contain the terms "autonomous," "pipeline," and "spec to code" for search relevance.
+- **SC-004**: The Autonomous Pipeline section appears before the manual New Feature section in common-workflows.md -- visible without scrolling past other workflow documentation.
+- **SC-005**: `npm run build` succeeds with zero errors after all changes.
+- **SC-006**: Zero broken anchor links result from the common-workflows restructuring -- verified by checking external link patterns.
+
+## Clarifications
+
+### Session 2026-03-31
+
+- Q: Should the Developer Guide's "Daily Workflow" section be updated to reflect the unleash-centered workflow? → A: Yes. The daily workflow should be focused on specify -> unleash (maybe back to clarify) -> finale, replacing the current generic session flow.
+
+## Assumptions
+
+- The blog post will follow the same format and quality standard as the existing Gaze blog posts ("Why Contract Coverage" and "Gaze in Practice") -- technical depth with real-world grounding, not marketing fluff.
+- The blog post will describe the current `/unleash` behavior without hardcoding version numbers, so it remains accurate across minor releases.
+- The homepage feature card update will modify the existing "Speckit Workflow" card text rather than adding a 5th card, to maintain the current 4-card grid layout.
+- The common-workflows restructuring will reorder existing H2 sections without rewriting their content (content was just written in spec 012).
+- The anchor slug `#new-feature-end-to-end` will be preserved using Hugo's heading ID override syntax or by keeping the exact heading text.
+- The blog post's example will use a realistic but generic feature description (not a real project) to avoid coupling to specific repo state.
+- The Getting Started landing page's Common Workflows link description will be updated in the list-item text, not requiring any structural page changes.

--- a/specs/013-unleash-visibility/tasks.md
+++ b/specs/013-unleash-visibility/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: Unleash Visibility
+
+**Input**: Design documents from `/specs/013-unleash-visibility/`
+**Tests**: Not applicable. Static documentation site. Validation is `npm run build` + visual verification.
+
+## Format: `[ID] [P?] [Story] Description`
+
+---
+
+## Phase 1: User Story 1 — Blog Post (Priority: P1)
+
+**Goal**: Create a blog post that walks through the `/unleash` pipeline from spec to demo.
+
+**Independent Test**: Navigate to `/blog/` and verify the post exists with all 8 pipeline steps, exit points, and a Getting Started section.
+
+- [x] T001 [US1] Create content/blog/unleash-in-practice.md with frontmatter (title, description, lead, slug, date, categories: Engineering, tags: unleash/swarm/autonomous/pipeline, contributors: Unbound Force) and write the full blog post covering: the problem (manual multi-step pipelines), what /unleash does (single command, 8 steps), the 8-step pipeline walkthrough, exit points and resumability, key capabilities (Dewey clarification, Swarm parallelism, Divisor review, Hivemind learning), the unleash+finale loop, and a Getting Started section linking to Quick Start. Source: research.md R1, R6. (FR-001 through FR-006, FR-018)
+
+**Checkpoint**: `npm run build` must succeed. Blog post renders on `/blog/`.
+
+---
+
+## Phase 2: User Story 2 — Entry-Point Cross-References (Priority: P1)
+
+**Goal**: Surface `/unleash` on 5 entry-point pages so visitors discover it regardless of entry path.
+
+**Independent Test**: Search each of the 5 pages for "unleash" and verify it appears with a link.
+
+- [x] T002 [P] [US2] Update the "Speckit Workflow" feature card in layouts/home.html to communicate the one-command autonomous pipeline. Change heading to "One-Command Pipeline" and rewrite description to lead with /unleash. (FR-007, FR-016)
+- [x] T003 [P] [US2] Update the "Start Working" section in content/docs/getting-started/quick-start.md to present /unleash as the first and simplest option, followed by /speckit.specify for manual control. (FR-008)
+- [x] T004 [P] [US2] Add a prominent /unleash callout note before the individual Speckit command listing in the "Working with Speckit" section of content/docs/getting-started/developer.md. (FR-009)
+- [x] T005 [P] [US2] Update the Common Workflows bullet description in content/docs/getting-started/\_index.md to surface the autonomous pipeline capability. (FR-010)
+- [x] T006 [P] [US2] Add /unleash as the named command alongside /workflow seed in the autonomous workflow section of content/docs/getting-started/product-owner.md. (FR-011)
+
+**Checkpoint**: `npm run build` must succeed. All 5 pages mention `/unleash`.
+
+---
+
+## Phase 3: User Story 3 — Restructure Common Workflows (Priority: P2)
+
+**Goal**: Move the Autonomous Pipeline section to the top of common-workflows.md so it's the first workflow a reader encounters.
+
+**Independent Test**: Open common-workflows.md and verify the Autonomous Pipeline section appears before the manual New Feature section.
+
+- [x] T007 [US3] Reorder the H2 sections in content/docs/getting-started/common-workflows.md: move Autonomous Pipeline (/unleash) to position 1, End-of-Branch Workflow (/finale) to position 2, keep New Feature (End-to-End) at position 3. Use Hugo's explicit heading ID syntax `{#new-feature-end-to-end}` on the New Feature heading to guarantee anchor stability regardless of future heading text edits. (FR-012, FR-013, FR-015)
+- [x] T008 [US3] Add a note at the top of the New Feature (End-to-End) section in content/docs/getting-started/common-workflows.md indicating it is the step-by-step alternative to /unleash for when fine-grained control is needed. (FR-014)
+
+**Checkpoint**: `npm run build` must succeed. TOC shows new order. `#new-feature-end-to-end` anchor preserved.
+
+---
+
+## Phase 4: Verification
+
+- [x] T009 Run `npm run build` and verify zero errors (FR-019)
+- [x] T010 Count pages mentioning /unleash -- must be at least 7 (SC-001)
+- [x] T011 Verify anchor #new-feature-end-to-end is preserved in common-workflows.md (SC-006)
+
+<!-- spec-review: passed -->


### PR DESCRIPTION
## Summary

- Add **blog post** "From Spec to Demo in One Command" — a technical walkthrough of the /unleash pipeline covering all 8 stages, exit points, graceful degradation, limitations, and the unleash+finale developer loop
- **Surface /unleash on 7 pages** (up from 1): homepage feature card, Quick Start, Developer Guide, Getting Started landing, Product Owner guide, common-workflows, and the blog post
- **Restructure common-workflows.md** — move Autonomous Pipeline to the first H2 section; /finale follows immediately; manual workflow gets a note pointing to /unleash
- **Rewrite Developer Guide daily workflow** to the specify -> unleash -> finale loop, replacing the old generic session flow
- **Update homepage** feature card to "Spec to Demo in One Command" with /unleash named in the description
- Add 2 new Divisor personas: **divisor-techwriter** (documentation clarity/usability) and **divisor-pr** (public perception/messaging)
- Add **Markdown convention pack** (45 rules for content quality, blog posts, cross-referencing, credibility)
- Include spec artifacts for 013-unleash-visibility

## Review Council

All 7 Divisor personas invoked (5 existing + 2 new). 11 findings addressed in iteration 1:
- Blog description rewritten for social media shareability (PR HIGH)
- Divisor persona count dropped from blog prose (Adversary MEDIUM)
- common-workflows description frontmatter updated (Adversary MEDIUM)
- Weasel word "just" removed from blog + developer guide (Tech Writer MEDIUM)
- Em-dashes normalized in blog post (Architect MEDIUM)
- 7 bare code blocks given language IDs (Architect MEDIUM)
- Blog link repositioned as "See also" (PR MEDIUM)
- Homepage card heading improved (PR MEDIUM)
- Limitations section added to blog (PR MEDIUM)
- Spec status updated (Guard MEDIUM)
- Blog cross-links expanded (SRE/Tester LOW)