### PR TITLE
docs: address remaining 11 Gaze documentation gaps from audit

### DIFF
--- a/content/docs/projects/gaze.md
+++ b/content/docs/projects/gaze.md
@@ -106,6 +106,11 @@ This creates 8 files across 3 directories in `.opencode/` that wire up the `/gaz
 | `.opencode/command/`    | `gaze.md`, `gaze-fix.md`, `speckit.testreview.md`                   |
 | `.opencode/references/` | `doc-scoring-model.md`, `example-report.md`                         |
 
+Notable scaffolded files:
+
+- **`reviewer-testing.md`** — The Tester Divisor persona for code review. When the review council runs, this agent evaluates test architecture, coverage strategy, assertion depth, and test isolation. It uses Gaze quality data (when available) to ground its findings in concrete CRAP scores and coverage numbers.
+- **`speckit.testreview.md`** — A read-only spec testability analysis command (`/speckit.testreview`). Evaluates whether a spec's requirements are testable before implementation begins — checking that acceptance criteria are specific enough to write tests from.
+
 ### The `/gaze` Command
 
 Inside OpenCode, use `/gaze` to get AI-assisted quality reports:
@@ -126,6 +131,15 @@ gaze report ./... --ai=claude     # Full report using Claude adapter
 ```
 
 Both `--ai=opencode` and `--ai=claude` are fully supported AI backends for `gaze report`.
+
+### CLI Flags
+
+| Flag                   | Commands             | Description                                                                                                                                                    |
+| ---------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--include-unexported` | `analyze`, `quality` | Include unexported functions in the analysis. Auto-detected for `package main` — CLI tools and entry points are analyzed by default without needing this flag. |
+| `--ai-mapper`          | `quality`, `crap`    | Enable AI-assisted assertion mapping as a 5th pass (confidence 50). Uses the configured AI adapter to evaluate structurally disconnected assertions.           |
+| `--max-gaze-crapload`  | `report`             | Fail if more than N functions exceed the GazeCRAP threshold. Similar to `--max-crapload` but uses contract coverage instead of line coverage.                  |
+| `--coverprofile`       | `report`             | Pass a pre-generated `go test -coverprofile` to skip Gaze's internal test run. See the [Tester guide](/docs/getting-started/tester/) for the CI pattern.       |
 
 ### The `/gaze fix` Command
 
@@ -152,7 +166,7 @@ The `/gaze fix` command uses these labels to determine the appropriate test gene
 
 ## Sample Output
 
-Here is what a full Gaze report looks like on a real Go project — [gcal-organizer](https://github.com/jflowers/gcal-organizer), analyzed with Gaze v1.2.3.
+Here is what a full Gaze report looks like on a real Go project — [gcal-organizer](https://github.com/jflowers/gcal-organizer). This sample was generated with an earlier version of Gaze; current output may include additional metrics and formatting improvements.
 
 ### Overall Health Assessment
 
@@ -195,6 +209,17 @@ Gaze is structured as a set of focused packages:
 | `scaffold` | OpenCode file scaffolding for `/gaze` command setup               |
 
 The analysis engine detects side effects across three implemented tiers (P0, P1, P2), covering the most common and impactful effect types — from return values and error returns through mutations, I/O, channel operations, and more.
+
+### Analysis Engine Details
+
+These details are primarily relevant for understanding Gaze's output and accuracy characteristics:
+
+- **SSA degradation diagnostics.** When SSA (Static Single Assignment) construction fails for a package (e.g., due to upstream toolchain issues), Gaze degrades gracefully instead of failing. The CRAP output includes `ssa_degraded_packages` listing affected packages, and the text report shows an SSA diagnostics section. Metrics for degraded packages are based on AST-only analysis with reduced accuracy.
+- **AST mutation fallback.** When SSA analysis fails, Gaze falls back to AST-based mutation detection for side effect identification. This is transparent to users but may affect accuracy for complex data flow patterns. The degradation is surfaced via the SSA diagnostics above.
+- **`no_test_coverage` classification.** Contract coverage distinguishes between functions that have side effects but no test coverage (`no_test_coverage`) and functions that have no detectable effects. This separation ensures the fix strategy labels recommend "write tests" rather than "add assertions" for completely untested functions.
+- **Constructor naming signal.** Functions with `New` or `NewXxx` naming prefixes receive a classification signal that biases toward constructor patterns, improving contractual classification accuracy for factory functions.
+- **Reduced GoDoc signal.** GoDoc keywords contribute a reduced signal (+5) to non-matching effect types, preventing documentation-derived classification from overwhelming mechanical signals.
+- **Container unwrap mapping.** Assertion mapping handles field access and transformation chains (e.g., JSON unmarshal followed by field access followed by type assertion) at confidence 55, improving mapping accuracy for assertions that verify deeply nested return values.
 
 ## Current Limitations
 

--- a/specs/017-gaze-docs-remaining/checklists/requirements.md
+++ b/specs/017-gaze-docs-remaining/checklists/requirements.md
@@ -1,0 +1,27 @@
+# Specification Quality Checklist: Gaze Docs Remaining
+
+**Purpose**: Validate specification completeness
+**Created**: 2026-04-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details
+- [x] Focused on user value
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes
+- [x] No implementation details leak into specification

--- a/specs/017-gaze-docs-remaining/spec.md
+++ b/specs/017-gaze-docs-remaining/spec.md
@@ -1,0 +1,45 @@
+# Feature Specification: Gaze Docs Remaining
+
+**Feature Branch**: `017-gaze-docs-remaining`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: Address remaining 11 Gaze documentation gaps from the gaze-website-docs-audit.md: sample output version, `--include-unexported`, `--ai-mapper`, deeper reviewer-testing/testreview docs, and 7 internal feature docs.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+**Stale Reference (1 item):**
+
+- **FR-001**: The sample output version reference MUST be updated or contextualized (currently says "v1.2.3").
+
+**Missing Significant Features (3 items):**
+
+- **FR-002**: The `--include-unexported` flag MUST be documented with its auto-detection behavior for `package main`.
+- **FR-003**: The `--ai-mapper` flag MUST be documented as an opt-in AI-assisted assertion mapping pass.
+- **FR-004**: The `reviewer-testing` agent and `/speckit.testreview` command MUST have brief explanatory text beyond their listing in the `gaze init` table.
+
+**Missing Internal Features (7 items):**
+
+- **FR-005**: The `--max-gaze-crapload` threshold flag MUST be documented.
+- **FR-006**: SSA degradation diagnostics (`ssa_degraded_packages`) MUST be mentioned in the limitations or architecture section.
+- **FR-007**: The AST mutation fallback behavior MUST be mentioned.
+- **FR-008**: The `no_test_coverage` classification reason MUST be mentioned.
+- **FR-009**: The `New` naming prefix constructor signal MUST be mentioned.
+- **FR-010**: The reduced GoDoc signal behavior MUST be mentioned.
+- **FR-011**: The container unwrap assertion mapping MUST be mentioned.
+
+**Cross-cutting:**
+
+- **FR-012**: All changes MUST pass `npm run build` without errors.
+
+## Success Criteria _(mandatory)_
+
+- **SC-001**: Every feature from the 11-item remaining gap list is documented on at least one page.
+- **SC-002**: `npm run build` succeeds with zero errors.
+
+## Assumptions
+
+- All features are documented via additions to the existing `content/docs/projects/gaze.md` page. The `--include-unexported` and `--ai-mapper` flags go in the CLI Usage section. The internal features go in a new "Advanced Features" or expanded "Architecture" section. The `reviewer-testing` and `testreview` expansion goes near the existing `gaze init` table.
+- The sample output version line will note that the sample was generated with an earlier version and may differ from current output, rather than regenerating the entire sample.
+- Source material comes from the Gaze README, PR descriptions, and issue context (discovered via Dewey).


### PR DESCRIPTION
## Summary

Addresses the remaining 11 items from the gaze-website-docs-audit.md that were not covered by spec 012.

- Update sample output version reference (no longer says v1.2.3)
- Add CLI Flags table with `--include-unexported`, `--ai-mapper`, `--max-gaze-crapload`, `--coverprofile`
- Expand `reviewer-testing` agent and `/speckit.testreview` command descriptions beyond the init table listing
- Add Analysis Engine Details section covering SSA degradation diagnostics, AST mutation fallback, `no_test_coverage` classification, constructor naming signal, reduced GoDoc signal, and container unwrap assertion mapping

All 24 items from the original audit are now addressed (13 in spec 012 + 11 in this PR).