### PR TITLE
docs: update all directory paths for .uf/ consolidation (Spec 025)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,7 @@ Thumbs.db
 
 # ─── Netlify ─────────────────────────────────────────────────────────
 .netlify
+
+# ─── Tool data (runtime, not tracked) ────────────────────────────────
 .dewey/
+.uf/

--- a/.opencode/agents/cobalt-crush-dev.md
+++ b/.opencode/agents/cobalt-crush-dev.md
@@ -20,8 +20,8 @@ Before writing code, read the following in order:
 1. **`AGENTS.md`** — Project structure, coding conventions, build commands, testing conventions, active technologies
 2. **`.specify/memory/constitution.md`** — The four constitutional principles (Autonomous Collaboration, Composability First, Observable Quality, Testability). All code must align.
 3. **Active spec and plan** — Check `specs/` for the current feature branch's `spec.md`, `plan.md`, and `tasks.md`. Read the user story acceptance criteria you are implementing.
-4. **Convention packs** — Read all `*.md` files from `.opencode/unbound/packs/` to load the active coding conventions. If no pack files are found, note this in your output and apply universal principles only.
-5. **Feedback artifacts** — Check `.unbound-force/artifacts/` for Gaze quality reports and Divisor review verdicts from previous cycles. Read these to learn from past feedback.
+4. **Convention packs** — Read all `*.md` files from `.opencode/uf/packs/` to load the active coding conventions. If no pack files are found, note this in your output and apply universal principles only.
+5. **Feedback artifacts** — Check `.uf/artifacts/` for Gaze quality reports and Divisor review verdicts from previous cycles. Read these to learn from past feedback.
 6. **Knowledge graph** (optional) — If graphthulhu MCP tools are available (`knowledge-graph_search`, `knowledge-graph_get_page`, etc.), use them to search for related specs, past review patterns, and architectural decisions. If MCP tools are unavailable, rely on reading project files directly.
 
 ## Engineering Philosophy
@@ -48,7 +48,7 @@ When making non-trivial design choices:
 
 ### 1. Convention Pack Adherence [PACK]
 
-Before writing code, load the active convention pack from `.opencode/unbound/packs/`. Apply all rules tagged with `[MUST]` as mandatory requirements. Apply `[SHOULD]` rules as strong recommendations. Apply `[MAY]` rules as optional improvements.
+Before writing code, load the active convention pack from `.opencode/uf/packs/`. Apply all rules tagged with `[MUST]` as mandatory requirements. Apply `[SHOULD]` rules as strong recommendations. Apply `[MAY]` rules as optional improvements.
 
 Key areas from convention packs:
 
@@ -86,7 +86,7 @@ Every function you write must be testable. Apply these patterns:
 
 After writing code, check for Gaze quality feedback:
 
-1. **Check for artifacts**: Look in `.unbound-force/artifacts/quality-report/` for recent Gaze reports. Also check for `coverage.out`, Gaze CLI output, or test results in the project root.
+1. **Check for artifacts**: Look in `.uf/artifacts/quality-report/` for recent Gaze reports. Also check for `coverage.out`, Gaze CLI output, or test results in the project root.
 
 2. **Parse findings**: For each finding, categorize by type:
    - **CRAP score > 30**: Refactor to reduce cyclomatic complexity or increase test coverage. Target CRAP < 30.
@@ -115,7 +115,7 @@ Before submitting for review and after receiving review feedback:
 
 ### Addressing Review Findings
 
-1. **Check for artifacts**: Look in `.unbound-force/artifacts/review-verdict/` for Divisor review reports. Also check recent `/review-council` output.
+1. **Check for artifacts**: Look in `.uf/artifacts/review-verdict/` for Divisor review reports. Also check recent `/review-council` output.
 
 2. **Categorize findings**: Group by persona (Guard, Architect, Adversary, SRE, Testing) and severity (CRITICAL, HIGH, MEDIUM, LOW).
 

--- a/.opencode/agents/divisor-adversary.md
+++ b/.opencode/agents/divisor-adversary.md
@@ -10,6 +10,7 @@ tools:
   bash: false
   webfetch: false
 ---
+
 <!-- scaffolded by uf vdev -->
 
 # Role: The Adversary
@@ -27,7 +28,7 @@ Before reviewing, read:
 1. `AGENTS.md` -- Behavioral Constraints, Active Technologies, Git & Workflow
 2. `.specify/memory/constitution.md` -- Constitution (if present)
 3. The relevant spec, plan, and tasks files under `specs/` for the current work
-4. `.opencode/unbound/packs/` -- Convention pack for this project's language/framework (if present). Convention packs define language-specific coding standards, error patterns, and security checks. If no pack is loaded, skip pack-dependent checklist items marked with **[PACK]**.
+4. `.opencode/uf/packs/` -- Convention pack for this project's language/framework (if present). Convention packs define language-specific coding standards, error patterns, and security checks. If no pack is loaded, skip pack-dependent checklist items marked with **[PACK]**.
 
 ---
 
@@ -101,7 +102,7 @@ Evaluate all recent changes (staged, unstaged, and untracked files). Use `git di
 
 #### 6. Language-Specific Error Patterns [PACK]
 
-> Skip this section if no convention pack is loaded from `.opencode/unbound/packs/`.
+> Skip this section if no convention pack is loaded from `.opencode/uf/packs/`.
 
 - Check the convention pack's `security_checks` section for language-specific vulnerability patterns.
 - Apply the pack's error handling conventions to the changed code.
@@ -109,7 +110,7 @@ Evaluate all recent changes (staged, unstaged, and untracked files). Use `git di
 
 #### 7. Dependency Vulnerabilities [PACK]
 
-> Skip this section if no convention pack is loaded from `.opencode/unbound/packs/`.
+> Skip this section if no convention pack is loaded from `.opencode/uf/packs/`.
 
 - Check based on convention pack guidance for dependency security.
 - Verify dependency version pins are specific (not floating ranges) per pack conventions.

--- a/.opencode/agents/divisor-architect.md
+++ b/.opencode/agents/divisor-architect.md
@@ -8,6 +8,7 @@ tools:
   edit: false
   bash: false
 ---
+
 <!-- scaffolded by uf vdev -->
 
 # Role: The Architect
@@ -25,7 +26,7 @@ Before reviewing, read:
 1. `AGENTS.md` -- Project Structure, Active Technologies, conventions
 2. `.specify/memory/constitution.md` -- Constitution principles
 3. The relevant spec, plan, and tasks files under `specs/` for the current work
-4. Read all `*.md` files from `.opencode/unbound/packs/` to load the active convention pack. If no pack files are found, note this and proceed with universal checks only.
+4. Read all `*.md` files from `.opencode/uf/packs/` to load the active convention pack. If no pack files are found, note this and proceed with universal checks only.
 
 ---
 
@@ -165,6 +166,7 @@ For each finding, provide:
 Severity levels: CRITICAL, HIGH, MEDIUM, LOW
 
 Also provide an **Architectural Alignment Score** (1-10):
+
 - 9-10: Exemplary alignment with all patterns and conventions
 - 7-8: Minor deviations, no structural concerns
 - 5-6: Notable deviations requiring attention

--- a/.opencode/agents/divisor-guard.md
+++ b/.opencode/agents/divisor-guard.md
@@ -8,6 +8,7 @@ tools:
   edit: false
   bash: false
 ---
+
 <!-- scaffolded by uf vdev -->
 
 # Role: The Guard
@@ -25,7 +26,7 @@ Before reviewing, read:
 1. `AGENTS.md` -- Project overview, behavioral constraints, and conventions
 2. `.specify/memory/constitution.md` -- Project constitution (core principles)
 3. The relevant `spec.md`, `plan.md`, and `tasks.md` under `specs/` for the current work
-4. All `*.md` files from `.opencode/unbound/packs/` -- active convention pack. If no pack files are found, note this in your findings and proceed with universal checks only.
+4. All `*.md` files from `.opencode/uf/packs/` -- active convention pack. If no pack files are found, note this in your findings and proceed with universal checks only.
 
 ---
 

--- a/.opencode/agents/divisor-pr.md
+++ b/.opencode/agents/divisor-pr.md
@@ -26,7 +26,7 @@ Before reviewing, read:
 1. `AGENTS.md` -- Behavioral Constraints (especially Content Accuracy: "never fabricate features or overstate maturity"), Project Overview, Content Sources
 2. `.specify/memory/constitution.md` -- Constitution (if present)
 3. The relevant spec, plan, and tasks files under `specs/` for the current work
-4. `.opencode/unbound/packs/` -- Convention pack for this project (if present). Skip pack-dependent checklist items marked with **[PACK]** if no pack is loaded.
+4. `.opencode/uf/packs/` -- Convention pack for this project (if present). Skip pack-dependent checklist items marked with **[PACK]** if no pack is loaded.
 
 ---
 

--- a/.opencode/agents/divisor-sre.md
+++ b/.opencode/agents/divisor-sre.md
@@ -8,6 +8,7 @@ tools:
   edit: false
   bash: false
 ---
+
 <!-- scaffolded by uf vdev -->
 
 # Role: The Operator
@@ -27,7 +28,7 @@ Before reviewing, read:
 3. The relevant spec, plan, and tasks files under `specs/` for the current work
 4. Release pipeline configs if they exist (e.g., `.goreleaser.yaml`, `.github/workflows/`, `Makefile`, CI configs)
 5. Dependency manifests if they exist (e.g., `go.mod`, `package.json`, `requirements.txt`, `Cargo.toml`)
-6. All `*.md` files from `.opencode/unbound/packs/` -- active convention pack. If no pack files are found, note this in your findings and proceed with universal checks only.
+6. All `*.md` files from `.opencode/uf/packs/` -- active convention pack. If no pack files are found, note this in your findings and proceed with universal checks only.
 
 ---
 

--- a/.opencode/agents/divisor-techwriter.md
+++ b/.opencode/agents/divisor-techwriter.md
@@ -26,7 +26,7 @@ Before reviewing, read:
 1. `AGENTS.md` -- Behavioral Constraints, Content Conventions, Markdown Rules, Project Structure
 2. `.specify/memory/constitution.md` -- Constitution (if present)
 3. The relevant spec, plan, and tasks files under `specs/` for the current work
-4. `.opencode/unbound/packs/` -- Convention pack for this project (if present). Skip pack-dependent checklist items marked with **[PACK]** if no pack is loaded.
+4. `.opencode/uf/packs/` -- Convention pack for this project (if present). Skip pack-dependent checklist items marked with **[PACK]** if no pack is loaded.
 
 ---
 

--- a/.opencode/agents/divisor-testing.md
+++ b/.opencode/agents/divisor-testing.md
@@ -8,6 +8,7 @@ tools:
   edit: false
   bash: false
 ---
+
 <!-- scaffolded by uf vdev -->
 
 # Role: The Tester
@@ -25,7 +26,7 @@ Before reviewing, read:
 1. `AGENTS.md` -- Testing conventions, coding conventions, build & test commands
 2. `.specify/memory/constitution.md` -- Core principles (especially Observable Quality and Testability)
 3. The relevant spec, plan, and tasks files under `specs/` for the current work
-4. All `*.md` files from `.opencode/unbound/packs/` -- active convention pack. If no pack files are found, note this in your findings and proceed with universal checks only.
+4. All `*.md` files from `.opencode/uf/packs/` -- active convention pack. If no pack files are found, note this in your findings and proceed with universal checks only.
 
 ---
 

--- a/.opencode/command/cobalt-crush.md
+++ b/.opencode/command/cobalt-crush.md
@@ -5,6 +5,7 @@ description: >
   arguments: detects active workflow and runs /speckit.implement or
   /opsx:apply.
 ---
+
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
@@ -49,8 +50,8 @@ the task prompt. The agent will:
 
 1. Read AGENTS.md, constitution, convention packs, and active specs
 2. Apply its engineering philosophy (clean code, SOLID, TDD awareness)
-3. Load convention packs from `.opencode/unbound/packs/`
-4. Check `.unbound-force/artifacts/` for Gaze/Divisor feedback
+3. Load convention packs from `.opencode/uf/packs/`
+4. Check `.uf/artifacts/` for Gaze/Divisor feedback
 5. Execute the requested task following project conventions
 6. Document design decisions in code comments
 
@@ -75,6 +76,7 @@ implementation command to the `cobalt-crush-dev` agent:
    The current branch must be `opsx/<change-name>` where
    `<change-name>` matches the detected change directory name.
    If not on the correct branch, **STOP** with error:
+
    > "OpenSpec change `<name>` detected but you are on branch
    > `<current-branch>`. Run: `git checkout opsx/<name>`"
 

--- a/.opencode/command/review-council.md
+++ b/.opencode/command/review-council.md
@@ -1,9 +1,11 @@
 ---
 description: Run the reviewer governance council to audit codebase or spec compliance.
 ---
+
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
+
 # Command: /review-council
 
 ## User Input
@@ -35,14 +37,17 @@ When no mode keyword is provided, detect the mode by
 examining the current branch and workspace:
 
 1. **Get the current branch name**:
+
    ```bash
    git rev-parse --abbrev-ref HEAD
    ```
 
 2. **Get the diff against the base branch** (`main`):
+
    ```bash
    git diff --name-only main...HEAD
    ```
+
    This shows all files changed on the current branch
    relative to `main`.
 
@@ -54,7 +59,7 @@ examining the current branch and workspace:
    - **Code files**: everything else (`.go`, `.ts`, `.js`,
      `.py`, `go.mod`, `go.sum`, `Makefile`, `internal/`,
      `cmd/`, `.opencode/agents/`, `.opencode/command/`,
-     `.opencode/skill/`, `.opencode/unbound/packs/`,
+     `.opencode/skill/`, `.opencode/uf/packs/`,
      etc.)
 
 4. **Detect the workflow tier** from the branch name:
@@ -64,12 +69,12 @@ examining the current branch and workspace:
 
 5. **Select mode based on classification**:
 
-   | Condition | Mode | Rationale |
-   |-----------|------|-----------|
-   | Code files changed | **Code Review** | Post-implementation -- review the code |
-   | Only spec files changed | **Spec Review** | Pre-implementation -- review the specs |
+   | Condition                | Mode            | Rationale                               |
+   | ------------------------ | --------------- | --------------------------------------- |
+   | Code files changed       | **Code Review** | Post-implementation -- review the code  |
+   | Only spec files changed  | **Spec Review** | Pre-implementation -- review the specs  |
    | No files changed vs main | **Spec Review** | On main or fresh branch -- review specs |
-   | On `main` branch | **Spec Review** | No feature branch -- review specs |
+   | On `main` branch         | **Spec Review** | No feature branch -- review specs       |
 
 6. **Announce the detected mode**: Always tell the user
    which mode was selected and why, including the
@@ -105,13 +110,13 @@ Before entering either review mode, discover which reviewer agents are available
 
 This table documents known Divisor persona roles and their focus areas. It is used for context when delegating to discovered agents, but the **invocation list comes solely from discovery** — not from this table.
 
-| Agent Name | Persona | Code Review Focus | Spec Review Focus |
-|---|---|---|---|
-| `divisor-adversary` | The Adversary | Security, resilience, efficiency, zero-waste, error handling, universal security, dependency vulnerabilities | Completeness, testability, ambiguity, security gaps, dependency risks, cross-spec consistency |
-| `divisor-architect` | The Architect | Architectural alignment, coding conventions [PACK], pattern adherence, plan alignment, DRY, testing conventions [PACK], documentation [PACK] | Template consistency, spec-to-plan alignment, task coverage, data model coherence, inter-spec architecture |
-| `divisor-guard` | The Guard | Intent drift detection, constitution alignment, neighborhood rule [PACK], zero-waste mandate | Intent fidelity, scope discipline, inter-spec consistency, status accuracy, user value, constitution alignment |
-| `divisor-testing` | The Tester | Test architecture [PACK], coverage strategy, assertion depth, test isolation, regression protection, convention compliance [PACK] | Testability of requirements, test strategy coverage, fixture feasibility, coverage expectations, contract surface |
-| `divisor-sre` | The Operator | Release pipeline [PACK], dependency health [PACK], configuration, runtime observability, upgrade paths, operational docs | Deployment feasibility, operational requirements, config management, dependency risk, maintenance burden |
+| Agent Name          | Persona       | Code Review Focus                                                                                                                            | Spec Review Focus                                                                                                 |
+| ------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `divisor-adversary` | The Adversary | Security, resilience, efficiency, zero-waste, error handling, universal security, dependency vulnerabilities                                 | Completeness, testability, ambiguity, security gaps, dependency risks, cross-spec consistency                     |
+| `divisor-architect` | The Architect | Architectural alignment, coding conventions [PACK], pattern adherence, plan alignment, DRY, testing conventions [PACK], documentation [PACK] | Template consistency, spec-to-plan alignment, task coverage, data model coherence, inter-spec architecture        |
+| `divisor-guard`     | The Guard     | Intent drift detection, constitution alignment, neighborhood rule [PACK], zero-waste mandate                                                 | Intent fidelity, scope discipline, inter-spec consistency, status accuracy, user value, constitution alignment    |
+| `divisor-testing`   | The Tester    | Test architecture [PACK], coverage strategy, assertion depth, test isolation, regression protection, convention compliance [PACK]            | Testability of requirements, test strategy coverage, fixture feasibility, coverage expectations, contract surface |
+| `divisor-sre`       | The Operator  | Release pipeline [PACK], dependency health [PACK], configuration, runtime observability, upgrade paths, operational docs                     | Deployment feasibility, operational requirements, config management, dependency risk, maintenance burden          |
 
 For any discovered agent not in this table, delegate with a generic review prompt appropriate to the current review mode.
 
@@ -131,48 +136,50 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    #### Phase 1a -- CI Checks (mandatory, hard gate)
 
    a. Read all files in `.github/workflows/` to
-      identify the exact commands CI runs. Do not
-      rely on a memorized list -- the workflow files
-      are the source of truth.
+   identify the exact commands CI runs. Do not
+   rely on a memorized list -- the workflow files
+   are the source of truth.
 
    b. Execute each CI command locally in the order
-      they appear in the workflow (typically:
-      `go build ./...`, `go vet ./...`,
-      `go test -race -count=1 ./...`, plus any
-      coverage ratchet steps).
+   they appear in the workflow (typically:
+   `go build ./...`, `go vet ./...`,
+   `go test -race -count=1 ./...`, plus any
+   coverage ratchet steps).
 
    c. **If any command fails**: **STOP immediately.**
-      Report each failure as a CRITICAL finding with
-      the full error output. Do NOT proceed to Phase
-      1b or to step 2 (Divisor agent delegation).
-      The rationale: reviewing code that doesn't
-      compile or pass tests is wasted work.
+   Report each failure as a CRITICAL finding with
+   the full error output. Do NOT proceed to Phase
+   1b or to step 2 (Divisor agent delegation).
+   The rationale: reviewing code that doesn't
+   compile or pass tests is wasted work.
 
    d. **If all commands pass**: report success and
-      proceed to Phase 1b.
+   proceed to Phase 1b.
 
    #### Phase 1b -- Gaze Quality Analysis (conditional)
 
    a. Check if `gaze` is available:
-      ```bash
-      which gaze
-      ```
+
+   ```bash
+   which gaze
+   ```
 
    b. **If `gaze` is available**: invoke the
-      `gaze-reporter` agent via the Task tool
-      (subagent_type: `gaze-reporter`) with prompt
-      `"full"` to produce a comprehensive quality
-      report (CRAP scores, quality metrics,
-      classification, health assessment). Capture
-      the agent's output as the **Gaze Report**.
+   `gaze-reporter` agent via the Task tool
+   (subagent_type: `gaze-reporter`) with prompt
+   `"full"` to produce a comprehensive quality
+   report (CRAP scores, quality metrics,
+   classification, health assessment). Capture
+   the agent's output as the **Gaze Report**.
 
    c. **If `gaze` is NOT available**: skip with an
-      informational note:
-      > "Gaze not installed -- skipping quality
-      > analysis. Install with
-      > `brew install unbound-force/tap/gaze`."
+   informational note:
 
-      Proceed to step 2 without Gaze data.
+   > "Gaze not installed -- skipping quality
+   > analysis. Install with
+   > `brew install unbound-force/tap/gaze`."
+
+   Proceed to step 2 without Gaze data.
 
 2. Delegate the review to all **discovered** reviewer agents in parallel using the Task tool. For each discovered agent, use the focus area from the Known Reviewer Roles reference table to provide targeted context. For any discovered agent not in the table, use a generic prompt: "Review the current changes for quality, correctness, and compliance. Return your verdict (APPROVE or REQUEST CHANGES) along with all findings."
 

--- a/.opencode/command/uf-init.md
+++ b/.opencode/command/uf-init.md
@@ -5,6 +5,7 @@ description: >
   correct insertion points. Run after uf init, uf setup, or
   updating the OpenSpec CLI.
 ---
+
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
@@ -30,6 +31,7 @@ or after updating the OpenSpec CLI (`npm update`). Safe to re-run
 Verify the project has been initialized:
 
 1. Check that `.opencode/` directory exists. If not, **STOP** with:
+
    > `.opencode/` not found. Run `uf init` from your terminal first.
 
 2. Check that these 4 OpenSpec skill files exist:
@@ -44,6 +46,7 @@ Verify the project has been initialized:
    - `.opencode/command/opsx-archive.md`
 
 For each missing file, report an error:
+
 > `❌ <path>: file not found`
 > This file should have been created by `openspec init` which
 > runs as part of `uf init`. Run `uf setup` to install OpenSpec,
@@ -79,6 +82,7 @@ customization. For each file:
 #### Branch Enforcement: Propose (Skills + Commands)
 
 **Target files**:
+
 - `.opencode/skills/openspec-propose/SKILL.md`
 - `.opencode/command/opsx-propose.md`
 
@@ -92,6 +96,7 @@ directory (`openspec new change "<name>"`), insert a new step:
 > ```
 >
 > **Guard**: Before creating the branch, check the current branch:
+>
 > - If already on `opsx/<name>` (exact match): skip branch creation, proceed.
 > - If on a different `opsx/*` branch: **STOP** with error: "Already on branch `opsx/<other>` -- finish or archive that change first."
 > - If on `main` or any non-opsx branch: create and checkout `opsx/<name>`.
@@ -103,6 +108,7 @@ renumber existing steps (to avoid accidental content loss).
 #### Branch Enforcement: Apply (Skills + Commands)
 
 **Target files**:
+
 - `.opencode/skills/openspec-apply-change/SKILL.md`
 - `.opencode/command/opsx-apply.md`
 
@@ -125,6 +131,7 @@ existing steps.
 #### Branch Enforcement: Archive (Skills + Commands)
 
 **Target files**:
+
 - `.opencode/skills/openspec-archive-change/SKILL.md`
 - `.opencode/command/opsx-archive.md`
 
@@ -134,6 +141,7 @@ branch cleanup step:
 > **Return to main branch**
 >
 > After the archive move completes:
+>
 > ```bash
 > git checkout main
 > ```
@@ -170,6 +178,7 @@ instructions. For each file:
 #### Dewey Context: Propose (Skills + Commands)
 
 **Target files**:
+
 - `.opencode/skills/openspec-propose/SKILL.md`
 - `.opencode/command/opsx-propose.md`
 
@@ -201,6 +210,7 @@ of whether branch enforcement was applied.
 #### Dewey Context: Apply (Skills + Commands)
 
 **Target files**:
+
 - `.opencode/skills/openspec-apply-change/SKILL.md`
 - `.opencode/command/opsx-apply.md`
 
@@ -232,6 +242,7 @@ applied.
 #### Dewey Context: Explore (Skills only)
 
 **Target file**:
+
 - `.opencode/skills/openspec-explore/SKILL.md`
 
 **What to insert**: As part of the exploration workflow, add
@@ -277,6 +288,7 @@ degradation pattern. For each file:
    Report `✅ <filename>: inserted`
 
 **Target files**:
+
 - `.opencode/skills/openspec-propose/SKILL.md`
 - `.opencode/skills/openspec-apply-change/SKILL.md`
 - `.opencode/skills/openspec-explore/SKILL.md`
@@ -298,10 +310,11 @@ at each tier:
 > structural queries. Semantic search is unavailable.
 >
 > **Tier 1 (No Dewey)**: Fall back to direct file operations:
+>
 > - Use the Read tool to read local specs, backlog items, and
 >   convention packs
 > - Use the Grep tool for keyword search across the codebase
-> - Reference `.opencode/unbound/packs/` for coding standards
+> - Reference `.opencode/uf/packs/` for coding standards
 >
 > All tiers produce valid results. Higher tiers provide richer
 > cross-repo context but are never required.
@@ -340,6 +353,7 @@ Applied: N | Already present: N | Errors: N
 ```
 
 Use these status indicators:
+
 - `✅` -- customization was inserted
 - `⊘` -- customization already present (skipped)
 - `❌` -- file not found or error (with fix suggestion)
@@ -355,7 +369,8 @@ modified (had at least one `✅` insertion):
 3. **Verify** no existing content was accidentally removed
    (the file should be longer than before, not shorter)
 4. If verification fails, report: `⚠️ <filename>: verification
-   failed -- review with git diff`
+failed -- review with git diff`
 
 Finally, remind the user:
+
 > Run `git diff` to review all changes before committing.

--- a/content/blog/dewey-knowledge-retrieval.md
+++ b/content/blog/dewey-knowledge-retrieval.md
@@ -58,7 +58,7 @@ The difference is not always dramatic — sometimes the training data is current
 
 ## Adding Web Sources
 
-Adding web sources to Dewey takes about two minutes. Open `.dewey/sources.yaml` and add entries for your project's key dependencies:
+Adding web sources to Dewey takes about two minutes. Open `.uf/dewey/sources.yaml` and add entries for your project's key dependencies:
 
 ```yaml
 # Go standard library reference
@@ -95,6 +95,6 @@ brew install unbound-force/tap/unbound-force
 uf setup
 ```
 
-`uf setup` installs Dewey and runs `uf init`, which auto-detects sibling repos and your GitHub org to generate a multi-repo source config. To add web sources for your toolstack, edit `.dewey/sources.yaml` and run `dewey index`.
+`uf setup` installs Dewey and runs `uf init`, which auto-detects sibling repos and your GitHub org to generate a multi-repo source config. To add web sources for your toolstack, edit `.uf/dewey/sources.yaml` and run `dewey index`.
 
 See the [Quick Start guide](/docs/getting-started/quick-start/) for detailed installation, or the [knowledge retrieval guide](/docs/getting-started/knowledge/#extending-your-sources) for the full source configuration reference.

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -223,7 +223,7 @@ For explicit control over the define mode, use `/workflow start` with flags:
 
 ### Workflow Configuration
 
-Set project-level defaults in `.unbound-force/config.yaml` so you don't need to pass flags on every workflow start:
+Set project-level defaults in `.uf/config.yaml` so you don't need to pass flags on every workflow start:
 
 ```yaml
 workflow:
@@ -432,7 +432,7 @@ export OLLAMA_EMBED_DIM=256
 
 Dewey is optional -- all heroes function without it. See the [knowledge retrieval guide](/docs/getting-started/knowledge/) for source configuration and OpenCode integration.
 
-As the final step of setup, `uf init` scaffolds your project files and performs sub-tool initialization: it creates `.unbound-force/config.yaml` for [workflow configuration](#workflow-configuration), runs `dewey init` + `dewey index` when Dewey is available, and configures `opencode.json` with Dewey MCP server and Replicator MCP server entries when those tools are detected.
+As the final step of setup, `uf init` scaffolds your project files and performs sub-tool initialization: it creates `.uf/config.yaml` for [workflow configuration](#workflow-configuration), runs `dewey init` + `dewey index` when Dewey is available, and configures `opencode.json` with Dewey MCP server and Replicator MCP server entries when those tools are detected.
 
 ### 3. Verify
 

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -194,7 +194,7 @@ Every session follows this ritual:
 
 ### Convention Packs
 
-Convention packs are shared coding standards files stored in `.opencode/unbound/packs/`. Cobalt-Crush follows these conventions during implementation, and The Divisor enforces them during review. Every rule in a pack has a severity tag that determines how violations are handled.
+Convention packs are shared coding standards files stored in `.opencode/uf/packs/`. Cobalt-Crush follows these conventions during implementation, and The Divisor enforces them during review. Every rule in a pack has a severity tag that determines how violations are handled.
 
 #### Pack Files
 
@@ -251,7 +251,7 @@ Custom rules are loaded by Cobalt-Crush during implementation and by all Divisor
 
 Cobalt-Crush integrates with two feedback systems:
 
-- **Gaze feedback**: After writing code, checks `.unbound-force/artifacts/quality-report/` for quality findings. High CRAP scores trigger complexity reduction; low contract coverage triggers test improvements.
+- **Gaze feedback**: After writing code, checks `.uf/artifacts/quality-report/` for quality findings. High CRAP scores trigger complexity reduction; low contract coverage triggers test improvements.
 - **Divisor feedback**: Before submitting for review, validates against a pre-review checklist. After review, addresses findings by persona and severity (CRITICAL and HIGH first).
 
 ## Project Scaffolding with `uf init`
@@ -298,8 +298,8 @@ Files deployed by `uf init` fall into two ownership categories:
 
 After deploying files, `uf init` performs sub-tool initialization:
 
-- Creates `.unbound-force/config.yaml` for [workflow configuration](/docs/getting-started/common-workflows/#workflow-configuration) (skipped if it already exists)
-- If [Dewey](/docs/getting-started/knowledge/) is available: creates the `.dewey/` workspace, auto-detects sibling repos and your GitHub org to generate a [multi-repo source config](/docs/getting-started/knowledge/#what-uf-init-creates), and builds the initial index. After setup, you can [extend sources with web crawls](/docs/getting-started/knowledge/#extending-your-sources) for your project's toolstack documentation. With `--force`, re-indexes an existing Dewey workspace.
+- Creates `.uf/config.yaml` for [workflow configuration](/docs/getting-started/common-workflows/#workflow-configuration) (skipped if it already exists)
+- If [Dewey](/docs/getting-started/knowledge/) is available: creates the `.uf/dewey/` workspace, auto-detects sibling repos and your GitHub org to generate a [multi-repo source config](/docs/getting-started/knowledge/#what-uf-init-creates), and builds the initial index. After setup, you can [extend sources with web crawls](/docs/getting-started/knowledge/#extending-your-sources) for your project's toolstack documentation. With `--force`, re-indexes an existing Dewey workspace.
 - Configures `opencode.json` with MCP and plugin entries:
   - **Dewey MCP entry**: When `dewey` is in PATH, adds the `mcp.dewey` entry for the Dewey MCP server
   - **Replicator MCP entry**: When `replicator` is in PATH, adds `mcp.replicator` entry for the Replicator MCP server

--- a/content/docs/getting-started/knowledge.md
+++ b/content/docs/getting-started/knowledge.md
@@ -53,12 +53,12 @@ go install github.com/unbound-force/dewey@latest
 Initialize Dewey in your repository:
 
 ```bash
-# Create .dewey/ directory with default configuration
+# Create .uf/dewey/ directory with default configuration
 dewey init
 
 # Edit the source configuration
 # (see Source Configuration below for examples)
-$EDITOR .dewey/sources.yaml
+$EDITOR .uf/dewey/sources.yaml
 
 # Build the initial index (local files + any configured sources)
 dewey index
@@ -69,7 +69,7 @@ dewey status
 
 The `dewey status` command reports index health: page count, block count, embedding coverage, and source status. A healthy output shows all configured sources indexed with recent timestamps.
 
-After initialization, Dewey persists its indexes to `.dewey/graph.db` (SQLite). Subsequent sessions load from the persistent index and only re-process changed files — startup is near-instant after the first index.
+After initialization, Dewey persists its indexes to `.uf/dewey/graph.db` (SQLite). Subsequent sessions load from the persistent index and only re-process changed files — startup is near-instant after the first index.
 
 ## What `uf init` Creates
 
@@ -77,7 +77,7 @@ If you used `uf setup` or `uf init` to scaffold your project, Dewey's source con
 
 `uf init` runs three steps for Dewey initialization:
 
-1. `dewey init` — creates the `.dewey/` directory with a bare default config (single disk source pointing to `.`)
+1. `dewey init` — creates the `.uf/dewey/` directory with a bare default config (single disk source pointing to `.`)
 2. `generateDeweySources()` — overwrites `sources.yaml` with an auto-detected multi-repo config
 3. `dewey index` — indexes all configured sources
 
@@ -144,13 +144,13 @@ If you ran `dewey init` directly (without `uf init`), you have the bare default 
 
 ## Configure Content Sources
 
-Dewey indexes content from three pluggable source types. Configure them in `.dewey/sources.yaml`:
+Dewey indexes content from three pluggable source types. Configure them in `.uf/dewey/sources.yaml`:
 
 ### Local Disk
 
 The foundational source — indexes Markdown files in your repository. This is enabled by default after `dewey init`.
 
-Dewey automatically respects `.gitignore` at the source root — no configuration needed. Directories like `node_modules/`, `vendor/`, and other `.gitignore`-excluded paths are skipped during indexing. Hidden directories used by tools (`.git/`, `.obsidian/`, `.dewey/`) are always skipped regardless of `.gitignore`. Dewey-specific directories (`.opencode/`, `.specify/`, `.muti-mind/`) are indexed normally unless excluded by `.gitignore`.
+Dewey automatically respects `.gitignore` at the source root — no configuration needed. Directories like `node_modules/`, `vendor/`, and other `.gitignore`-excluded paths are skipped during indexing. Hidden directories used by tools (`.git/`, `.obsidian/`, `.uf/dewey/`) are always skipped regardless of `.gitignore`. Dewey-specific directories (`.opencode/`, `.specify/`, `.uf/muti-mind/`) are indexed normally unless excluded by `.gitignore`.
 
 You can add additional ignore patterns and control recursion depth via `sources.yaml`:
 
@@ -221,7 +221,7 @@ sources:
     refresh_interval: weekly
 ```
 
-Web crawls respect `robots.txt`, impose a configurable delay between requests, and cache content locally in `.dewey/cache/`. Content is only re-fetched when the refresh interval expires.
+Web crawls respect `robots.txt`, impose a configurable delay between requests, and cache content locally in `.uf/dewey/cache/`. Content is only re-fetched when the refresh interval expires.
 
 ### Updating Sources
 
@@ -354,7 +354,7 @@ Run `dewey doctor` to check the health of your Dewey installation. It reports on
 | Section                 | What It Checks                                             |
 | ----------------------- | ---------------------------------------------------------- |
 | **Environment**         | Vault path, dewey binary location                          |
-| **Workspace**           | `.dewey/` directory, config files, `sources.yaml`          |
+| **Workspace**           | `.uf/dewey/` directory, config files, `sources.yaml`       |
 | **Database**            | `graph.db` health, page/block/embedding counts             |
 | **Sources in Database** | Per-source page counts                                     |
 | **Embedding Layer**     | Ollama availability, model status                          |
@@ -379,12 +379,12 @@ This is a destructive operation — the existing index is deleted before rebuild
 
 These flags are available on all Dewey commands:
 
-| Flag              | Short | Description                                                            |
-| ----------------- | ----- | ---------------------------------------------------------------------- |
-| `--verbose`       | `-v`  | Enable debug logging                                                   |
-| `--log-file PATH` |       | Write logs to file (auto-logging to `.dewey/dewey.log` also available) |
-| `--no-embeddings` |       | Skip embedding generation (useful for quick indexing without Ollama)   |
-| `--vault PATH`    |       | Specify vault directory (default: current directory)                   |
+| Flag              | Short | Description                                                               |
+| ----------------- | ----- | ------------------------------------------------------------------------- |
+| `--verbose`       | `-v`  | Enable debug logging                                                      |
+| `--log-file PATH` |       | Write logs to file (auto-logging to `.uf/dewey/dewey.log` also available) |
+| `--no-embeddings` |       | Skip embedding generation (useful for quick indexing without Ollama)      |
+| `--vault PATH`    |       | Specify vault directory (default: current directory)                      |
 
 ## Graceful Degradation
 
@@ -406,7 +406,7 @@ Common issues and how to resolve them:
 | ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | MCP server timeout     | OpenCode shows connection timeout      | Check `.gitignore` for large directories being indexed; run `dewey reindex`                                                                 |
 | Ollama not running     | `dewey doctor` shows embedding layer ✗ | Run `ollama serve` or install Ollama (`brew install --cask ollama`)                                                                         |
-| Lock file conflicts    | "Another dewey instance is running"    | Only one `dewey serve` per vault; check for stale `.dewey/dewey.lock`                                                                       |
+| Lock file conflicts    | "Another dewey instance is running"    | Only one `dewey serve` per vault; check for stale `.uf/dewey/.dewey.lock`                                                                   |
 | Low embedding coverage | Semantic search returns few results    | Run `dewey index` to generate embeddings for new content                                                                                    |
 | Slow startup           | First `dewey serve` takes minutes      | Normal for large repos on first index; subsequent startups are near-instant. Check `.gitignore` to exclude `node_modules/`, `vendor/`, etc. |
 

--- a/content/docs/projects/dewey.md
+++ b/content/docs/projects/dewey.md
@@ -51,7 +51,7 @@ Vector-based similarity search using IBM Granite embeddings (30M parameters, 63 
 
 ### Persistent SQLite Index
 
-Indexes persist to `.dewey/graph.db` across sessions. Subsequent startups load from the persistent index and only re-process changed files — startup is near-instant after the first index.
+Indexes persist to `.uf/dewey/graph.db` across sessions. Subsequent startups load from the persistent index and only re-process changed files — startup is near-instant after the first index.
 
 ### Graceful Degradation
 
@@ -70,7 +70,7 @@ See [Common Workflows](/docs/getting-started/common-workflows/#new-feature-end-t
 Dewey runs as an MCP server alongside your AI coding environment. It combines:
 
 - **Knowledge graph** — in-memory graph built from Markdown files with wikilink, tag, and property relationships
-- **SQLite persistence** — pages, blocks, links, and embeddings stored in `.dewey/graph.db`
+- **SQLite persistence** — pages, blocks, links, and embeddings stored in `.uf/dewey/graph.db`
 - **Ollama embeddings** — IBM Granite model generates vector embeddings for semantic similarity search
 - **Pluggable sources** — content source interface supports disk, GitHub, and web crawl with configurable refresh intervals
 

--- a/content/docs/projects/replicator.md
+++ b/content/docs/projects/replicator.md
@@ -48,7 +48,7 @@ Replicator exposes 53 tools via the [MCP protocol](https://modelcontextprotocol.
 Replicator provides 9 subcommands for setup, monitoring, and diagnostics:
 
 ```bash
-# Per-repo setup (creates .hive/ directory)
+# Per-repo setup (creates .uf/replicator/ directory)
 replicator init
 
 # Per-machine setup (creates ~/.config/swarm-tools/ + SQLite DB)

--- a/content/docs/team/dewey.md
+++ b/content/docs/team/dewey.md
@@ -17,7 +17,7 @@ Dewey is a per-repository MCP server that provides AI agent personas with unifie
 
 Together, these modes let agents start with a vague concept ("authentication timeout issues") and progressively refine their understanding through structured navigation — discovering related specifications, past decisions, and connected documentation they did not know to ask for.
 
-Dewey runs locally as an MCP server alongside your AI coding environment. It persists its indexes to a SQLite database (`.dewey/graph.db`), so subsequent sessions load near-instantly from the persistent index instead of rebuilding from scratch. No data leaves your machine — the embedding model runs locally via Ollama.
+Dewey runs locally as an MCP server alongside your AI coding environment. It persists its indexes to a SQLite database (`.uf/dewey/graph.db`), so subsequent sessions load near-instantly from the persistent index instead of rebuilding from scratch. No data leaves your machine — the embedding model runs locally via Ollama.
 
 ### The graphthulhu Relationship
 
@@ -73,7 +73,7 @@ Dewey indexes content from three pluggable source types. Each source implements 
 
 ### Local Disk
 
-The foundational source, inherited from graphthulhu. Indexes all Markdown files in the repository, including hidden directories (`.opencode/`, `.specify/`, `.muti-mind/`). Files are watched for changes in real time via fsnotify — when you save a file, Dewey re-indexes only the changed content using SHA-256 content hashing for change detection.
+The foundational source, inherited from graphthulhu. Indexes all Markdown files in the repository, including hidden directories (`.opencode/`, `.specify/`, `.uf/muti-mind/`). Files are watched for changes in real time via fsnotify — when you save a file, Dewey re-indexes only the changed content using SHA-256 content hashing for change detection.
 
 ### GitHub API
 
@@ -101,7 +101,7 @@ Dewey uses [IBM Granite Embedding](https://www.ibm.com/granite/docs/models/embed
 
 Enterprise licensing provenance matters. Granite's training data is fully disclosed and permissibly licensed — there are no questions about whether the model was trained on proprietary or restricted content. This is a deliberate choice for organizations where licensing provenance is a compliance requirement.
 
-The embedding model is configurable. While Granite is the recommended default, teams can swap to any Ollama-compatible embedding model by editing `.dewey/config.yaml`:
+The embedding model is configurable. While Granite is the recommended default, teams can swap to any Ollama-compatible embedding model by editing `.uf/dewey/config.yaml`:
 
 ```yaml
 embedding:

--- a/content/docs/team/the-divisor.md
+++ b/content/docs/team/the-divisor.md
@@ -123,7 +123,7 @@ This ownership model ensures that a finding like "missing error handling" is rai
 
 ## Shared Severity Standard
 
-All eight personas share a calibration standard defined in the `severity.md` convention pack (`.opencode/unbound/packs/severity.md`):
+All eight personas share a calibration standard defined in the `severity.md` convention pack (`.opencode/uf/packs/severity.md`):
 
 | Level        | Definition                                                                           | Auto-Fix?                    |
 | ------------ | ------------------------------------------------------------------------------------ | ---------------------------- |

--- a/specs/018-uf-directory-paths/checklists/requirements.md
+++ b/specs/018-uf-directory-paths/checklists/requirements.md
@@ -1,0 +1,27 @@
+# Specification Quality Checklist: .uf/ Directory Path Update
+
+**Purpose**: Validate specification completeness
+**Created**: 2026-04-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details
+- [x] Focused on user value
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes
+- [x] No implementation details leak into specification

--- a/specs/018-uf-directory-paths/plan.md
+++ b/specs/018-uf-directory-paths/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: .uf/ Directory Path Update
+
+**Branch**: `018-uf-directory-paths` | **Date**: 2026-04-06 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/018-uf-directory-paths/spec.md`
+
+## Summary
+
+Mechanical find-and-replace across content pages and internal agent/command files to update stale directory paths (`.dewey/`, `.hive/`, `.unbound-force/`, `.muti-mind/`, `.opencode/unbound/`) to their `.uf/`-consolidated equivalents per Spec 025. Also updates `.gitignore` entry.
+
+## Technical Context
+
+**Language/Version**: Markdown (Hugo content files)
+**Primary Dependencies**: Hugo (via @thulite), Doks theme
+**Storage**: N/A (static Markdown files)
+**Testing**: `npm run build` (zero errors) + grep verification (zero stale paths)
+**Target Platform**: GitHub Pages (static site)
+**Project Type**: Static documentation site
+**Performance Goals**: N/A
+**Constraints**: No changes to files under `specs/` (historical records)
+**Scale/Scope**: ~18 files, ~40 replacements
+
+## Constitution Check
+
+_GATE: Must pass before implementation._
+
+| Principle             | Verdict  | Rationale                                                                                                                                                                                      |
+| --------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| I. Content Accuracy   | **PASS** | Fixing stale filesystem paths to match the current state of upstream repos (Spec 025 landed). Paths like `.dewey/sources.yaml` no longer exist — the correct path is `.uf/dewey/sources.yaml`. |
+| II. Minimal Footprint | **PASS** | Pure text edits in existing files. No new files, templates, CSS, or dependencies added.                                                                                                        |
+| III. Visitor Clarity  | **PASS** | Developers following documented paths will find the correct files on their filesystem. Stale paths cause confusion; updated paths match reality.                                               |
+
+## File Change Matrix
+
+| File                                               | Old Patterns                            | Replacement Count |
+| -------------------------------------------------- | --------------------------------------- | ----------------- |
+| `content/docs/getting-started/knowledge.md`        | `.dewey/`, `.muti-mind/`                | ~12               |
+| `content/docs/projects/dewey.md`                   | `.dewey/`                               | ~2                |
+| `content/docs/team/dewey.md`                       | `.dewey/`                               | ~3                |
+| `content/blog/dewey-knowledge-retrieval.md`        | `.dewey/`                               | ~2                |
+| `content/docs/getting-started/developer.md`        | `.dewey/`, `.unbound-force/`            | ~3                |
+| `content/docs/getting-started/common-workflows.md` | `.unbound-force/`                       | ~2                |
+| `content/docs/projects/replicator.md`              | `.hive/`                                | ~1                |
+| `.opencode/agents/cobalt-crush-dev.md`             | `.opencode/unbound/`, `.unbound-force/` | ~5                |
+| `.opencode/agents/divisor-adversary.md`            | `.opencode/unbound/`                    | ~3                |
+| `.opencode/agents/divisor-architect.md`            | `.opencode/unbound/`                    | ~1                |
+| `.opencode/agents/divisor-guard.md`                | `.opencode/unbound/`                    | ~1                |
+| `.opencode/agents/divisor-sre.md`                  | `.opencode/unbound/`                    | ~1                |
+| `.opencode/agents/divisor-testing.md`              | `.opencode/unbound/`                    | ~1                |
+| `.opencode/agents/divisor-techwriter.md`           | `.opencode/unbound/`                    | ~1                |
+| `.opencode/agents/divisor-pr.md`                   | `.opencode/unbound/`                    | ~1                |
+| `.opencode/command/review-council.md`              | `.opencode/unbound/`                    | ~1                |
+| `.opencode/command/uf-init.md`                     | `.opencode/unbound/`                    | ~1                |
+| `.opencode/command/cobalt-crush.md`                | `.opencode/unbound/`, `.unbound-force/` | ~2                |
+| `.gitignore`                                       | `.dewey/`                               | ~1                |
+
+**Total**: ~18 files, ~42 replacements
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-uf-directory-paths/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── tasks.md             # Task checklist
+└── checklists/          # Requirement quality checklists
+```
+
+### Source Code (repository root)
+
+No new source files. All changes are in-place text edits to existing Markdown files.

--- a/specs/018-uf-directory-paths/spec.md
+++ b/specs/018-uf-directory-paths/spec.md
@@ -1,0 +1,77 @@
+# Feature Specification: .uf/ Directory Path Update
+
+**Feature Branch**: `018-uf-directory-paths`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: Update all directory references across the website for the `.uf/` consolidation (Spec 025). Covers content pages, internal agent/command files, and the local `.dewey/sources.yaml`.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — Content Pages Reference Correct Paths (Priority: P1)
+
+A developer reads the website documentation and encounters directory paths like `.dewey/sources.yaml`, `.hive/`, and `.unbound-force/config.yaml`. These no longer exist — all tool data now lives under `.uf/`. Following these stale paths leads to confusion when the developer's actual filesystem doesn't match the documentation.
+
+**Why this priority**: Stale filesystem paths are the most immediately confusing error a user can encounter. They try to edit a file at the documented path and it doesn't exist.
+
+**Independent Test**: Search all content pages for `.dewey/`, `.hive/`, `.unbound-force/`, `.muti-mind/` — zero results. All replaced with `.uf/` equivalents.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reading any documentation page, **When** they see a directory path referencing Dewey workspace files, **Then** the path uses `.uf/dewey/` (not `.dewey/`).
+2. **Given** a developer reading workflow configuration docs, **When** they see the config file path, **Then** it reads `.uf/config.yaml` (not `.unbound-force/config.yaml`).
+3. **Given** a developer reading the Replicator project page, **When** they see the workspace directory, **Then** it reads `.uf/replicator/` (not `.hive/`).
+
+---
+
+### User Story 2 — Internal Agent/Command Files Reference Correct Paths (Priority: P1)
+
+Agent files and command files reference `.opencode/unbound/packs/` for convention packs. This directory was renamed to `.opencode/uf/packs/` in Spec 025. When agents try to load convention packs from the documented path, the path is wrong.
+
+**Why this priority**: Agent files directly affect agent behavior. If an agent reads its own file and sees `.opencode/unbound/packs/`, it looks for packs at the wrong path.
+
+**Independent Test**: Search all `.opencode/` files for `.opencode/unbound/` — zero results. All replaced with `.opencode/uf/`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent loading convention packs, **When** it reads its agent file for the pack path, **Then** the path says `.opencode/uf/packs/` (not `.opencode/unbound/packs/`).
+
+---
+
+### Edge Cases
+
+- The local `.dewey/sources.yaml` is gitignored and won't be committed, but it should be noted that users need to re-run `dewey init` or move their `.dewey/` directory to `.uf/dewey/` to match the new structure.
+- The `.opencode/unbound/packs/` directory in this repo needs to be physically moved to `.opencode/uf/packs/` (not just the references updated). However, this may be handled by `uf init` — verify before moving files manually.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+**Content Pages (US1):**
+
+- **FR-001**: All `.dewey/` path references in content pages MUST be replaced with `.uf/dewey/`.
+- **FR-002**: All `.unbound-force/` path references MUST be replaced with `.uf/`.
+- **FR-003**: All `.hive/` path references MUST be replaced with `.uf/replicator/`.
+- **FR-004**: All `.muti-mind/` path references MUST be replaced with `.uf/muti-mind/`.
+
+**Internal Files (US2):**
+
+- **FR-005**: All `.opencode/unbound/` path references in agent files and command files MUST be replaced with `.opencode/uf/`.
+
+**Cross-cutting:**
+
+- **FR-006**: All changes MUST pass `npm run build` without errors.
+- **FR-007**: Zero occurrences of `.dewey/`, `.hive/`, `.unbound-force/`, `.muti-mind/`, or `.opencode/unbound/` in content or `.opencode/` files (excluding historical specs).
+
+## Success Criteria _(mandatory)_
+
+- **SC-001**: Zero old-style directory references in user-facing content (17 `.dewey/` + 4 `.unbound-force/` + 1 `.hive/` + 2 `.muti-mind/` = 24 total replaced).
+- **SC-002**: Zero `.opencode/unbound/` references in internal files (16 total replaced).
+- **SC-003**: `npm run build` succeeds with zero errors.
+
+## Assumptions
+
+- Spec 025 has landed in the meta repo (confirmed: commit `4140b0c`, 80/80 tasks complete).
+- Dewey's code uses `.uf/dewey/` (confirmed: README references `.uf/dewey/graph.db`).
+- Replicator's code uses `.uf/replicator/` (confirmed: README says "creates .uf/replicator/ directory").
+- The `.opencode/unbound/packs/` directory in this repo will be physically moved to `.opencode/uf/packs/` by running `uf init` (which handles the migration). If `uf init` has not been run on this repo yet, the physical move is out of scope for this spec — only the documentation references are updated.
+- Historical spec artifacts (specs/002, 005, 010, etc.) are NOT updated — they document what was true when they were written.

--- a/specs/018-uf-directory-paths/tasks.md
+++ b/specs/018-uf-directory-paths/tasks.md
@@ -1,0 +1,75 @@
+# Tasks: .uf/ Directory Path Update
+
+**Input**: Design documents from `/specs/018-uf-directory-paths/`
+**Prerequisites**: plan.md (required), spec.md (required)
+
+## Phase 1: Content Pages — Dewey Paths (US1)
+
+**Goal**: Replace all `.dewey/` references with `.uf/dewey/` in content pages
+
+- [x] T001 [P] [US1] Replace `.dewey/` → `.uf/dewey/` in `content/docs/getting-started/knowledge.md` (~12 occurrences)
+- [x] T002 [P] [US1] Replace `.dewey/` → `.uf/dewey/` in `content/docs/projects/dewey.md` (~2 occurrences)
+- [x] T003 [P] [US1] Replace `.dewey/` → `.uf/dewey/` in `content/docs/team/dewey.md` (~3 occurrences)
+- [x] T004 [P] [US1] Replace `.dewey/` → `.uf/dewey/` in `content/blog/dewey-knowledge-retrieval.md` (~2 occurrences)
+- [x] T005 [P] [US1] Replace `.dewey/` → `.uf/dewey/` in `content/docs/getting-started/developer.md` (~1 occurrence)
+
+**Checkpoint**: `grep -rn "\.dewey/" content/ | grep -v specs/` returns zero results
+
+---
+
+## Phase 2: Content Pages — Other Tool Paths (US1)
+
+**Goal**: Replace `.unbound-force/`, `.hive/`, `.muti-mind/` references in content pages
+
+- [x] T006 [P] [US1] Replace `.unbound-force/` → `.uf/` in `content/docs/getting-started/developer.md` (~2 occurrences)
+- [x] T007 [P] [US1] Replace `.unbound-force/` → `.uf/` in `content/docs/getting-started/common-workflows.md` (~2 occurrences)
+- [x] T008 [P] [US1] Replace `.hive/` → `.uf/replicator/` in `content/docs/projects/replicator.md` (~1 occurrence)
+- [x] T009 [P] [US1] Replace `.muti-mind/` → `.uf/muti-mind/` in `content/docs/getting-started/knowledge.md` (~2 occurrences)
+
+**Checkpoint**: `grep -rn "\.unbound-force/\|\.hive/\|\.muti-mind/" content/ | grep -v specs/` returns zero results
+
+---
+
+## Phase 3: Internal Agent/Command Files (US2)
+
+**Goal**: Replace all `.opencode/unbound/` references with `.opencode/uf/` in agent and command files
+
+- [x] T010 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/agents/cobalt-crush-dev.md`
+- [x] T011 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/agents/divisor-adversary.md`
+- [x] T012 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/agents/divisor-architect.md`
+- [x] T013 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/agents/divisor-guard.md`
+- [x] T014 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/agents/divisor-sre.md`
+- [x] T015 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/agents/divisor-testing.md`
+- [x] T016 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/agents/divisor-techwriter.md`
+- [x] T017 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/agents/divisor-pr.md`
+- [x] T018 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/command/review-council.md`
+- [x] T019 [P] [US2] Replace `.opencode/unbound/` → `.opencode/uf/` in `.opencode/command/uf-init.md`
+- [x] T020 [P] [US2] Replace `.opencode/unbound/` and `.unbound-force/` → `.opencode/uf/` and `.uf/` in `.opencode/command/cobalt-crush.md`
+- [x] T021 [P] [US2] Replace `.unbound-force/` → `.uf/` in `.opencode/agents/cobalt-crush-dev.md`
+
+**Checkpoint**: `grep -rn "\.opencode/unbound/\|\.unbound-force/" .opencode/ | grep -v specs/` returns zero results
+
+---
+
+## Phase 4: Infrastructure Files
+
+**Goal**: Update `.gitignore` entry
+
+- [x] T022 [US1] Replace `.dewey/` → `.uf/dewey/` in `.gitignore`
+
+---
+
+## Phase 5: Verification
+
+**Goal**: Build succeeds and zero stale path references remain
+
+- [x] T023 Run `npm run build` — zero errors
+- [x] T024 Grep verification: zero results for all old patterns outside `specs/`
+
+---
+
+## Dependencies & Execution Order
+
+- Phases 1–4 are independent and can run in parallel
+- Phase 5 depends on all prior phases completing
+- All [P] tasks within a phase can run in parallel (different files)


### PR DESCRIPTION
## Summary

Updates 40 directory path references across 20 files for the `.uf/` consolidation (upstream Spec 025, issue #23).

### Path Replacements
- `.dewey/` -> `.uf/dewey/` (17 occurrences across 8 content pages)
- `.unbound-force/` -> `.uf/` (4 occurrences across 2 pages)
- `.hive/` -> `.uf/replicator/` (1 occurrence in replicator project page)
- `.muti-mind/` -> `.uf/muti-mind/` (2 occurrences in dewey team page)
- `.opencode/unbound/` -> `.opencode/uf/` (16 occurrences across 11 agent/command files)

### Verification
- Zero old-style directory references in content/ and .opencode/ (excluding historical specs)
- `npm run build`: 82 pages, 0 errors
- `.gitignore` updated to ignore both `.dewey/` (old, still present locally) and `.uf/` (new)

Closes #23