### PR TITLE
feat: replace Swarm plugin with Replicator across the website

### DIFF
--- a/.opencode/agents/cobalt-crush-dev.md
+++ b/.opencode/agents/cobalt-crush-dev.md
@@ -4,13 +4,14 @@ mode: subagent
 model: google-vertex-anthropic/claude-opus-4-6@default
 temperature: 0.4
 ---
+
 <!-- scaffolded by uf vdev -->
 
 # Role: Cobalt-Crush — The Developer
 
 You are the Engineering Core of the Unbound Force swarm. You implement features from specifications with a clear engineering philosophy: clean code, SOLID principles, test-driven awareness, and spec-driven development. You produce code designed to pass Gaze's quality validation and The Divisor's multi-persona review.
 
-You are the coding persona for `/speckit.implement`. The implement command orchestrates *what* to execute (task ordering, dependency resolution, phase checkpoints). You define *how* each task is executed: which conventions to follow, when to generate test hooks, how to document decisions, and how to integrate feedback.
+You are the coding persona for `/speckit.implement`. The implement command orchestrates _what_ to execute (task ordering, dependency resolution, phase checkpoints). You define _how_ each task is executed: which conventions to follow, when to generate test hooks, how to document decisions, and how to integrate feedback.
 
 ## Source Documents
 
@@ -27,7 +28,7 @@ Before writing code, read the following in order:
 
 ### Core Principles
 
-- **Clean Code**: Functions should do one thing, do it well, and do it only. Names should reveal intent. Comments explain *why*, not *what*. No dead code.
+- **Clean Code**: Functions should do one thing, do it well, and do it only. Names should reveal intent. Comments explain _why_, not _what_. No dead code.
 - **SOLID**: Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, Dependency Inversion. Apply at the function, type, and package level.
 - **DRY / YAGNI**: Don't repeat yourself. Don't build features that aren't needed yet. Extract only when there are 3+ duplications.
 - **Separation of Concerns**: Business logic, I/O, configuration, and presentation are distinct layers. Dependencies flow inward.
@@ -37,6 +38,7 @@ Before writing code, read the following in order:
 ### Design Decision Documentation
 
 When making non-trivial design choices:
+
 1. Document the decision in a code comment at the point of implementation
 2. Cite the relevant principle (e.g., "Chose Strategy pattern per SOLID Open/Closed Principle")
 3. Note alternatives considered and why they were rejected
@@ -49,6 +51,7 @@ When making non-trivial design choices:
 Before writing code, load the active convention pack from `.opencode/unbound/packs/`. Apply all rules tagged with `[MUST]` as mandatory requirements. Apply `[SHOULD]` rules as strong recommendations. Apply `[MAY]` rules as optional improvements.
 
 Key areas from convention packs:
+
 - **Coding Style** (CS-NNN): Formatting, naming, import organization, error handling
 - **Architectural Patterns** (AP-NNN): Design patterns, dependency injection, package boundaries
 - **Testing Conventions** (TC-NNN): Test naming, isolation, assertion depth, coverage strategy
@@ -59,6 +62,7 @@ If no convention pack is loaded, apply universal principles: consistent formatti
 ### 2. Test Hook Generation
 
 Every function you write must be testable. Apply these patterns:
+
 - **Interface abstractions**: External dependencies (filesystem, network, time, random) must be injected as interfaces
 - **Dependency injection**: Use constructor injection (`NewFoo(deps)`) or `Options` structs, not global state
 - **Exported test helpers**: For complex setup, export test helpers in `_test.go` files or `testutil` packages
@@ -68,7 +72,7 @@ Every function you write must be testable. Apply these patterns:
 ### 3. Documentation
 
 - **Exported symbols**: Every exported function, type, and constant must have a documentation comment (GoDoc, JSDoc, or language equivalent)
-- **Inline comments**: Explain *why*, not *what*. The code explains what; comments explain the reasoning.
+- **Inline comments**: Explain _why_, not _what_. The code explains what; comments explain the reasoning.
 - **Error messages**: Include context — wrap errors with `fmt.Errorf("operation context: %w", err)` or equivalent
 - **Design decisions**: Non-obvious choices get a comment citing the principle or trade-off
 
@@ -101,6 +105,7 @@ After writing code, check for Gaze quality feedback:
 Before submitting for review and after receiving review feedback:
 
 ### Pre-Review Checklist
+
 1. All convention pack `[MUST]` rules are satisfied
 2. All exported symbols have documentation comments
 3. All error paths are handled
@@ -127,6 +132,7 @@ Before submitting for review and after receiving review feedback:
 When working with the speckit pipeline and `/speckit.implement`:
 
 ### Task Processing
+
 1. **Read `tasks.md`**: Identify the current phase and its tasks
 2. **Dependency order**: Process tasks in the order listed. Tasks without `[P]` markers are sequential — complete each before starting the next.
 3. **Parallelization**: Tasks marked `[P]` can be executed concurrently if they touch different files. Tasks modifying the same file must be sequential.
@@ -134,32 +140,40 @@ When working with the speckit pipeline and `/speckit.implement`:
 5. **Completion**: Mark each task `[x]` in `tasks.md` immediately after completing it. Do not batch completions.
 
 ### Phase Checkpoints
+
 After all tasks in a phase are complete:
+
 1. Run the project's test suite (per AGENTS.md build commands)
 2. Report pass/fail results
 3. Do not proceed to the next phase if tests fail — fix failures first
 
 ### Dependency Handling
+
 If a task depends on another task that is not yet complete:
+
 1. Skip the dependent task
 2. Continue with other available tasks in the phase
 3. Return to the skipped task after its dependency is resolved
 
-## Swarm Coordination
+## Replicator Coordination
 
-When operating as a Swarm worker (spawned via
+When operating as a Replicator worker (spawned via
 `swarm_spawn_subtask()`), follow this protocol:
 
 ### File Reservation Protocol
+
 Before editing any file, MUST call `swarmmail_reserve()`
 with the file paths you intend to modify. This prevents
 conflicts with parallel workers:
+
 ```
 swarmmail_reserve({ paths: ["internal/doctor/checks.go"], reason: "Implementing Ollama check" })
 ```
 
 ### Session Lifecycle
+
 Every session MUST end with:
+
 1. Call `swarm_complete()` with `files_touched` listing all
    modified files
 2. Call `hive_sync()` to persist work items to git
@@ -168,13 +182,15 @@ Every session MUST end with:
 **The plane is not landed until `git push` succeeds.**
 
 ### Progress Reporting
+
 SHOULD call `swarm_progress()` at milestones (25%, 50%,
 75% completion) so the coordinator can track status.
 
-### When NOT Operating Under Swarm
+### When NOT Operating Under Replicator
+
 If you are invoked directly (not via `swarm_spawn_subtask`),
 ignore this section. These protocols only apply when
-Swarm is coordinating parallel workers.
+Replicator is coordinating parallel workers.
 
 ## Decision Framework
 

--- a/.opencode/command/unleash.md
+++ b/.opencode/command/unleash.md
@@ -2,10 +2,11 @@
 description: >
   Run the full Speckit pipeline autonomously: clarify
   ambiguities with Dewey, generate plan and tasks, review
-  specs, implement with parallel Swarm workers, review code,
+  specs,   implement with parallel Replicator workers, review code,
   store learnings, and present demo instructions. Exits to
   the human only when it genuinely needs human judgment.
 ---
+
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 
@@ -40,7 +41,7 @@ previous interrupted runs:
    plan.md, tasks.md, and task checkboxes live in the main
    working directory, not in worktrees.
 
-If `swarm_worktree_list` is not available (Swarm plugin
+If `swarm_worktree_list` is not available (Replicator
 not installed), skip this step silently.
 
 ### 1. Branch Safety Gate
@@ -52,11 +53,13 @@ git rev-parse --abbrev-ref HEAD
 ```
 
 - If on `main`: **STOP** with error:
+
   > "Cannot run /unleash on main. Must be on a Speckit
   > feature branch (`NNN-*`). Run `/speckit.specify`
   > first."
 
 - If on `opsx/*`: **STOP** with error:
+
   > "/unleash is for Speckit strategic specs only. Use
   > `/opsx:apply` for OpenSpec tactical changes."
 
@@ -75,6 +78,7 @@ root:
 
 If the script fails or no spec.md is found: **STOP**
 with error:
+
 > "No spec.md found in the feature directory. Run
 > `/speckit.specify` first."
 
@@ -249,9 +253,11 @@ analysis + quality validation) in a single pass.
 
 - If all reviewers APPROVE: write the spec review marker
   to `tasks.md`:
+
   ```
   <!-- spec-review: passed -->
   ```
+
   Append this marker at the very end of `tasks.md`.
   Proceed to step 5.
 
@@ -308,90 +314,92 @@ of truth. This is the same pattern used by
 3. **Parallel execution**: check if
    `swarm_worktree_create` is available.
 
-   **If Swarm worktrees are available**:
+   **If Replicator worktrees are available**:
 
    a. Get the current commit hash:
-      ```bash
-      git rev-parse HEAD
-      ```
+
+   ```bash
+   git rev-parse HEAD
+   ```
 
    b. Limit concurrent workers to 4. If more than 4
-      `[P]` tasks exist in the phase, batch them: run
-      the first 4, wait for all to complete, then run
-      the next batch.
+   `[P]` tasks exist in the phase, batch them: run
+   the first 4, wait for all to complete, then run
+   the next batch.
 
    c. For each `[P]` task in the current batch:
-      - Call `swarm_worktree_create` with the project
-        path, task ID, and current commit hash to create
-        a dedicated worktree.
-      - Call `swarm_spawn_subtask` with the task
-        description, files from the task, and the
-        worktree path.
+   - Call `swarm_worktree_create` with the project
+     path, task ID, and current commit hash to create
+     a dedicated worktree.
+   - Call `swarm_spawn_subtask` with the task
+     description, files from the task, and the
+     worktree path.
 
    d. Wait for all workers in the batch to complete.
 
    e. **If any worker fails**: stop spawning new workers
-      (do not start the next batch). Wait for any
-      already-running workers to complete or fail. Then
-      call `swarm_worktree_cleanup` with `cleanup_all:
-      true` to remove all worktrees. **EXIT** with error
-      context:
+   (do not start the next batch). Wait for any
+   already-running workers to complete or fail. Then
+   call `swarm_worktree_cleanup` with `cleanup_all:
+true` to remove all worktrees. **EXIT** with error
+   context:
 
-      ```
-      ## /unleash paused at: implement (Phase N)
+   ```
+   ## /unleash paused at: implement (Phase N)
 
-      **Reason**: Parallel worker failed
+   **Reason**: Parallel worker failed
 
-      **Failed task**: [task ID and description]
-      **Error**: [error details from worker]
+   **Failed task**: [task ID and description]
+   **Error**: [error details from worker]
 
-      ### What to do next
-      Fix the issue described above, then re-run
-      `/unleash`.
+   ### What to do next
+   Fix the issue described above, then re-run
+   `/unleash`.
 
-      ### Then resume
-      Run `/unleash` to continue from the failed phase.
-      ```
+   ### Then resume
+   Run `/unleash` to continue from the failed phase.
+   ```
 
    f. After all workers in a batch complete successfully,
-      merge each worktree back:
-      - Call `swarm_worktree_merge` for each worktree.
-        This uses cherry-pick to apply the worker's
-        commits to the main branch.
-      - After each merge, check for conflict markers
-        (`<<<<<<<`, `=======`, `>>>>>>>`) in the
-        affected files.
-      - If NO conflict markers remain: merge succeeded.
-        Call `swarm_worktree_cleanup` for that worktree.
-      - If conflict markers remain: auto-resolution
-        failed. Call `swarm_worktree_cleanup` with
-        `cleanup_all: true`. **EXIT** with conflict
-        details:
+   merge each worktree back:
+   - Call `swarm_worktree_merge` for each worktree.
+     This uses cherry-pick to apply the worker's
+     commits to the main branch.
+   - After each merge, check for conflict markers
+     (`<<<<<<<`, `=======`, `>>>>>>>`) in the
+     affected files.
+   - If NO conflict markers remain: merge succeeded.
+     Call `swarm_worktree_cleanup` for that worktree.
+   - If conflict markers remain: auto-resolution
+     failed. Call `swarm_worktree_cleanup` with
+     `cleanup_all: true`. **EXIT** with conflict
+     details:
 
-        ```
-        ## /unleash paused at: implement (Phase N)
+     ```
+     ## /unleash paused at: implement (Phase N)
 
-        **Reason**: Worktree merge conflict
+     **Reason**: Worktree merge conflict
 
-        **Conflicting files**:
-        [list files with conflict markers]
+     **Conflicting files**:
+     [list files with conflict markers]
 
-        ### What to do next
-        Resolve the merge conflicts manually, then
-        re-run `/unleash`.
+     ### What to do next
+     Resolve the merge conflicts manually, then
+     re-run `/unleash`.
 
-        ### Then resume
-        Run `/unleash` to continue from the current
-        phase.
-        ```
+     ### Then resume
+     Run `/unleash` to continue from the current
+     phase.
+     ```
 
    g. Mark each successfully merged `[P]` task as `[x]`
-      in `tasks.md`.
+   in `tasks.md`.
 
-   **If Swarm worktrees are NOT available**: fall back to
+   **If Replicator worktrees are NOT available**: fall back to
    sequential execution for `[P]` tasks. Announce:
-   > "Swarm worktrees not available -- executing parallel
-   > tasks sequentially. Install the Swarm plugin for
+
+   > "Replicator worktrees not available -- executing parallel
+   > tasks sequentially. Install Replicator for
    > parallel execution."
 
    Execute each `[P]` task sequentially via the
@@ -512,8 +520,9 @@ memory.
 
 4. **If Hivemind is NOT available**: skip the storage
    step with an informational note:
+
    > "Hivemind not available -- retrospective learnings
-   > not stored. Install the Swarm plugin for semantic
+   > not stored. Install Replicator for semantic
    > memory."
 
    Display the learnings in the output so they are not
@@ -533,9 +542,11 @@ Present structured demo instructions to the developer.
    spec.md.
 
 3. **Key Files Changed**: run:
+
    ```bash
    git diff --name-only main...HEAD
    ```
+
    List the changed files grouped by directory.
 
 4. **Test Results**: summarize the test output from the

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.3.17"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.17.tgz",
+      "integrity": "sha512-N5lckFtYvEu2R8K1um//MIOTHsJHniF2kHoPIWPCrxKG5Jpismt1ISGzIiU3aKI2ht/9VgcqKPC5oZFLdmpxPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.17",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.96",
+        "@opentui/solid": ">=0.1.96"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.17.tgz",
+      "integrity": "sha512-2+MGgu7wynqTBwxezR01VAGhILXlpcHDY/pF7SWB87WOgLt3kD55HjKHNj6PWxyY8n575AZolR95VUC3gtwfmA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/.opencode/skill/speckit-workflow/SKILL.md
+++ b/.opencode/skill/speckit-workflow/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: speckit-workflow
-description: "Teaches the Swarm coordinator to follow Speckit's pre-decomposed tasks.md as the authoritative task breakdown instead of generating its own decomposition via CASS."
+description: "Teaches the Replicator coordinator to follow Speckit's pre-decomposed tasks.md as the authoritative task breakdown instead of generating its own decomposition via CASS."
 tags:
   - speckit
   - workflow
   - decomposition
 ---
+
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
-# Speckit Workflow — Swarm Skill
+# Speckit Workflow — Replicator Skill
 
-This skill teaches you (the Swarm coordinator) how to work
+This skill teaches you (the Replicator coordinator) how to work
 with Speckit's pre-decomposed task lists. When a `tasks.md`
 file exists for the active feature, it is the authoritative
 decomposition — do NOT re-decompose via CASS.
@@ -44,7 +45,7 @@ Tasks are organized into numbered phases:
 ## Phase N: Polish
 ```
 
-**Map each phase to a Swarm epic.** Phase 1 becomes
+**Map each phase to a Replicator epic.** Phase 1 becomes
 epic "Setup", Phase 2 becomes epic "Foundational", etc.
 
 ### Task Format
@@ -61,7 +62,7 @@ Each task follows this format:
   other `[P]` tasks in the same phase (they touch different
   files). Tasks WITHOUT `[P]` are sequential.
 - **`[US1]` label**: Maps to User Story 1 from the spec.
-  Use as cell metadata when creating Swarm cells.
+  Use as cell metadata when creating Replicator cells.
 - **Description**: What to do and which file to modify.
 
 ### Phase Dependencies
@@ -72,7 +73,7 @@ Each task follows this format:
   as independent in the Dependencies section of tasks.md.
 - **Polish** phase runs after all User Story phases.
 
-## Creating Swarm Work Items
+## Creating Replicator Work Items
 
 1. **Read the full `tasks.md`** to understand all phases.
 

--- a/content/blog/unleash-in-practice.md
+++ b/content/blog/unleash-in-practice.md
@@ -82,11 +82,11 @@ LOW and MEDIUM findings are auto-fixed. If HIGH or CRITICAL findings remain, the
 Executes tasks phase by phase. Within each phase:
 
 - **Sequential tasks** run in order via the [Cobalt-Crush](/docs/team/cobalt-crush/) developer agent
-- **Parallel tasks** (marked `[P]`) spawn independent [Swarm](/docs/getting-started/developer/#working-with-swarm) workers, each in a dedicated git worktree, up to 4 concurrent workers
+- **Parallel tasks** (marked `[P]`) spawn independent [Replicator](/docs/getting-started/developer/#working-with-replicator) workers, each in a dedicated git worktree, up to 4 concurrent workers
 
 After each phase, the pipeline runs the CI build and test commands (derived from `.github/workflows/`, not hardcoded). If anything fails, it exits with the failure details.
 
-If Swarm worktrees are not available, parallel tasks fall back to sequential execution. The pipeline adapts to whatever tools are installed.
+If Replicator worktrees are not available, parallel tasks fall back to sequential execution. The pipeline adapts to whatever tools are installed.
 
 ### 6. Code Review
 
@@ -143,12 +143,12 @@ After `/unleash` presents demo instructions, run `/finale` to automate the end-o
 
 `/unleash` is designed for graceful degradation. Every external tool it uses has a fallback:
 
-| Tool     | If Available                          | If Not Available               |
-| -------- | ------------------------------------- | ------------------------------ |
-| Dewey    | Auto-resolves clarification questions | Questions exit for human input |
-| Swarm    | Parallel task execution in worktrees  | Sequential execution           |
-| Gaze     | Quality analysis in code review       | Code review skips quality data |
-| Hivemind | Stores retrospective learnings        | Displays learnings in output   |
+| Tool       | If Available                          | If Not Available               |
+| ---------- | ------------------------------------- | ------------------------------ |
+| Dewey      | Auto-resolves clarification questions | Questions exit for human input |
+| Replicator | Parallel task execution in worktrees  | Sequential execution           |
+| Gaze       | Quality analysis in code review       | Code review skips quality data |
+| Hivemind   | Stores retrospective learnings        | Displays learnings in output   |
 
 The pipeline works with all four tools, with none of them, or with any combination. You get the most autonomous experience with the full stack, but the pipeline never fails because a tool is missing.
 

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -18,13 +18,13 @@ But these are not just instruction files. Each hero can include LSP servers, MCP
 
 Unbound Force is built on three complementary tools that form a layered stack:
 
-| Layer            | Tool                                                     | What It Does                                                                                                    |
-| ---------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **Agent**        | [OpenCode](https://opencode.ai)                          | The AI coding environment where you interact, write code, and run commands. The personas run inside OpenCode.   |
-| **Planning**     | [Speckit](https://github.com/github/spec-kit) (spec-kit) | A specification pipeline that turns ideas into structured specs, plans, and tasks before implementation begins. |
-| **Coordination** | [Swarm](https://www.swarmtools.ai/)                      | An OpenCode plugin that enables multi-agent parallelism and learning amongst team members.                      |
+| Layer            | Tool                                                      | What It Does                                                                                                               |
+| ---------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Agent**        | [OpenCode](https://opencode.ai)                           | The AI coding environment where you interact, write code, and run commands. The personas run inside OpenCode.              |
+| **Planning**     | [Speckit](https://github.com/github/spec-kit) (spec-kit)  | A specification pipeline that turns ideas into structured specs, plans, and tasks before implementation begins.            |
+| **Coordination** | [Replicator](https://github.com/unbound-force/replicator) | Multi-agent coordination: parallel workers, git-backed tracking, file reservations, and semantic memory. Single Go binary. |
 
-Each tool is independently useful, but they compose into the full Unbound Force workflow: plan with Speckit, execute with OpenCode, coordinate with Swarm.
+Each tool is independently useful, but they compose into the full Unbound Force workflow: plan with Speckit, execute with OpenCode, coordinate with Replicator.
 
 ## The Heroes
 
@@ -42,7 +42,7 @@ Together, they cover the full software development lifecycle -- from requirement
 
 Ready to dive in? Start with the [Quick Start](/docs/getting-started/quick-start/) guide to install the tools, then pick the guide for your role:
 
-- **[Developer / Engineer](/docs/getting-started/developer/)** -- Daily workflow, Speckit pipeline, Swarm coordination, convention packs
+- **[Developer / Engineer](/docs/getting-started/developer/)** -- Daily workflow, Speckit pipeline, Replicator coordination, convention packs
 - **[Tester](/docs/getting-started/tester/)** -- Gaze quality analysis, CRAP scores, coverage ratchets, CI integration
 - **[Product Owner](/docs/getting-started/product-owner/)** -- Muti-Mind backlog management, priority scoring, acceptance decisions
 - **[Product Manager](/docs/getting-started/product-manager/)** -- Mx F metrics, dashboards, coaching, retrospectives

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -14,21 +14,21 @@ toc: true
 
 ### The Pipeline
 
-| Step | Name              | Description                                                                                                                                                                   |
-| ---- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1    | **Clarify**       | Scans spec.md for `[NEEDS CLARIFICATION]` markers. Uses Dewey semantic search to auto-resolve. Exits to human only for unanswerable questions.                                |
-| 2    | **Plan**          | Delegates to Cobalt-Crush to generate `plan.md` via `/speckit.plan`                                                                                                           |
-| 3    | **Tasks**         | Delegates to Cobalt-Crush to generate `tasks.md` via `/speckit.tasks`                                                                                                         |
-| 4    | **Spec Review**   | Runs the review council in Spec Review Mode. Auto-fixes LOW/MEDIUM findings. Exits on HIGH/CRITICAL.                                                                          |
-| 5    | **Implement**     | Parses `tasks.md` for phases. `[P]` parallel tasks run via Swarm worktrees (up to 4 concurrent workers). Phase checkpoints run CI commands derived from `.github/workflows/`. |
-| 6    | **Code Review**   | Runs the review council in Code Review Mode. Includes Phase 1a CI hard gate, Phase 1b Gaze quality analysis, and Divisor agent reviews. Up to 3 fix iterations.               |
-| 7    | **Retrospective** | Analyzes the session and stores learnings in Hivemind semantic memory.                                                                                                        |
-| 8    | **Demo**          | Presents structured demo instructions: what was built, how to verify, key files changed, and next steps.                                                                      |
+| Step | Name              | Description                                                                                                                                                                        |
+| ---- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | **Clarify**       | Scans spec.md for `[NEEDS CLARIFICATION]` markers. Uses Dewey semantic search to auto-resolve. Exits to human only for unanswerable questions.                                     |
+| 2    | **Plan**          | Delegates to Cobalt-Crush to generate `plan.md` via `/speckit.plan`                                                                                                                |
+| 3    | **Tasks**         | Delegates to Cobalt-Crush to generate `tasks.md` via `/speckit.tasks`                                                                                                              |
+| 4    | **Spec Review**   | Runs the review council in Spec Review Mode. Auto-fixes LOW/MEDIUM findings. Exits on HIGH/CRITICAL.                                                                               |
+| 5    | **Implement**     | Parses `tasks.md` for phases. `[P]` parallel tasks run via Replicator worktrees (up to 4 concurrent workers). Phase checkpoints run CI commands derived from `.github/workflows/`. |
+| 6    | **Code Review**   | Runs the review council in Code Review Mode. Includes Phase 1a CI hard gate, Phase 1b Gaze quality analysis, and Divisor agent reviews. Up to 3 fix iterations.                    |
+| 7    | **Retrospective** | Analyzes the session and stores learnings in Hivemind semantic memory.                                                                                                             |
+| 8    | **Demo**          | Presents structured demo instructions: what was built, how to verify, key files changed, and next steps.                                                                           |
 
 ### Key Capabilities
 
 - **Dewey-powered clarification**: Auto-resolves spec ambiguities using semantic search. Falls back to human input when Dewey is unavailable or results are insufficient.
-- **Parallel Swarm workers**: `[P]`-marked tasks execute in parallel via git worktrees (up to 4 concurrent). Falls back to sequential when the Swarm plugin is not installed.
+- **Parallel Replicator workers**: `[P]`-marked tasks execute in parallel via git worktrees (up to 4 concurrent). Falls back to sequential when Replicator is not installed.
 - **Resumability**: Probes filesystem state on startup to detect completed steps. Resumes from the first incomplete step. All progress is persisted in spec artifacts (plan.md, tasks.md checkboxes, spec-review marker).
 - **Graceful exit points**: Every exit (unanswerable questions, HIGH/CRITICAL findings, worker failures, merge conflicts, test failures, review exhaustion) includes actionable next steps and resume instructions.
 - **CI command derivation**: Build and test commands are derived from `.github/workflows/` files, not hardcoded.
@@ -121,7 +121,7 @@ The [Developer (Cobalt-Crush)](/docs/getting-started/developer/) creates the tec
 - Run cross-artifact analysis: `/speckit.analyze`
 - Validate checklists: `/speckit.checklist`
 - Execute implementation: `/speckit.implement` or `/cobalt-crush`
-- For parallel work: `/swarm "implement spec NNN"`
+- For parallel work: use `/unleash` which handles parallel task execution automatically
 - Mark each task `[x]` in tasks.md as it completes
 - Run tests after each phase checkpoint
 
@@ -413,7 +413,7 @@ uf setup
 This installs the full toolchain in one command:
 
 - **Core tools** -- OpenCode (AI coding environment), Gaze (quality analysis), Mx F (manager hero), GitHub CLI
-- **Development tools** -- Node.js, Bun, OpenSpec CLI, Swarm plugin (multi-agent coordination), Swarm configuration and `.hive/` initialization
+- **Development tools** -- Node.js, Bun, OpenSpec CLI, Replicator (multi-agent coordination), `.hive/` initialization
 - **Knowledge layer** -- Ollama (local model runtime), Dewey (semantic search), IBM Granite embedding model, Dewey workspace initialization and index build
 - **Project scaffolding** -- `uf init` to deploy agents, commands, convention packs, templates, and workflow configuration
 
@@ -428,11 +428,11 @@ export OLLAMA_MODEL=granite-embedding:30m
 export OLLAMA_EMBED_DIM=256
 ```
 
-`uf setup` sets these during installation, but they must be in your shell profile for processes spawned outside of setup (e.g., `dewey serve`, manual `swarm init`).
+`uf setup` sets these during installation, but they must be in your shell profile for processes spawned outside of setup (e.g., `dewey serve`, manual `replicator init`).
 
 Dewey is optional -- all heroes function without it. See the [knowledge retrieval guide](/docs/getting-started/knowledge/) for source configuration and OpenCode integration.
 
-As the final step of setup, `uf init` scaffolds your project files and performs sub-tool initialization: it creates `.unbound-force/config.yaml` for [workflow configuration](#workflow-configuration), runs `dewey init` + `dewey index` when Dewey is available, and configures `opencode.json` with Dewey MCP server and Swarm plugin entries when those tools are detected.
+As the final step of setup, `uf init` scaffolds your project files and performs sub-tool initialization: it creates `.unbound-force/config.yaml` for [workflow configuration](#workflow-configuration), runs `dewey init` + `dewey index` when Dewey is available, and configures `opencode.json` with Dewey MCP server and Replicator MCP server entries when those tools are detected.
 
 ### 3. Verify
 
@@ -444,21 +444,21 @@ Doctor checks 7 areas and shows pass/warn/fail for each with install hints. Fix 
 
 ### 4. Start Working
 
-Open OpenCode and try your first task:
-
-```text
-/swarm "your first task description"
-```
-
-Or start with the Speckit pipeline for a new feature:
+Open OpenCode and start with the Speckit pipeline for a new feature:
 
 ```text
 /speckit.specify
 ```
 
+Then run the full autonomous pipeline:
+
+```text
+/unleash
+```
+
 ## Next Steps
 
-- [Developer Guide](/docs/getting-started/developer/) -- Daily workflow, Speckit, Swarm, and Cobalt-Crush
+- [Developer Guide](/docs/getting-started/developer/) -- Daily workflow, Speckit, Replicator, and Cobalt-Crush
 - [Tester Guide](/docs/getting-started/tester/) -- Gaze quality analysis and CI integration
 - [Product Owner Guide](/docs/getting-started/product-owner/) -- Muti-Mind and backlog management
 - [Product Manager Guide](/docs/getting-started/product-manager/) -- Mx F metrics and coaching

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started: Developer"
 description: "Set up your environment, learn the daily workflow, and start building with the Unbound Force AI agent swarm as a developer."
-lead: "Install the tools, learn the workflows, and start shipping code with Cobalt-Crush, Speckit, and Swarm."
+lead: "Install the tools, learn the workflows, and start shipping code with Cobalt-Crush, Speckit, and Replicator."
 date: 2026-03-22T00:00:00+00:00
 draft: false
 weight: 30
@@ -20,7 +20,7 @@ uf setup
 `uf setup` detects your existing version managers (goenv, nvm, fnm, Homebrew) and installs through them:
 
 - **Core tools** -- OpenCode (AI coding environment), Gaze (quality analysis), Mx F (manager hero), GitHub CLI
-- **Development tools** -- Node.js, Bun, OpenSpec CLI, Swarm plugin (multi-agent coordination)
+- **Development tools** -- Node.js, Bun, OpenSpec CLI, Replicator (multi-agent coordination)
 - **Knowledge layer** -- Ollama (local model runtime), Dewey (semantic search), IBM Granite embedding model
 - **Project scaffolding** -- agents, commands, convention packs, templates, and workflow configuration via `uf init`
 
@@ -30,7 +30,7 @@ After setup, verify everything is working:
 uf doctor
 ```
 
-Doctor checks 7 areas: your detected environment (version managers), core tools, Swarm plugin health, scaffolded files, hero availability, MCP server config, and agent/skill integrity. Every failed check includes a copy-pasteable install command to fix it.
+Doctor checks 7 areas: your detected environment (version managers), core tools, Replicator health, scaffolded files, hero availability, MCP server config, and agent/skill integrity. Every failed check includes a copy-pasteable install command to fix it.
 
 ## Daily Workflow
 
@@ -56,7 +56,7 @@ A typical development session follows the specify-unleash-finale loop:
    /finale
    ```
 
-That is the complete loop. For smaller changes that don't need the full Speckit pipeline, use the [OpenSpec tactical workflow](/docs/getting-started/common-workflows/#bug-fix-tactical) (`/opsx-propose` -> `/opsx-apply` -> `/finale`). For parallel task execution without a spec, use `/swarm "task description"` directly.
+That is the complete loop. For smaller changes that don't need the full Speckit pipeline, use the [OpenSpec tactical workflow](/docs/getting-started/common-workflows/#bug-fix-tactical) (`/opsx-propose` -> `/opsx-apply` -> `/finale`).
 
 ## Working with Speckit
 
@@ -89,28 +89,24 @@ Each stage produces artifacts that feed the next. Specs must be committed and pu
 
 Both workflows enforce branch conventions: Speckit uses `NNN-<short-name>` branches (created by `/speckit.specify`), and OpenSpec uses `opsx/<change-name>` branches (created by `/opsx-propose`). Branch validation is a hard gate at each pipeline step.
 
-## Working with Swarm
+## Working with Replicator
 
-Swarm coordinates parallel AI agents on your codebase. When you have a task that can be broken into independent pieces, Swarm decomposes it and spawns parallel workers.
+[Replicator](/docs/projects/replicator/) coordinates parallel AI agents on your codebase. It provides 53 MCP tools for work tracking, file reservations, parallel orchestration with git worktrees, and semantic memory -- all in a single Go binary.
 
-### Using `/swarm`
+### Replicator + Speckit Integration
 
-```
-/swarm "Implement the authentication module"
-```
+When a `tasks.md` file exists from the Speckit pipeline, Replicator uses it as the authoritative task decomposition instead of generating its own. It maps each phase to an epic and respects the `[P]` parallel markers and phase dependencies. The `/unleash` command orchestrates this automatically.
 
-Swarm analyzes the task, decomposes it into subtasks, reserves files for each worker to prevent conflicts, and spawns parallel agents. Each worker:
+### Parallel Workers
+
+When `/unleash` encounters `[P]`-marked tasks, Replicator spawns parallel workers in dedicated git worktrees. Each worker:
 
 1. Calls `swarmmail_reserve()` to lock their files
 2. Implements their subtask
 3. Calls `swarm_complete()` when done
 4. Releases file locks automatically
 
-### Swarm + Speckit Integration
-
-When a `tasks.md` file exists from the Speckit pipeline, Swarm uses it as the authoritative task decomposition instead of generating its own. It maps each phase to a Swarm epic and respects the `[P]` parallel markers and phase dependencies.
-
-### Swarm Delegation
+### Autonomous Delegation
 
 The hero lifecycle supports **autonomous swarm delegation**. After the Product Owner completes the define stage (specify + clarify), the swarm takes over and runs the implement, validate, and review stages without human intervention. The workflow pauses automatically before the accept stage, returning control to the Product Owner. After acceptance, the swarm runs the final reflect stage (Mx F) autonomously. This means the developer's work -- planning, implementation, and quality validation -- runs as part of the swarm's autonomous stages.
 
@@ -128,7 +124,7 @@ When Dewey is not available, Cobalt-Crush falls back to direct file reads and CL
 
 ### File Reservations
 
-Before editing any file under Swarm coordination, always reserve it first:
+Before editing any file under Replicator coordination, always reserve it first:
 
 ```
 swarmmail_reserve({ paths: ["internal/auth/handler.go"], reason: "Implementing auth handler" })
@@ -140,11 +136,11 @@ This prevents conflicts when multiple workers are active. Reservations auto-rele
 
 Every session follows this ritual:
 
-| Step      | Command                          | Purpose                          |
-| --------- | -------------------------------- | -------------------------------- |
-| **Start** | `hive_ready()`                   | Get the next unblocked work item |
-| **Work**  | `/swarm "task"` or direct coding | Execute the work                 |
-| **End**   | `hive_sync()` + `git push`       | Persist work items and learnings |
+| Step      | Command                     | Purpose                          |
+| --------- | --------------------------- | -------------------------------- |
+| **Start** | `hive_ready()`              | Get the next unblocked work item |
+| **Work**  | `/unleash` or direct coding | Execute the work                 |
+| **End**   | `hive_sync()` + `git push`  | Persist work items and learnings |
 
 ## Cobalt-Crush Persona
 
@@ -265,7 +261,7 @@ After deploying files, `uf init` performs sub-tool initialization:
 - If [Dewey](/docs/getting-started/knowledge/) is available: creates the `.dewey/` workspace, auto-detects sibling repos and your GitHub org to generate a [multi-repo source config](/docs/getting-started/knowledge/#what-uf-init-creates), and builds the initial index. After setup, you can [extend sources with web crawls](/docs/getting-started/knowledge/#extending-your-sources) for your project's toolstack documentation. With `--force`, re-indexes an existing Dewey workspace.
 - Configures `opencode.json` with MCP and plugin entries:
   - **Dewey MCP entry**: When `dewey` is in PATH, adds the `mcp.dewey` entry for the Dewey MCP server
-  - **Swarm plugin entry**: When `.hive/` directory exists, adds `opencode-swarm-plugin` to the plugin array
+  - **Replicator MCP entry**: When `replicator` is in PATH, adds `mcp.replicator` entry for the Replicator MCP server
   - Idempotent — checks for existing entries before adding. Use `--force` to overwrite stale entries.
   - Preserves user-added keys (custom MCP servers, custom config) — only manages the entries it owns
 
@@ -289,4 +285,4 @@ The plane is not landed until `git push` succeeds. This ensures your work items,
 
 - Read the [Common Workflows](/docs/getting-started/common-workflows/) page to understand how your work flows through the full hero lifecycle
 - Explore the [Cobalt-Crush](/docs/team/cobalt-crush/) team page for the full persona details
-- Run `uf doctor` to verify your environment, then try `/swarm "your first task"`
+- Run `uf doctor` to verify your environment, then try `/unleash` on your first feature

--- a/content/docs/getting-started/knowledge.md
+++ b/content/docs/getting-started/knowledge.md
@@ -33,7 +33,7 @@ The `granite-embedding:30m` model is IBM's Granite Embedding — a 63 MB model l
 
 ### Embedding Model Alignment
 
-The Unbound Force swarm and Dewey are aligned on the same embedding model (IBM Granite `granite-embedding:30m`). To ensure consistency for processes spawned outside of `uf setup` (e.g., `dewey serve`, manual `swarm init`), add these environment variables to your shell profile (`~/.zshrc` or `~/.bashrc`):
+The Unbound Force swarm and Dewey are aligned on the same embedding model (IBM Granite `granite-embedding:30m`). To ensure consistency for processes spawned outside of `uf setup` (e.g., `dewey serve`, manual `replicator init`), add these environment variables to your shell profile (`~/.zshrc` or `~/.bashrc`):
 
 ```bash
 export OLLAMA_MODEL=granite-embedding:30m

--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -20,7 +20,7 @@ uf setup
 `uf setup` installs everything in one command:
 
 - **Core tools** -- OpenCode (AI coding environment), Gaze (quality analysis), Mx F (manager hero), GitHub CLI
-- **Development tools** -- Node.js, Bun, OpenSpec CLI, Swarm plugin (multi-agent coordination)
+- **Development tools** -- Node.js, Bun, OpenSpec CLI, Replicator (multi-agent coordination)
 - **Knowledge layer** -- Ollama (local model runtime), Dewey (semantic search), IBM Granite embedding model
 - **Project scaffolding** -- agents, commands, convention packs, templates, and workflow configuration via `uf init`
 
@@ -51,27 +51,21 @@ For step-by-step control over each stage:
 /speckit.specify    # then /speckit.plan, /speckit.tasks, /speckit.implement
 ```
 
-For parallel task execution without the full pipeline:
-
-```text
-/swarm "your task description"
-```
-
 ## The Stack
 
 Unbound Force runs on three tools that form a layered stack. `uf setup` installs all of them, but each is independently useful:
 
-| Layer            | Tool                                                     | What It Does                                                                                                    |
-| ---------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **Agent**        | [OpenCode](https://opencode.ai)                          | The AI coding environment where you interact, write code, and run commands. The personas run inside OpenCode.   |
-| **Planning**     | [Speckit](https://github.com/github/spec-kit) (spec-kit) | A specification pipeline that turns ideas into structured specs, plans, and tasks before implementation begins. |
-| **Coordination** | [Swarm](https://www.swarmtools.ai/)                      | An OpenCode plugin that enables multi-agent parallelism and learning amongst team members.                      |
+| Layer            | Tool                                                      | What It Does                                                                                                               |
+| ---------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Agent**        | [OpenCode](https://opencode.ai)                           | The AI coding environment where you interact, write code, and run commands. The personas run inside OpenCode.              |
+| **Planning**     | [Speckit](https://github.com/github/spec-kit) (spec-kit)  | A specification pipeline that turns ideas into structured specs, plans, and tasks before implementation begins.            |
+| **Coordination** | [Replicator](https://github.com/unbound-force/replicator) | Multi-agent coordination: parallel workers, git-backed tracking, file reservations, and semantic memory. Single Go binary. |
 
-Each tool is independently useful, but they compose into the full Unbound Force workflow: plan with Speckit, execute with OpenCode, coordinate with Swarm.
+Each tool is independently useful, but they compose into the full Unbound Force workflow: plan with Speckit, execute with OpenCode, coordinate with Replicator.
 
 ## Next Steps
 
-- **[Developer Guide](/docs/getting-started/developer/)** -- Daily workflow, Speckit pipeline, Swarm coordination, convention packs
+- **[Developer Guide](/docs/getting-started/developer/)** -- Daily workflow, Speckit pipeline, Replicator coordination, convention packs
 - **[Tester Guide](/docs/getting-started/tester/)** -- Gaze quality analysis, CRAP scores, coverage ratchets, CI integration
 - **[Product Owner Guide](/docs/getting-started/product-owner/)** -- Muti-Mind backlog management, priority scoring, acceptance decisions
 - **[Product Manager Guide](/docs/getting-started/product-manager/)** -- Mx F metrics, dashboards, coaching, retrospectives

--- a/content/docs/projects/_index.md
+++ b/content/docs/projects/_index.md
@@ -17,3 +17,7 @@ Test quality analysis via side effect detection for Go. Gaze detects every obser
 ### [Dewey](/docs/projects/dewey/)
 
 Semantic knowledge retrieval for AI agents. Dewey combines structured graph traversal with vector-based semantic search to give every hero in the swarm cross-repository context -- local files, GitHub issues, and web documentation searchable through a unified MCP interface. Dewey enables autonomous specification drafting, reducing human checkpoints from two to one.
+
+### [Replicator](/docs/projects/replicator/)
+
+Multi-agent coordination for AI coding agents. Replicator provides 53 MCP tools for work tracking, parallel orchestration with git worktrees, file reservations, and semantic memory -- all in a single Go binary with zero runtime dependencies. Install via Homebrew and connect any MCP-compatible AI agent.

--- a/content/docs/projects/replicator.md
+++ b/content/docs/projects/replicator.md
@@ -1,0 +1,129 @@
+---
+title: "Replicator"
+description: "Multi-agent coordination for AI coding agents — 53 MCP tools for work tracking, orchestration, and semantic memory."
+lead: "Multi-agent coordination for AI coding agents."
+date: 2026-04-06T00:00:00+00:00
+draft: false
+weight: 40
+toc: true
+---
+
+## What Replicator Does
+
+AI coding agents are powerful individually, but coordinating multiple agents on the same codebase requires structure — work tracking, file reservations, parallel orchestration, and shared memory. Replicator provides all of this as a single Go binary with zero runtime dependencies.
+
+Replicator exposes 53 MCP tools over stdio JSON-RPC. AI agents (OpenCode, Claude Code, or any MCP-compatible client) connect to Replicator and gain access to work item tracking, inter-agent messaging, parallel task orchestration with git worktrees, and semantic memory via Dewey integration.
+
+## Installation
+
+### Homebrew (macOS)
+
+```bash
+brew install unbound-force/tap/replicator
+```
+
+### Go Install
+
+```bash
+go install github.com/unbound-force/replicator/cmd/replicator@latest
+```
+
+### Binary Download
+
+Download from [GitHub Releases](https://github.com/unbound-force/replicator/releases). Available for macOS (arm64), Linux (amd64, arm64).
+
+## MCP Tools (53)
+
+Replicator exposes 53 tools via the [MCP protocol](https://modelcontextprotocol.io/) across four categories:
+
+| Category       | Tools | Purpose                                                                 |
+| -------------- | ----- | ----------------------------------------------------------------------- |
+| **Hive**       | 11    | Work item tracking: create, query, update, close, epics, sessions, sync |
+| **Swarm Mail** | 10    | Agent messaging: send, inbox, ack, file reservations                    |
+| **Swarm**      | 24    | Orchestration: decompose, spawn, worktrees, progress, review, insights  |
+| **Memory**     | 8     | Dewey proxy: store/find learnings, deprecated tool stubs                |
+
+## CLI Commands
+
+Replicator provides 9 subcommands for setup, monitoring, and diagnostics:
+
+```bash
+# Per-repo setup (creates .hive/ directory)
+replicator init
+
+# Per-machine setup (creates ~/.config/swarm-tools/ + SQLite DB)
+replicator setup
+
+# Start MCP server (AI agents connect via stdio)
+replicator serve
+
+# List work items
+replicator cells
+
+# Check environment health
+replicator doctor
+
+# Activity summary
+replicator stats
+
+# Run preset analytics queries
+replicator query cells_by_status
+
+# Generate tool reference docs
+replicator docs
+
+# Version info
+replicator version
+```
+
+## Connecting an AI Agent
+
+Add Replicator to your `opencode.json`:
+
+```json
+{
+  "mcp": {
+    "replicator": {
+      "type": "stdio",
+      "command": "replicator",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+For Claude Code, add to `mcp_servers` in your config:
+
+```json
+{
+  "mcp_servers": {
+    "replicator": {
+      "command": "replicator",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+## Architecture
+
+Replicator is a single Go binary (~15MB) with <50ms startup time. It uses SQLite (WAL mode) for persistent storage and communicates with AI agents via stdio JSON-RPC.
+
+```text
+AI Agent (OpenCode, Claude)
+  └── stdin/stdout → MCP Server (stdio JSON-RPC)
+                       └── Tool Registry (53 tools)
+                             └── Domain Logic (hive, swarm, mail)
+                                   ├── SQLite (WAL mode)
+                                   ├── HTTP proxy → Dewey (semantic memory)
+                                   └── os/exec → Git (worktrees)
+```
+
+## Heritage
+
+Go rewrite of [cyborg-swarm](https://github.com/unbound-force/cyborg-swarm), originally forked from [swarm-tools](https://github.com/joelhooks/swarm-tools) by [Joel Hooks](https://github.com/joelhooks).
+
+## Links
+
+- [GitHub Repository](https://github.com/unbound-force/replicator)
+- [License: MIT](https://github.com/unbound-force/replicator/blob/main/LICENSE)

--- a/content/docs/team/cobalt-crush.md
+++ b/content/docs/team/cobalt-crush.md
@@ -44,6 +44,6 @@ While The Divisor sets the architectural blueprint, Cobalt-Crush ensures the cod
 
 ## Next Steps
 
-- Read the [Developer getting-started guide](/docs/getting-started/developer/) for daily workflow, Speckit pipeline, and Swarm coordination
+- Read the [Developer getting-started guide](/docs/getting-started/developer/) for daily workflow, Speckit pipeline, and Replicator coordination
 - See [Common Workflows](/docs/getting-started/common-workflows/) for how Cobalt-Crush fits into the full hero lifecycle
 - Learn about [convention packs](/docs/getting-started/developer/#convention-packs) that govern coding standards

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -267,7 +267,7 @@
       </div>
     </div>
     <div class="row g-4 justify-content-center">
-      <div class="col-lg-6">
+      <div class="col-lg-4">
         <a href="/docs/projects/gaze/" class="text-decoration-none">
           <div class="project-card p-4 rounded-4 h-100">
             <div class="d-flex align-items-center mb-3">
@@ -286,7 +286,7 @@
           </div>
         </a>
       </div>
-      <div class="col-lg-6">
+      <div class="col-lg-4">
         <a href="/docs/projects/dewey/" class="text-decoration-none">
           <div class="project-card p-4 rounded-4 h-100">
             <div class="d-flex align-items-center mb-3">
@@ -301,6 +301,25 @@
               Give your AI agents the context they need. Dewey indexes your
               repos, GitHub issues, and toolstack documentation — so agents
               reference current API docs instead of stale training data.
+            </p>
+          </div>
+        </a>
+      </div>
+      <div class="col-lg-4">
+        <a href="/docs/projects/replicator/" class="text-decoration-none">
+          <div class="project-card p-4 rounded-4 h-100">
+            <div class="d-flex align-items-center mb-3">
+              <span
+                class="badge bg-primary-subtle text-primary-emphasis rounded-pill me-2"
+                >Go</span
+              >
+              <span class="text-body-secondary small">MCP Server</span>
+            </div>
+            <h3 class="h5 fw-semibold text-body">Replicator</h3>
+            <p class="text-body-secondary mb-0">
+              Coordinate parallel AI agents across your codebase. Work tracking,
+              file reservations, and semantic memory in a single binary with
+              zero runtime dependencies.
             </p>
           </div>
         </a>

--- a/specs/016-replicator-migration/checklists/requirements.md
+++ b/specs/016-replicator-migration/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Replicator Migration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Source material verified from Replicator README.md and upstream migration spec (024-replicator-migration).

--- a/specs/016-replicator-migration/plan.md
+++ b/specs/016-replicator-migration/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Replicator Migration
+
+**Branch**: `016-replicator-migration` | **Date**: 2026-04-06 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/016-replicator-migration/spec.md`
+
+## Summary
+
+Replace all Swarm plugin product references with Replicator across the Unbound Force website. Replicator (Go binary, 53 MCP tools, zero runtime dependencies) has replaced the Node.js Swarm plugin. This involves updating 10 content/layout files, 3 internal agent/command files, 1 config file, and creating 1 new project page. All MCP tool names and generic "swarm" noun usage remain unchanged.
+
+## Technical Context
+
+**Language/Version**: Hugo (Go-based SSG) via @thulite npm packages  
+**Primary Dependencies**: thulite ^2.6.3, @thulite/doks-core ^1.8.3  
+**Storage**: N/A (static Markdown files)  
+**Testing**: `npm run build` (zero-error build is the test gate)  
+**Target Platform**: GitHub Pages (static site)  
+**Project Type**: Static documentation website  
+**Performance Goals**: N/A  
+**Constraints**: Zero build errors, all links valid  
+**Scale/Scope**: 14 files modified, 1 file created, 19 functional requirements
+
+## Constitution Check
+
+_GATE: Must pass before implementation._
+
+### I. Content Accuracy — PASS
+
+All Replicator content is sourced from the upstream `replicator/README.md` (53 MCP tools, 190+ tests, 15MB binary, <50ms startup, Go 1.25+, MIT license). No fabricated features. The migration removes factually incorrect references to a deprecated product (Swarm plugin / swarmtools.ai) and replaces them with the current tool (Replicator). This directly serves Content Accuracy.
+
+### II. Minimal Footprint — PASS
+
+Changes are content-only (Markdown text replacements) plus one new Markdown page and one HTML card addition. No new dependencies, no new custom CSS, no new JavaScript. The homepage grid change (`col-lg-6` → `col-lg-4`) uses existing Bootstrap classes. All changes use Doks built-in features.
+
+### III. Visitor Clarity — PASS
+
+The migration improves clarity by replacing references to a tool that no longer exists (Swarm plugin) with the tool developers will actually install (Replicator). The new project page follows the same structure as existing Gaze and Dewey pages. The homepage 3-column grid maintains visual consistency.
+
+## File Change Matrix
+
+| File                                               | FRs                                                    | Change Type                                                               |
+| -------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `content/docs/getting-started/quick-start.md`      | FR-001, FR-002, FR-003, FR-005, FR-008, FR-009         | Edit: Stack table, setup list, /swarm removal                             |
+| `content/docs/getting-started/developer.md`        | FR-001, FR-003, FR-004, FR-006, FR-007, FR-008, FR-009 | Edit: Section rename, setup list, opencode.json docs, /swarm removal      |
+| `content/docs/getting-started/common-workflows.md` | FR-001, FR-003, FR-008, FR-009                         | Edit: Swarm references, /swarm removal, setup list                        |
+| `content/docs/getting-started/_index.md`           | FR-001, FR-002, FR-005                                 | Edit: Stack table                                                         |
+| `content/docs/getting-started/knowledge.md`        | FR-001, FR-004                                         | Edit: "swarm init" reference                                              |
+| `content/docs/getting-started/artifacts.md`        | FR-001                                                 | Edit: "Swarm Orchestration" → keep (role name, not product) — verify only |
+| `content/blog/unleash-in-practice.md`              | FR-001, FR-008                                         | Edit: Swarm product references, /swarm link                               |
+| `content/docs/projects/replicator.md`              | FR-010, FR-011                                         | **NEW**: Replicator project page                                          |
+| `content/docs/projects/_index.md`                  | FR-013                                                 | Edit: Add Replicator to project list                                      |
+| `layouts/home.html`                                | FR-012                                                 | Edit: Add Replicator card, change grid to 3-column                        |
+| `.opencode/command/unleash.md`                     | FR-014                                                 | Edit: "Swarm plugin" → "Replicator" in fallback messages                  |
+| `.opencode/agents/cobalt-crush-dev.md`             | FR-015                                                 | Edit: "Swarm" product refs → "Replicator" in coordination section         |
+| `.opencode/skill/speckit-workflow/SKILL.md`        | FR-016                                                 | Edit: "Swarm coordinator" → "Replicator"                                  |
+| `.dewey/sources.yaml`                              | FR-017                                                 | Edit: Remove web-swarm entry                                              |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-replicator-migration/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Upstream content research
+└── tasks.md             # Task breakdown (next step)
+```
+
+### Source Code (repository root)
+
+```text
+content/
+├── docs/
+│   ├── getting-started/
+│   │   ├── _index.md          # Stack table update
+│   │   ├── quick-start.md     # Stack table, setup list, /swarm removal
+│   │   ├── developer.md       # Section rename, opencode.json, /swarm removal
+│   │   ├── common-workflows.md # Swarm refs, /swarm removal, setup list
+│   │   ├── knowledge.md       # swarm init reference
+│   │   └── artifacts.md       # Verify only (role name stays)
+│   └── projects/
+│       ├── _index.md          # Add Replicator listing
+│       └── replicator.md      # NEW project page
+├── blog/
+│   └── unleash-in-practice.md # Swarm product refs
+layouts/
+└── home.html                  # Replicator card, 3-column grid
+.opencode/
+├── command/unleash.md         # Swarm plugin → Replicator
+├── agents/cobalt-crush-dev.md # Swarm → Replicator in coordination
+└── skill/speckit-workflow/SKILL.md # Swarm coordinator → Replicator
+.dewey/
+└── sources.yaml               # Remove web-swarm entry
+```
+
+## Complexity Tracking
+
+No constitution violations. All changes are content updates within the existing site structure.

--- a/specs/016-replicator-migration/research.md
+++ b/specs/016-replicator-migration/research.md
@@ -1,0 +1,81 @@
+# Research: Replicator Migration
+
+**Branch**: `016-replicator-migration` | **Date**: 2026-04-06
+
+## Replicator Upstream Content
+
+Source: `/Users/jflowers/Projects/github/unbound-force/replicator/README.md`
+
+### Key Facts
+
+- **Description**: Multi-agent coordination for AI coding agents
+- **Language**: Go (1.25+)
+- **License**: MIT
+- **Binary**: Single Go binary, zero runtime dependencies
+- **Stats**: 53 MCP tools, 190+ tests, 15MB binary, <50ms startup
+- **Install**: `brew install unbound-force/tap/replicator` or `go install github.com/unbound-force/replicator/cmd/replicator@latest`
+- **Heritage**: Go rewrite of cyborg-swarm, originally forked from swarm-tools by Joel Hooks
+
+### MCP Tool Categories (53 total)
+
+| Category   | Tools | Purpose                                                                 |
+| ---------- | ----- | ----------------------------------------------------------------------- |
+| Hive       | 11    | Work item tracking: create, query, update, close, epics, sessions, sync |
+| Swarm Mail | 10    | Agent messaging: send, inbox, ack, file reservations                    |
+| Swarm      | 24    | Orchestration: decompose, spawn, worktrees, progress, review, insights  |
+| Memory     | 8     | Dewey proxy: store/find learnings, deprecated tool stubs                |
+
+### CLI Commands (9)
+
+- `replicator serve` — Start MCP server (AI agents connect via stdio)
+- `replicator init` — Per-repo setup (creates .hive/ directory)
+- `replicator setup` — Per-machine setup (creates ~/.config/swarm-tools/ + SQLite DB)
+- `replicator doctor` — Check environment health
+- `replicator cells` — List work items
+- `replicator stats` — Activity summary
+- `replicator query` — Run preset analytics queries
+- `replicator docs` — Generate tool reference docs
+- `replicator version` — Version info
+
+### Architecture
+
+- MCP Server (stdio JSON-RPC) → Tool Registry (53 tools) → Domain Logic (hive, swarm, mail) → SQLite (WAL mode)
+- Dewey proxy via HTTP
+- Git worktrees via os/exec
+
+## Current State of Files to Edit
+
+### Files with "Swarm plugin" product references (FR-001, FR-003)
+
+1. **quick-start.md** — Line 24: "Swarm plugin (multi-agent coordination)" in uf setup list; Line 68: Stack table row with `[Swarm](https://www.swarmtools.ai/)` and "An OpenCode plugin that enables multi-agent parallelism"; Line 70: "coordinate with Swarm"
+2. **developer.md** — Line 4: "Swarm" in lead; Line 23: "Swarm plugin" in setup list; Line 33: "Swarm plugin health"; Line 92-93: "Working with Swarm" section heading; Line 268: "Swarm plugin entry" in opencode.json docs
+3. **common-workflows.md** — Line 31: "Swarm workers"; Line 85: "Swarm workers" link; Line 124: "parallel task execution without a spec" with `/swarm`; Line 394: "Install the Swarm plugin for parallel execution"; Line 416-417: "Swarm plugin" and "Swarm configuration" in setup list; Line 435: "Swarm plugin entries"
+4. **\_index.md** — Line 25: Stack table with `[Swarm](https://www.swarmtools.ai/)`; Line 27: "coordinate with Swarm"
+5. **knowledge.md** — Line 36: "swarm init" reference
+6. **artifacts.md** — Line 45: "Swarm Orchestration" producer (this is a role name, not product — KEEP)
+7. **unleash-in-practice.md** — Line 85: "Swarm workers" link; Line 89: "Swarm worktrees"; Line 148-149: "Swarm" in tool table
+
+### Files with `/swarm` command references (FR-008, FR-009)
+
+1. **quick-start.md** — Lines 56-58: `/swarm "your task description"` block
+2. **developer.md** — Line 59: `/swarm "task description"` reference; Lines 96-100: "Using /swarm" section
+3. **common-workflows.md** — Line 124: `/swarm "implement spec NNN"`; Lines 449-451: `/swarm "your first task description"`
+
+### Files with swarmtools.ai URLs (FR-002)
+
+1. **quick-start.md** — Line 68: `[Swarm](https://www.swarmtools.ai/)`
+2. **\_index.md** — Line 25: `[Swarm](https://www.swarmtools.ai/)`
+
+### Files with opencode-swarm-plugin (FR-003, FR-006)
+
+1. **developer.md** — Line 268: `opencode-swarm-plugin`
+
+### Internal files (FR-014, FR-015, FR-016)
+
+1. **unleash.md** — Lines 43-44, 392-395, 516-517: "Swarm plugin" references
+2. **cobalt-crush-dev.md** — Lines 148-177: "Swarm Coordination" section header, "Swarm worker" references
+3. **SKILL.md** — Line 2: "Swarm coordinator" in description; Line 15: "Swarm coordinator"
+
+### Dewey sources (FR-017)
+
+1. **.dewey/sources.yaml** — Lines 97-104: `web-swarm` entry with swarmtools.ai URL

--- a/specs/016-replicator-migration/spec.md
+++ b/specs/016-replicator-migration/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: Replicator Migration
+
+**Feature Branch**: `016-replicator-migration`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: Replace all Swarm plugin references with Replicator across the website. Replicator (Go binary, 53 MCP tools, zero runtime dependencies) has replaced the Node.js Swarm plugin. Remove all swarmtools.ai references except heritage attribution. Create Replicator project page. Add to homepage.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — Replace Swarm Product References with Replicator (Priority: P1)
+
+A new developer reads the website and encounters references to "Swarm plugin," `opencode-swarm-plugin`, `npm install`, `swarmtools.ai`, and `swarm init` — none of which are accurate anymore. Replicator is now the coordination layer: a Go binary installed via Homebrew, integrated as an MCP server entry (not a plugin array entry), with `replicator init`/`replicator serve` subcommands.
+
+**Why this priority**: Factually incorrect installation and configuration instructions are the highest-severity gap. A developer following the current docs will install the wrong tool.
+
+**Independent Test**: Search the entire content directory for "swarmtools.ai", "opencode-swarm-plugin", "Swarm plugin", and `swarm init`. Zero results for all except the heritage attribution on the Replicator project page.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reading any page on the site, **When** they search for "swarmtools.ai", **Then** zero results are found except the heritage attribution on the Replicator project page.
+2. **Given** a developer reading the Stack table (Quick Start or Getting Started landing), **Then** the coordination layer row shows "Replicator" with a link to `github.com/unbound-force/replicator`, not "Swarm" with swarmtools.ai.
+3. **Given** a developer reading setup instructions, **Then** install commands show `brew install unbound-force/tap/replicator`, not `npm install -g opencode-swarm-plugin`.
+4. **Given** a developer reading the `uf init` documentation, **Then** it describes `opencode.json` with `mcp.replicator` entry (not plugin array with `opencode-swarm-plugin`).
+
+---
+
+### User Story 2 — Remove `/swarm` Command References (Priority: P1)
+
+The website references `/swarm "task description"` as a user-facing command in the Quick Start, Developer Guide, and Common Workflows. This command does not exist in Replicator. The primary entry point is `/unleash` (full pipeline) or `/speckit.implement` (manual implementation step).
+
+**Why this priority**: Referencing a nonexistent command causes immediate confusion when a developer tries to use it.
+
+**Independent Test**: Search the entire content directory for `/swarm`. Zero results in user-facing docs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reading the Quick Start "Start Working" section, **When** they look for how to run a quick task, **Then** `/swarm` is not offered as an option.
+2. **Given** a developer reading the Developer Guide, **When** they look for the "Working with Replicator" section, **Then** it describes Replicator's coordination capabilities without referencing a `/swarm` slash command.
+3. **Given** a developer reading the Common Workflows implement stage, **When** they look for how to start implementation, **Then** they find `/speckit.implement` or `/unleash`, not `/swarm`.
+
+---
+
+### User Story 3 — Create Replicator Project Page and Homepage Card (Priority: P1)
+
+Gaze and Dewey each have project pages and homepage cards. Replicator is a first-party project in the org with a shipped Homebrew formula, 53 MCP tools, and 190+ tests — it deserves the same treatment.
+
+**Why this priority**: Without a project page, visitors can't learn about Replicator's capabilities. Without a homepage card, the third shipped project is invisible from the site's highest-traffic page.
+
+**Independent Test**: Navigate to `/docs/projects/replicator/` — the page exists with installation, features, and architecture. The homepage shows 3 project cards (Gaze, Dewey, Replicator).
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the projects index page, **When** they look for Replicator, **Then** they find a project page describing its capabilities, installation, MCP tool categories, and architecture.
+2. **Given** a visitor on the homepage, **When** they scroll to the Projects section, **Then** they see 3 project cards (Gaze, Dewey, Replicator) in a 3-column grid.
+3. **Given** a developer reading the Replicator project page, **When** they look for heritage, **Then** they find one attribution line: "Go rewrite of cyborg-swarm, originally forked from swarm-tools by Joel Hooks."
+
+---
+
+### User Story 4 — Update Internal Agent and Command Files (Priority: P2)
+
+The `/unleash` command file, Cobalt-Crush agent, and Speckit workflow skill all reference "Swarm plugin" as a product. These affect agent behavior — agents read these files to understand how to use coordination tools.
+
+**Why this priority**: While the MCP tool names are unchanged (agents call `swarm_worktree_create` by name regardless), the fallback messages and install hints reference the wrong product ("Install the Swarm plugin for...").
+
+**Independent Test**: Search `.opencode/` for "Swarm plugin" and "swarmtools" — zero results.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent reading the `/unleash` command, **When** Replicator is not available, **Then** the fallback message says "Install Replicator for parallel execution" (not "Install the Swarm plugin").
+2. **Given** an agent reading the Cobalt-Crush agent file, **When** it describes coordination, **Then** it references "Replicator" (not "Swarm") as the coordination product.
+
+---
+
+### User Story 5 — Update Dewey Sources Configuration (Priority: P3)
+
+The `.dewey/sources.yaml` includes a `web-swarm` source pointing to swarmtools.ai. This should be removed. The Replicator repo should be added as a disk source if not already auto-detected.
+
+**Why this priority**: Lowest priority because it only affects the Dewey knowledge index, not user-facing content. But stale web sources waste crawl time and pollute search results with outdated Swarm plugin docs.
+
+**Independent Test**: Read `.dewey/sources.yaml` and verify no swarmtools.ai references exist.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reading `.dewey/sources.yaml`, **When** they look at web sources, **Then** no swarmtools.ai entry exists.
+
+---
+
+### Edge Cases
+
+- What happens when a developer has an old installation with the Swarm plugin still configured? The website should describe the current state (Replicator) — `uf setup` handles the migration automatically.
+- What happens when a page uses "swarm" as a generic noun (e.g., "the swarm takes over")? These KEEP as-is — "swarm" as a concept is the project's identity. Only "Swarm" as a product name changes.
+- The MCP tool names still contain "swarm" (e.g., `swarm_worktree_create`, `swarmmail_send`). These stay — they're API identifiers, not product references.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+**Product References (US1):**
+
+- **FR-001**: All "Swarm plugin" product name references MUST be replaced with "Replicator" across all content pages.
+- **FR-002**: All swarmtools.ai URLs MUST be removed except one heritage attribution on the Replicator project page.
+- **FR-003**: All `opencode-swarm-plugin` npm package references MUST be replaced with `brew install unbound-force/tap/replicator`.
+- **FR-004**: All `swarm init`, `swarm setup` CLI references MUST be replaced with `replicator init`, `replicator setup`.
+- **FR-005**: The Stack table on Quick Start and Getting Started landing pages MUST show "Replicator" with a link to `github.com/unbound-force/replicator`.
+- **FR-006**: The `opencode.json` documentation MUST show `mcp.replicator` entry format (not plugin array).
+- **FR-007**: The "Working with Swarm" section heading in developer.md MUST be renamed to "Working with Replicator".
+
+**`/swarm` Command Removal (US2):**
+
+- **FR-008**: All `/swarm "task"` command references MUST be removed from user-facing documentation.
+- **FR-009**: Where `/swarm` was offered as a quick-start option, the documentation MUST offer `/unleash` as the primary option and `/speckit.implement` as the manual alternative.
+
+**Replicator Project Page (US3):**
+
+- **FR-010**: A new project page MUST exist at `content/docs/projects/replicator.md` with installation, features (53 MCP tools across 4 categories), CLI commands, and architecture.
+- **FR-011**: The project page MUST include one heritage attribution line.
+- **FR-012**: The homepage Projects section MUST include a Replicator card in a 3-column grid alongside Gaze and Dewey.
+- **FR-013**: The projects index page MUST list Replicator.
+
+**Internal Files (US4):**
+
+- **FR-014**: The `/unleash` command file MUST replace "Swarm plugin" references with "Replicator" in all fallback messages and install hints.
+- **FR-015**: The Cobalt-Crush agent file MUST replace "Swarm" product references with "Replicator" in the coordination section.
+- **FR-016**: The Speckit workflow skill MUST replace "Swarm coordinator" with "Replicator".
+
+**Dewey Sources (US5):**
+
+- **FR-017**: The `web-swarm` source entry in `.dewey/sources.yaml` MUST be removed.
+
+**Cross-cutting:**
+
+- **FR-018**: All changes MUST pass `npm run build` without errors.
+- **FR-019**: Generic "swarm" noun usage (80+ occurrences) MUST NOT be changed.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Zero occurrences of "swarmtools.ai" in user-facing content (except 1 heritage attribution on Replicator project page).
+- **SC-002**: Zero occurrences of "opencode-swarm-plugin" anywhere on the site.
+- **SC-003**: Zero occurrences of `/swarm` as a command reference in user-facing content.
+- **SC-004**: Replicator project page exists and is accessible from the homepage and projects index.
+- **SC-005**: `npm run build` succeeds with zero errors.
+- **SC-006**: The word "Swarm" as a product name (capitalized, referring to the tool) appears zero times in user-facing content. The word "swarm" as a generic noun remains unchanged.
+
+## Assumptions
+
+- The Replicator README (53 MCP tools, 190+ tests, 15MB binary, <50ms startup) is the authoritative source for project facts.
+- MCP tool names (`swarm_worktree_create`, `swarmmail_send`, etc.) do NOT change — they're API identifiers shared between old Swarm and Replicator.
+- `[swarm]` execution mode labels, `define=swarm`, and `--define-mode=swarm` are workflow concepts, not product references, and stay unchanged.
+- Historical spec artifacts (specs/002, 005, 010, 012) are planning records and will not be updated.
+- The homepage Projects section will change from 2-column to 3-column grid (`col-lg-4`) to accommodate Replicator.
+- The `.dewey/sources.yaml` change is a local config file (gitignored) but should still be done to clean up the dev environment.

--- a/specs/016-replicator-migration/tasks.md
+++ b/specs/016-replicator-migration/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Replicator Migration
+
+**Branch**: `016-replicator-migration` | **Date**: 2026-04-06
+
+## Dependencies
+
+- Phase 1 (US3 - New Page) has no dependencies
+- Phase 2 (US1+US2 - Content Updates) tasks are independent of each other (`[P]`)
+- Phase 3 (US4 - Internal Files) tasks are independent of each other (`[P]`)
+- Phase 4 (US5 - Config) has no dependencies
+- Phase 5 (Verification) depends on all prior phases
+
+## Phase 1: New Content (US3)
+
+- [x] T001 [US3] Create Replicator project page at `content/docs/projects/replicator.md` with installation, features (53 MCP tools across 4 categories), CLI commands, architecture, and heritage attribution (FR-010, FR-011)
+- [x] T002 [US3] Add Replicator entry to projects index page `content/docs/projects/_index.md` (FR-013)
+- [x] T003 [US3] Add Replicator card to homepage `layouts/home.html` — change grid from `col-lg-6` to `col-lg-4`, add 3rd project card with Go badge, MCP Server type, benefit-framed description (FR-012)
+
+## Phase 2: Content Updates (US1 + US2)
+
+- [x] T004 [P] [US1][US2] Update `content/docs/getting-started/quick-start.md` — replace "Swarm plugin" with "Replicator" in setup list, replace Stack table Coordination row with Replicator, remove `/swarm` command block, update "coordinate with Swarm" text (FR-001, FR-002, FR-005, FR-008, FR-009)
+- [x] T005 [P] [US1][US2] Update `content/docs/getting-started/developer.md` — replace "Swarm" in lead, replace "Swarm plugin" in setup list, rename "Working with Swarm" section to "Working with Replicator", replace `/swarm` command references, update opencode.json documentation from plugin array to mcp.replicator entry, update "Swarm plugin health" reference (FR-001, FR-003, FR-004, FR-006, FR-007, FR-008, FR-009)
+- [x] T006 [P] [US1][US2] Update `content/docs/getting-started/common-workflows.md` — replace "Swarm plugin" in setup list, replace "Swarm workers" product references (keep generic "swarm" nouns), remove `/swarm` command references, replace "Install the Swarm plugin" fallback message, update "Swarm plugin entries" reference (FR-001, FR-003, FR-008, FR-009)
+- [x] T007 [P] [US1] Update `content/docs/getting-started/_index.md` — replace Stack table Coordination row with Replicator, update "coordinate with Swarm" text (FR-001, FR-002, FR-005)
+- [x] T008 [P] [US1] Update `content/docs/getting-started/knowledge.md` — replace "swarm init" with "replicator init" (FR-004)
+- [x] T009 [P] [US1] Verify `content/docs/getting-started/artifacts.md` — confirm "Swarm Orchestration" is a role name (not product reference) and keep unchanged (FR-019)
+- [x] T010 [P] [US1] Update `content/blog/unleash-in-practice.md` — replace "Swarm" product references with "Replicator" where referring to the tool, keep generic "swarm" nouns, update Swarm link in implement section (FR-001, FR-002)
+
+## Phase 3: Internal Files (US4)
+
+- [x] T011 [P] [US4] Update `.opencode/command/unleash.md` — replace "Swarm plugin" with "Replicator" in all fallback messages and install hints (FR-014)
+- [x] T012 [P] [US4] Update `.opencode/agents/cobalt-crush-dev.md` — replace "Swarm" product references with "Replicator" in coordination section header and description (FR-015)
+- [x] T013 [P] [US4] Update `.opencode/skill/speckit-workflow/SKILL.md` — replace "Swarm coordinator" with "Replicator" in description and body (FR-016)
+
+## Phase 4: Configuration (US5)
+
+- [x] T014 [US5] Remove `web-swarm` entry from `.dewey/sources.yaml` (FR-017)
+
+## Phase 5: Verification
+
+- [x] T015 Run `npm run build` and verify zero errors (FR-018)
+- [x] T016 Verify `grep -r "swarmtools.ai" content/ layouts/` returns zero results — heritage uses GitHub links not swarmtools.ai (SC-001)
+- [x] T017 Verify `grep -r "opencode-swarm-plugin" content/ layouts/ .opencode/` returns zero results (SC-002)
+- [x] T018 Verify `grep -r '"/swarm ' content/` returns zero results (SC-003)
+- [x] T019 Verify generic "swarm" noun usage is preserved — 47+ instances intact (FR-019, SC-006)


### PR DESCRIPTION
## Summary

Replicator (`github.com/unbound-force/replicator`) has replaced the Node.js Swarm plugin. This PR updates the entire website to reflect the change.

### What Changed
- **All Swarm plugin product references** → Replicator (install commands, URLs, binary name, product name)
- **All `/swarm` command references** removed (command does not exist in Replicator)
- **All swarmtools.ai URLs** removed (except 1 heritage attribution on Replicator project page)
- **Stack tables** updated: Swarm → Replicator with GitHub repo URL
- **Developer Guide** renamed "Working with Swarm" → "Working with Replicator", rewrote section
- **opencode.json docs** updated: plugin array → `mcp.replicator` MCP entry
- **Replicator project page** created with installation, 53 MCP tools, CLI commands, architecture
- **Homepage** updated: 3 project cards (Gaze, Dewey, Replicator) in 3-column grid
- **Internal files** updated: unleash command, cobalt-crush agent, speckit-workflow skill
- **.dewey/sources.yaml**: removed web-swarm entry

### What Did NOT Change
- Generic "swarm" noun usage (~80 occurrences) — this is the project identity
- MCP tool names (`swarm_worktree_create`, `swarmmail_send`, etc.) — same API
- `[swarm]` execution mode labels, `define=swarm`, `--define-mode=swarm` — workflow concepts
- Historical spec artifacts — planning records

### Verification
- Zero `swarmtools.ai` in user-facing content (except heritage attribution)
- Zero `opencode-swarm-plugin` anywhere
- Zero `/swarm` command references
- `npm run build`: 82 pages, 0 errors