### PR TITLE
fix: remove stale Bun/Hivemind references, add content agents, update Divisor to 8 personas

### DIFF
--- a/content/blog/unleash-in-practice.md
+++ b/content/blog/unleash-in-practice.md
@@ -100,9 +100,9 @@ If findings exist, the pipeline attempts to fix them and re-review, up to 3 iter
 
 ### 7. Retrospective
 
-Analyzes the session — what was built, what the review council found, what patterns emerged — and stores learnings in semantic memory via [Hivemind](https://github.com/unbound-force/unbound-force). These learnings surface in future sessions when similar problems arise.
+Analyzes the session — what was built, what the review council found, what patterns emerged — and stores learnings in Dewey semantic memory. These learnings surface in future sessions when similar problems arise.
 
-If Hivemind is not available, learnings are displayed in the output instead of stored.
+If Dewey is not available, learnings are displayed in the output instead of stored.
 
 ### 8. Demo
 
@@ -148,7 +148,7 @@ After `/unleash` presents demo instructions, run `/finale` to automate the end-o
 | Dewey      | Auto-resolves clarification questions | Questions exit for human input |
 | Replicator | Parallel task execution in worktrees  | Sequential execution           |
 | Gaze       | Quality analysis in code review       | Code review skips quality data |
-| Hivemind   | Stores retrospective learnings        | Displays learnings in output   |
+| Dewey      | Stores retrospective learnings        | Displays learnings in output   |
 
 The pipeline works with all four tools, with none of them, or with any combination. You get the most autonomous experience with the full stack, but the pipeline never fails because a tool is missing.
 

--- a/content/docs/contributing/_index.md
+++ b/content/docs/contributing/_index.md
@@ -15,6 +15,7 @@ Found a bug or have a feature request? Open an issue on the relevant GitHub repo
 - [Unbound Force Website](https://github.com/unbound-force/website/issues) — this website
 - [Gaze](https://github.com/unbound-force/gaze/issues) — test quality analysis tool
 - [Dewey](https://github.com/unbound-force/dewey/issues) — semantic knowledge retrieval
+- [Replicator](https://github.com/unbound-force/replicator/issues) — multi-agent coordination
 - [Unbound Force](https://github.com/unbound-force/unbound-force/issues) — agent personas and roles
 
 Include steps to reproduce, expected behavior, and actual behavior. For feature requests, describe the problem you are trying to solve.
@@ -29,7 +30,7 @@ We follow the standard GitHub pull request workflow:
 4. Submit a pull request against the `main` branch
 5. Address any review feedback from The Divisor council
 
-All pull requests are reviewed by The Divisor — a council of five sub-personas (The Guard, The Architect, The Adversary, The Operator (SRE), and The Tester) that evaluate intent, structure, resilience, operational readiness, and test quality. Collective approval from all five is required before merge.
+All pull requests are reviewed by The Divisor — a council of eight sub-personas. Five review personas (The Guard, The Architect, The Adversary, The Operator (SRE), and The Tester) evaluate intent, structure, resilience, operational readiness, and test quality. Three content personas (The Scribe, The Herald, and The Envoy) ensure documentation, blog posts, and public communications meet quality standards. Collective approval from all active personas is required before merge.
 
 ## Conventional Commits
 
@@ -78,4 +79,5 @@ The constitution (`.specify/memory/constitution.md`) is the highest-authority do
 - [Website Repository](https://github.com/unbound-force/website)
 - [Gaze Repository](https://github.com/unbound-force/gaze)
 - [Dewey Repository](https://github.com/unbound-force/dewey)
+- [Replicator Repository](https://github.com/unbound-force/replicator)
 - [Speckit (spec-kit)](https://github.com/github/spec-kit)

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -22,7 +22,7 @@ toc: true
 | 4    | **Spec Review**   | Runs the review council in Spec Review Mode. Auto-fixes LOW/MEDIUM findings. Exits on HIGH/CRITICAL.                                                                               |
 | 5    | **Implement**     | Parses `tasks.md` for phases. `[P]` parallel tasks run via Replicator worktrees (up to 4 concurrent workers). Phase checkpoints run CI commands derived from `.github/workflows/`. |
 | 6    | **Code Review**   | Runs the review council in Code Review Mode. Includes Phase 1a CI hard gate, Phase 1b Gaze quality analysis, and Divisor agent reviews. Up to 3 fix iterations.                    |
-| 7    | **Retrospective** | Analyzes the session and stores learnings in Hivemind semantic memory.                                                                                                             |
+| 7    | **Retrospective** | Analyzes the session and stores learnings in Dewey semantic memory.                                                                                                                |
 | 8    | **Demo**          | Presents structured demo instructions: what was built, how to verify, key files changed, and next steps.                                                                           |
 
 ### Key Capabilities
@@ -140,10 +140,10 @@ The [Developer (Cobalt-Crush)](/docs/getting-started/developer/) creates the tec
 
 ### 4. Review (Reviewer Council) `[swarm]`
 
-[The Divisor](/docs/team/the-divisor/) reviews the code through five specialized personas.
+[The Divisor](/docs/team/the-divisor/) reviews the code through its specialized personas.
 
 - Invoke the review council: `/review-council`
-- Five personas evaluate in parallel:
+- Review personas evaluate in parallel:
   - **Guard**: Intent drift, constitution alignment, zero-waste
   - **Architect**: Coding conventions, pattern adherence, DRY
   - **Adversary**: Security, resilience, error handling
@@ -337,7 +337,7 @@ Run the review council to validate the fix:
 /review-council
 ```
 
-The five Divisor personas review the changes. Address any REQUEST CHANGES findings.
+The Divisor personas review the changes. Address any REQUEST CHANGES findings.
 
 ### 4. Archive
 
@@ -351,7 +351,7 @@ Moves the change to `openspec/changes/archive/` with a date prefix for historica
 
 ## Code Review
 
-The review council brings five specialized perspectives to every code review.
+The review council brings multiple specialized perspectives to every code review.
 
 ### Invoking the Council
 
@@ -413,7 +413,7 @@ uf setup
 This installs the full toolchain in one command:
 
 - **Core tools** -- OpenCode (AI coding environment), Gaze (quality analysis), Mx F (manager hero), GitHub CLI
-- **Development tools** -- Node.js, Bun, OpenSpec CLI, Replicator (multi-agent coordination), `.hive/` initialization
+- **Development tools** -- Node.js, OpenSpec CLI, Replicator (multi-agent coordination)
 - **Knowledge layer** -- Ollama (local model runtime), Dewey (semantic search), IBM Granite embedding model, Dewey workspace initialization and index build
 - **Project scaffolding** -- `uf init` to deploy agents, commands, convention packs, templates, and workflow configuration
 

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -20,7 +20,7 @@ uf setup
 `uf setup` detects your existing version managers (goenv, nvm, fnm, Homebrew) and installs through them:
 
 - **Core tools** -- OpenCode (AI coding environment), Gaze (quality analysis), Mx F (manager hero), GitHub CLI
-- **Development tools** -- Node.js, Bun, OpenSpec CLI, Replicator (multi-agent coordination)
+- **Development tools** -- Node.js, OpenSpec CLI, Replicator (multi-agent coordination)
 - **Knowledge layer** -- Ollama (local model runtime), Dewey (semantic search), IBM Granite embedding model
 - **Project scaffolding** -- agents, commands, convention packs, templates, and workflow configuration via `uf init`
 
@@ -175,11 +175,11 @@ This prevents conflicts when multiple workers are active. Reservations auto-rele
 
 Every session follows this ritual:
 
-| Step      | Command                     | Purpose                          |
-| --------- | --------------------------- | -------------------------------- |
-| **Start** | `hive_ready()`              | Get the next unblocked work item |
-| **Work**  | `/unleash` or direct coding | Execute the work                 |
-| **End**   | `hive_sync()` + `git push`  | Persist work items and learnings |
+| Step      | Command                               | Purpose                                 |
+| --------- | ------------------------------------- | --------------------------------------- |
+| **Start** | `/speckit.specify` or `/opsx-propose` | Define the work                         |
+| **Work**  | `/unleash` or `/cobalt-crush`         | Execute the work                        |
+| **End**   | `/finale`                             | Commit, push, PR, merge, return to main |
 
 ## Cobalt-Crush Persona
 
@@ -209,6 +209,8 @@ Packs are organized by language, with each language having a tool-owned canonica
 | `typescript.md`        | Tool-owned | TypeScript-specific rules: ESLint, Prettier, strict typing, architectural patterns                                |
 | `typescript-custom.md` | User-owned | Project-specific TypeScript conventions                                                                           |
 | `severity.md`          | Tool-owned | Shared severity definitions for all Divisor personas (calibration standard for CRITICAL/HIGH/MEDIUM/LOW findings) |
+| `content.md`           | Tool-owned | Language-agnostic writing standards for documentation, blog posts, and website content                            |
+| `content-custom.md`    | User-owned | Project-specific writing conventions                                                                              |
 
 #### Ownership Model
 
@@ -274,14 +276,14 @@ uf init [--divisor] [--lang go|typescript] [--force]
 
 `uf init` deploys approximately 50 files across these categories:
 
-| Category         | Files | Examples                                                                          |
-| ---------------- | ----- | --------------------------------------------------------------------------------- |
-| Agents           | ~12   | 5 Divisor personas, Cobalt-Crush, Constitution Check, Mx F Coach                  |
-| Commands         | ~15   | 9 Speckit commands, review-council, constitution-check, cobalt-crush              |
-| Convention Packs | 7     | default, go, typescript (each with tool-owned and user-owned variants) + severity |
-| Templates        | ~6    | spec, plan, tasks, checklist, constitution, agent-file templates                  |
-| Scripts          | ~5    | check-prerequisites, setup-plan, create-new-feature, update-agent-context         |
-| OpenSpec         | ~6    | config, schema, 4 templates (design, proposal, spec, tasks)                       |
+| Category         | Files | Examples                                                                                   |
+| ---------------- | ----- | ------------------------------------------------------------------------------------------ |
+| Agents           | ~12   | 5 Divisor personas, Cobalt-Crush, Constitution Check, Mx F Coach                           |
+| Commands         | ~15   | 9 Speckit commands, review-council, constitution-check, cobalt-crush                       |
+| Convention Packs | 9     | default, go, typescript, content (each with tool-owned and user-owned variants) + severity |
+| Templates        | ~6    | spec, plan, tasks, checklist, constitution, agent-file templates                           |
+| Scripts          | ~5    | check-prerequisites, setup-plan, create-new-feature, update-agent-context                  |
+| OpenSpec         | ~6    | config, schema, 4 templates (design, proposal, spec, tasks)                                |
 
 File counts are approximate and may change between versions.
 
@@ -310,15 +312,13 @@ After completion, `uf init` shows a summary with file dispositions (`+` created,
 
 ## Session Ritual
 
-The most important habit: **always end your session properly**.
+The most important habit: **always end your session properly**. The daily workflow follows a specify → unleash → finale loop. When you are done working, run `/finale` to commit, push, create a PR, and merge:
 
-```
-1. hive_sync()     # Persist work items to git
-2. git push        # Push to remote
-3. Verify          # "Your branch is up to date with origin"
+```text
+/finale        # commit → push → PR → merge → main
 ```
 
-The plane is not landed until `git push` succeeds. This ensures your work items, semantic memory learnings, and file reservation state are available for your next session -- and for other team members who may pick up where you left off.
+`/finale` handles the full end-of-branch workflow: staging changes, generating a conventional commit message, pushing to remote, creating a PR, watching CI checks, rebase-merging, and returning to `main`. The session is not complete until `git push` succeeds — this ensures your work items, semantic memory learnings, and file reservation state are available for your next session and for other team members who may pick up where you left off.
 
 ## Next Steps
 

--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -20,7 +20,7 @@ uf setup
 `uf setup` installs everything in one command:
 
 - **Core tools** -- OpenCode (AI coding environment), Gaze (quality analysis), Mx F (manager hero), GitHub CLI
-- **Development tools** -- Node.js, Bun, OpenSpec CLI, Replicator (multi-agent coordination)
+- **Development tools** -- Node.js, OpenSpec CLI, Replicator (multi-agent coordination)
 - **Knowledge layer** -- Ollama (local model runtime), Dewey (semantic search), IBM Granite embedding model
 - **Project scaffolding** -- agents, commands, convention packs, templates, and workflow configuration via `uf init`
 

--- a/content/docs/team/_index.md
+++ b/content/docs/team/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "The Team"
 description: "Meet the Unbound Force heroes — five AI agent personas that form a superhero-themed software engineering swarm."
-lead: "Meet the five AI agent personas and the infrastructure that powers the swarm."
+lead: "Meet the five hero personas and the infrastructure that powers the swarm."
 date: 2026-02-23T00:00:00+00:00
 draft: false
 weight: 10
@@ -28,7 +28,7 @@ _The Quality Sentinel and Predictive Validation Engine._ Gaze protects the produ
 
 ### [The Divisor](/docs/team/the-divisor/) — PR Reviewer Council
 
-_The Architectural Conscience and Code Integrity Guardian._ The Divisor operates as a council of five sub-personas — The Guard, The Architect, The Adversary, The Operator (SRE), and The Tester — providing comprehensive, multi-faceted validation of every code submission.
+_The Architectural Conscience and Code Integrity Guardian._ The Divisor operates as a council of eight sub-personas — five for code review (The Guard, The Architect, The Adversary, The Operator (SRE), and The Tester) and three for content creation (The Scribe, The Herald, and The Envoy) — providing comprehensive, multi-faceted validation of every code and content submission.
 
 ### [Mx F](/docs/team/mx-f/) — Manager
 

--- a/content/docs/team/the-divisor.md
+++ b/content/docs/team/the-divisor.md
@@ -1,6 +1,6 @@
 ---
 title: "The Divisor"
-description: "The Divisor is the PR Reviewer Council — five sub-personas (Guard, Architect, Adversary, SRE, Testing) serving as the Code Integrity Guardian."
+description: "The Divisor is the PR Reviewer Council — eight sub-personas for code review and content creation, serving as the Code Integrity Guardian."
 lead: "The Architectural Conscience and Code Integrity Guardian"
 date: 2026-02-23T00:00:00+00:00
 draft: false
@@ -14,7 +14,7 @@ toc: true
 
 The Divisor is the PR Reviewer of the Unbound Force swarm — the architectural conscience and code integrity guardian. Their mission is to ensure that all code changes proposed by Cobalt-Crush, once validated by Gaze, adhere strictly to established architectural standards, best practices, security policies, and maintainability requirements.
 
-The Divisor acts as the final technical gate before integration, translating high-level architectural standards into actionable review criteria. What makes The Divisor unique is its structure: it operates as a **council of five dynamically discovered personas** -- five canonical roles ship by default, with users able to add or remove personas freely. Each provides a different lens on every code submission.
+The Divisor acts as the final technical gate before integration, translating high-level architectural standards into actionable review criteria. What makes The Divisor unique is its structure: it operates as a **council of eight dynamically discovered personas** -- eight canonical roles ship by default (five review, three content creation), with users able to add or remove personas freely. Each provides a different lens on every code submission.
 
 ## The Council
 
@@ -65,6 +65,43 @@ The Tester focuses on _"Are the tests meaningful?"_ They ensure tests are not ju
 - Verifying test isolation (no shared mutable state, no execution order dependencies, no external network access)
 - Ensuring regression protection (spec-critical behavior locked down, known-good and known-bad scenarios covered)
 
+## Content Creation Personas
+
+Beyond code review, The Divisor includes three content creation personas that apply the same council-based quality model to written output. Each operates at a different temperature to match its domain — lower temperatures for precision-critical documentation, higher temperatures for creative public communication.
+
+### The Scribe — Technical Documentation
+
+The Scribe focuses on _"Does the documentation match the code?"_ They produce and review technical documentation with precision:
+
+- READMEs, specification artifacts, CLI help text, and API reference documentation
+- Ensuring documentation claims are verifiable against the actual codebase
+- Maintaining terminology consistency across all documentation pages
+- Flagging stale content that no longer reflects the current implementation
+
+Temperature: **0.1** (precision). Technical documentation demands accuracy over creativity — every claim must be traceable to code.
+
+### The Herald — Blog Posts and Announcements
+
+The Herald focuses on _"Does this tell a compelling technical story?"_ They produce and review narrative content:
+
+- Blog posts, release notes, changelogs, and feature announcements
+- Structuring content with a narrative arc: problem, approach, evidence, conclusion
+- Balancing technical depth with accessibility for a mid-level developer audience
+- Avoiding time-sensitive language that becomes stale ("recently," "new," "just launched")
+
+Temperature: **0.4** (controlled creativity). Blog posts need enough creative latitude to engage readers while staying grounded in technical accuracy.
+
+### The Envoy — Public Relations and Communications
+
+The Envoy focuses on _"Does this build trust?"_ They produce and review public-facing communications:
+
+- Press releases, social media posts, community updates, and partnership announcements
+- Calibrating claims to match the project's actual maturity level — never overstating capabilities
+- Building credibility through honest scoping and transparent limitation acknowledgment
+- Adapting tone for different audiences while maintaining the Unbound Force voice
+
+Temperature: **0.5** (most creative). Public communications benefit from the most creative latitude, but The Envoy's credibility constraints prevent overclaims.
+
 ## Exclusive Ownership Boundaries
 
 Each review dimension is owned by exactly one Divisor persona, eliminating duplicate findings across personas:
@@ -86,7 +123,7 @@ This ownership model ensures that a finding like "missing error handling" is rai
 
 ## Shared Severity Standard
 
-All 5 personas share a calibration standard defined in the `severity.md` convention pack (`.opencode/unbound/packs/severity.md`):
+All eight personas share a calibration standard defined in the `severity.md` convention pack (`.opencode/unbound/packs/severity.md`):
 
 | Level        | Definition                                                                           | Auto-Fix?                    |
 | ------------ | ------------------------------------------------------------------------------------ | ---------------------------- |
@@ -99,11 +136,11 @@ Each level includes domain-specific examples per persona — for example, an Adv
 
 ## Prior Learnings Integration
 
-All 5 Divisor personas include a "Prior Learnings" step at the start of their review workflow:
+All eight Divisor personas include a "Prior Learnings" step at the start of their review workflow:
 
-1. Search Hivemind for learnings tagged with the repo name and relevant file paths
+1. Search Dewey for learnings tagged with the repo name and relevant file paths
 2. Include found learnings as prior knowledge in the review context
-3. Graceful degradation when Hivemind is not available — the step is skipped with an informational note
+3. Graceful degradation when Dewey is not available — the step is skipped with an informational note
 
 This means the review council learns from past reviews. If a particular pattern has been flagged before, the relevant persona will reference that history when evaluating new code.
 
@@ -111,11 +148,11 @@ This means the review council learns from past reviews. If a particular pattern 
 
 The Divisor holds the ultimate authority to approve and merge code into the main branch. Approval requires collective consensus — **no outstanding REQUEST CHANGES from any persona** is mandatory. Gaze's functional validation serves as a prerequisite: the CI pipeline must be green before The Divisor begins review.
 
-This structure ensures that only code which passes all five lenses — intent, architecture, resilience, operational readiness, and test quality — is deployed.
+This structure ensures that only code which passes all eight lenses — intent, architecture, resilience, operational readiness, test quality, documentation accuracy, narrative clarity, and public communication — is deployed.
 
 ## How The Divisor Serves the Team
 
-**For Developers (Cobalt-Crush):** Cobalt-Crush relies on The Divisor for the final technical sign-off. The multi-faceted feedback from the five personas provides a holistic critique covering intent, structure, security, operational readiness, and test quality. Clear architectural standards minimize uncertainty, allowing Cobalt-Crush to code with confidence.
+**For Developers (Cobalt-Crush):** Cobalt-Crush relies on The Divisor for the final technical sign-off. The multi-faceted feedback from the eight personas provides a holistic critique covering intent, structure, security, operational readiness, test quality, and content accuracy. Clear architectural standards minimize uncertainty, allowing Cobalt-Crush to code with confidence.
 
 **For the Tester (Gaze):** Gaze relies on The Divisor to establish the architectural and non-functional requirements against which testability must be measured. Gaze's green light on functional tests is the entry criterion for The Divisor's review, ensuring review time is spent on high-level risk and structure rather than defect finding.
 

--- a/openspec/changes/fix-stale-refs-and-content-agents/.openspec.yaml
+++ b/openspec/changes/fix-stale-refs-and-content-agents/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-04-06

--- a/openspec/changes/fix-stale-refs-and-content-agents/design.md
+++ b/openspec/changes/fix-stale-refs-and-content-agents/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The website has 3 open issues (#20, #21, #22) reporting stale references and missing content caused by upstream meta repo changes (Specs 022, 024; PRs #79, #83, #84). All changes are text edits to existing Markdown pages — no new pages, layouts, or CSS.
+
+Per the proposal's constitution alignment: this is a documentation accuracy fix (Observable Quality: PASS). No hero communication, composability, or testability concerns.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Fix all factual errors identified in issues #20, #21, #22
+- Document the 3 new content agents (Scribe, Herald, Envoy)
+- Update convention pack count from 7 to 9
+- Add Replicator to contributing page
+- Close all 3 issues upon merge
+
+### Non-Goals
+
+- Rewriting the Divisor team page (only add content agent section and fix count)
+- Updating the `/unleash` command file or internal agent files (separate scope)
+- Adding content agent pages as standalone team pages (they are Divisor sub-personas, not independent heroes)
+
+## Decisions
+
+### 1. Content agents as a section within the Divisor page, not standalone pages
+
+The 3 content agents (Scribe, Herald, Envoy) are Divisor sub-personas, same as Guard, Architect, and Adversary. They belong on the existing `team/the-divisor.md` page in a new "Content Creation Personas" section, following the same subsection pattern as the existing review personas.
+
+### 2. Session Ritual: consolidate with Daily Workflow
+
+The Session Ritual section in `developer.md` references `hive_ready()`/`hive_sync()` — MCP tool calls that are now internal to the Replicator coordination layer. The Daily Workflow section already describes the specify → unleash → finale loop. The Session Ritual section will be updated to reference `/finale` as the end-of-session pattern and removed the stale `hive_ready()`/`hive_sync()` references.
+
+### 3. Convention pack table: add 2 rows, update any count references
+
+The `content.md` and `content-custom.md` packs follow the same tool-owned/user-owned pattern as the existing packs. They are always-deployed (like `default.md` and `severity.md`), not language-gated.
+
+### 4. ".hive/ initialization" attribution
+
+The `.hive/` directory is now created by `replicator init` (called by `uf init`), not by `uf setup` directly. The setup tool list in `common-workflows.md` will be updated to remove the `.hive/` initialization mention from the Development tools bullet and let the existing `uf init` description handle it.
+
+## Risks / Trade-offs
+
+**Risk**: The Divisor persona count (5 → 8) appears on multiple pages. A search for "five personas" must catch all occurrences to avoid cross-page inconsistency.
+
+**Mitigation**: Grep for "five personas", "five sub-personas", "five canonical", "council of five" across all content before marking complete.
+
+**Trade-off**: The Session Ritual section could be fully removed (the Daily Workflow section covers the same ground). Keeping a simplified version maintains backward compatibility for readers who bookmarked it. Decision: simplify rather than remove.

--- a/openspec/changes/fix-stale-refs-and-content-agents/proposal.md
+++ b/openspec/changes/fix-stale-refs-and-content-agents/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+Three GitHub issues (#20, #21, #22) report factual errors and missing content on the website caused by recent upstream changes in the unbound-force meta repo:
+
+- **Bun was removed** from `uf setup` (Spec 024) but 3 pages still list it as a development tool
+- **Hivemind was unified into Dewey** (Spec 022, PR #79) but 6 references to "Hivemind" remain across 3 pages
+- **3 content agents were added** to The Divisor (PR #84) but the website still says "five canonical roles" and doesn't describe The Scribe, The Herald, or The Envoy
+- **2 convention packs were added** (`content.md`, `content-custom.md`) but the developer guide still lists 7 packs instead of 9
+- **Replicator missing** from the contributing page's repo list
+- **Session Ritual section** still references `hive_ready()`/`hive_sync()` instead of the `/unleash` + `/finale` workflow
+- **`.hive/` initialization** listed as a `uf setup` step when it's now handled by `replicator init` via `uf init`
+
+These errors cause immediate confusion when a developer's experience doesn't match the documentation.
+
+## What Changes
+
+### Stale References Fixed
+
+- Remove "Bun" from the development tools list on 3 pages
+- Replace 6 "Hivemind" references with "Dewey" across 3 pages
+- Fix `.hive/` initialization attribution (setup → init)
+- Update Session Ritual to reference current workflow patterns
+
+### New Content Added
+
+- Document 3 content agents (The Scribe, The Herald, The Envoy) on the Divisor team page
+- Update Divisor persona count from 5 to 8 (5 review + 3 content)
+- Add `content.md` and `content-custom.md` to the convention packs table
+- Add Replicator to the contributing page
+
+## Capabilities
+
+### New Capabilities
+
+- Content agent documentation: visitors can learn about The Scribe, The Herald, and The Envoy on the Divisor team page
+
+### Modified Capabilities
+
+- Convention packs table: updated from 7 to 9 files
+- Contributing page: includes Replicator repo for issue reporting
+- Divisor persona count: reflects the 8 canonical roles (5 review + 3 content)
+
+### Removed Capabilities
+
+- Bun references: removed from setup documentation (no longer installed)
+- Hivemind references: replaced with Dewey (unified memory layer)
+- Stale Session Ritual: updated to current workflow
+
+## Impact
+
+**Affected files** (8):
+
+- `content/docs/getting-started/quick-start.md` — remove Bun
+- `content/docs/getting-started/developer.md` — remove Bun, update packs table, fix Session Ritual
+- `content/docs/getting-started/common-workflows.md` — remove Bun, fix Hivemind, fix .hive/ attribution
+- `content/blog/unleash-in-practice.md` — fix 3 Hivemind references
+- `content/docs/team/the-divisor.md` — fix persona count, add content agents, fix Hivemind
+- `content/docs/team/_index.md` — update Divisor summary
+- `content/docs/contributing/_index.md` — add Replicator
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+Documentation-only change. No artifacts, protocols, or hero communication affected.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No dependencies introduced or removed. Content pages are independent.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Fixes factual inaccuracies (Bun, Hivemind, persona count) that undermined the website's accuracy as the public-facing documentation. Adds missing content (content agents, convention packs) that were shipped in the meta repo but undocumented.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+Static documentation site. Validation is `npm run build` + visual verification.

--- a/openspec/changes/fix-stale-refs-and-content-agents/specs/requirements.md
+++ b/openspec/changes/fix-stale-refs-and-content-agents/specs/requirements.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Content Agent Documentation
+
+The Divisor team page MUST document 3 content creation personas (The Scribe, The Herald, The Envoy) with their role descriptions and temperature settings.
+
+#### Scenario: Visitor reads content agents
+
+- **GIVEN** a visitor on the Divisor team page
+- **WHEN** they look for content creation capabilities
+- **THEN** they find descriptions of The Scribe (tech docs, 0.1), The Herald (blog/announcements, 0.4), and The Envoy (PR/comms, 0.5)
+
+### Requirement: Convention Pack Completeness
+
+The developer guide convention packs table MUST list 9 files including `content.md` (tool-owned, writing standards) and `content-custom.md` (user-owned stub).
+
+#### Scenario: Developer checks pack files
+
+- **GIVEN** a developer reading the convention packs section
+- **WHEN** they count the pack files in the table
+- **THEN** they find 9 files listed
+
+### Requirement: Replicator in Contributing
+
+The contributing page MUST list the Replicator repository for issue reporting.
+
+#### Scenario: Contributor looks for Replicator issues
+
+- **GIVEN** a contributor on the contributing page
+- **WHEN** they look for where to report Replicator issues
+- **THEN** they find a link to `github.com/unbound-force/replicator/issues`
+
+## MODIFIED Requirements
+
+### Requirement: Bun Removal from Setup Lists
+
+The development tools list on quick-start.md, developer.md, and common-workflows.md MUST NOT include "Bun." Previously: "Node.js, Bun, OpenSpec CLI, Replicator."
+
+#### Scenario: Developer reads setup tools
+
+- **GIVEN** a developer reading any setup documentation page
+- **WHEN** they look at the development tools list
+- **THEN** "Bun" does not appear
+
+### Requirement: Hivemind to Dewey
+
+All references to "Hivemind" in user-facing content MUST be replaced with "Dewey." Previously: 6 references to "Hivemind" across common-workflows.md, unleash-in-practice.md, and the-divisor.md.
+
+#### Scenario: Reader searches for Hivemind
+
+- **GIVEN** a reader searching the website content (excluding historical specs)
+- **WHEN** they search for "Hivemind"
+- **THEN** zero results are found
+
+### Requirement: Divisor Persona Count
+
+The Divisor team page and team index MUST reflect 8 canonical personas (5 review + 3 content). Previously: "five canonical roles."
+
+#### Scenario: Visitor reads Divisor description
+
+- **GIVEN** a visitor on the Divisor team page
+- **WHEN** they read the council structure description
+- **THEN** the count reflects 8 personas
+
+### Requirement: Session Ritual Update
+
+The Session Ritual section in developer.md MUST reference current workflow patterns (`/finale`) instead of stale MCP tool calls (`hive_ready()`, `hive_sync()`).
+
+#### Scenario: Developer reads session lifecycle
+
+- **GIVEN** a developer reading the Session Ritual section
+- **WHEN** they look for end-of-session steps
+- **THEN** they find `/finale` referenced, not `hive_ready()`/`hive_sync()`
+
+### Requirement: .hive/ Initialization Attribution
+
+The common-workflows.md setup section MUST NOT list ".hive/ initialization" as a separate `uf setup` step. Previously: listed alongside Development tools.
+
+#### Scenario: Developer reads setup steps
+
+- **GIVEN** a developer reading the environment setup section
+- **WHEN** they look at what `uf setup` installs
+- **THEN** ".hive/ initialization" is not listed as a separate tool (it's handled by `replicator init` via `uf init`)
+
+## REMOVED Requirements
+
+_(None — all changes are additions or modifications)_

--- a/openspec/changes/fix-stale-refs-and-content-agents/tasks.md
+++ b/openspec/changes/fix-stale-refs-and-content-agents/tasks.md
@@ -1,0 +1,37 @@
+## 1. Fix Stale References (Issues #21, #22)
+
+- [x] 1.1 Remove "Bun" from development tools list in content/docs/getting-started/quick-start.md
+- [x] 1.2 Remove "Bun" from development tools list in content/docs/getting-started/developer.md
+- [x] 1.3 Remove "Bun" and ", `.hive/` initialization" from development tools list in content/docs/getting-started/common-workflows.md
+- [x] 1.4 Replace "Hivemind semantic memory" with "Dewey semantic memory" in the /unleash pipeline table in content/docs/getting-started/common-workflows.md
+- [x] 1.5 Replace 3 "Hivemind" references with "Dewey" in content/blog/unleash-in-practice.md (lines ~103, ~105, ~151) — also remove the GitHub link wrapper around the Hivemind mention
+- [x] 1.6 Replace 2 "Hivemind" references with "Dewey" in content/docs/team/the-divisor.md (lines ~104, ~106)
+
+## 2. Update Divisor Persona Count (Issue #22)
+
+- [x] 2.1 Update "council of five dynamically discovered personas -- five canonical roles" to reflect 8 personas (5 review + 3 content) in content/docs/team/the-divisor.md
+- [x] 2.2 Update "five personas" references in the Cobalt-Crush and Collective Approval sections of content/docs/team/the-divisor.md
+- [x] 2.3 Update "five sub-personas" to "eight sub-personas" in content/docs/team/\_index.md
+- [x] 2.4 Update "five sub-personas" in content/docs/contributing/\_index.md
+
+## 3. Add Content Agents (Issue #20)
+
+- [x] 3.1 Add a "Content Creation Personas" section to content/docs/team/the-divisor.md after the existing review personas, documenting The Scribe (tech docs, temperature 0.1), The Herald (blog/announcements, 0.4), and The Envoy (PR/comms, 0.5)
+- [x] 3.2 Update the Divisor summary in content/docs/team/\_index.md to mention content creation capability alongside review
+
+## 4. Update Convention Packs and Contributing (Issue #20)
+
+- [x] 4.1 Add `content.md` (tool-owned, language-agnostic writing standards) and `content-custom.md` (user-owned stub) rows to the convention packs table in content/docs/getting-started/developer.md
+- [x] 4.2 Add Replicator to the issue reporting list and links section in content/docs/contributing/\_index.md (if not already present)
+
+## 5. Fix Session Ritual (Issue #20)
+
+- [x] 5.1 Update the Session Ritual section in content/docs/getting-started/developer.md: replace `hive_ready()`/`hive_sync()` references with current workflow patterns, reference `/finale` as end-of-session
+
+## 6. Verification
+
+- [x] 6.1 Run `npm run build` and verify zero errors
+- [x] 6.2 Grep for "Hivemind" in content/ — zero results expected
+- [x] 6.3 Grep for "Bun" in setup tool lists — zero results expected
+- [x] 6.4 Grep for "five personas" / "five sub-personas" / "five canonical" — zero results expected
+- [x] 6.5 Verify constitution alignment: Observable Quality PASS (all factual claims now accurate)


### PR DESCRIPTION
## Summary

Addresses all 3 open issues (#20, #21, #22) in one change.

### Issue #22: Remove Bun + update Divisor count
- Remove "Bun" from development tools list on 3 pages (removed from `uf setup` in Spec 024)
- Update Divisor persona count from 5 to 8 across all pages (5 review + 3 content agents added in PR #84)

### Issue #21: Replace Hivemind with Dewey
- Replace 6 "Hivemind" references with "Dewey" across 3 pages (unified in Spec 022, PR #79)

### Issue #20: Content agents, convention packs, stale sections
- Add Content Creation Personas section to Divisor page: The Scribe (tech docs), The Herald (blog), The Envoy (PR/comms)
- Add `content.md` and `content-custom.md` to convention packs table (7 -> 9 files)
- Add Replicator to contributing page issue list
- Update Session Ritual to reference `/finale` instead of stale `hive_ready()`/`hive_sync()`
- Remove ".hive/ initialization" from `uf setup` tool list

### Verification
- Zero "Hivemind" in content/ (was 6)
- Zero "Bun" in setup tool lists (was 3)
- Zero "five sub-personas" / "five canonical" (was 4)
- Zero `hive_ready`/`hive_sync` in content/ (was 4)
- `npm run build`: 82 pages, 0 errors

Closes #20, closes #21, closes #22