### PR TITLE
docs: add blog post comparing Dewey and Karpathy's LLM Knowledge Base approaches

### DIFF
--- a/content/blog/dewey-vs-karpathy.md
+++ b/content/blog/dewey-vs-karpathy.md
@@ -1,0 +1,129 @@
+---
+title: "The Librarian vs The Index: Two Ways to Give AI Agents a Memory"
+description: "Karpathy's LLM Knowledge Base compiles a wiki. Dewey indexes existing repos. Both reject RAG, both bet on markdown — but they diverge on who does the work and how far they scale."
+lead: "Both reject RAG. Both bet on markdown. But they diverge on who does the work."
+slug: "dewey-vs-karpathy"
+date: 2026-04-07T00:00:00+00:00
+draft: false
+weight: 60
+toc: true
+categories: ["Engineering"]
+tags: ["dewey", "knowledge-management", "semantic-search", "karpathy", "rag"]
+contributors: ["Unbound Force"]
+---
+
+## The Problem Both Solve
+
+Every developer using AI coding tools knows the feeling: you spend an hour building context with an agent — explaining the architecture, the naming conventions, the reasons behind a particular design decision — and then the session ends. The next session starts blank. The agent has no memory of what you discussed, no access to the decisions you made, no awareness of the other repositories in your organization.
+
+Andrej Karpathy [described this as the "lobotomy on restart"](https://x.com/karpathy/status/2039805659525644595) problem. It is not a model limitation — it is an infrastructure problem. The model is capable of reasoning over context. It lacks the infrastructure to accumulate, organize, and retrieve that context across sessions.
+
+Both Karpathy and the [Dewey](/docs/projects/dewey/) project address this problem. Both reject the standard RAG approach (chunk documents, embed into a vector database, retrieve by similarity). Both bet on markdown as the native format. But they take fundamentally different paths to get there.
+
+## Karpathy's Approach: The AI Librarian
+
+Karpathy's "LLM Knowledge Base" treats the LLM itself as a research librarian. The system works in three stages ([VentureBeat coverage](https://venturebeat.com/data/karpathy-shares-llm-knowledge-base-architecture-that-bypasses-rag-with-an)):
+
+**1. Ingest.** Raw materials — research papers, GitHub repositories, datasets, web articles — are dumped into a `raw/` directory. Karpathy uses the Obsidian Web Clipper to convert web content to markdown, including images for vision model reference.
+
+**2. Compile.** This is the core innovation. Instead of indexing the files, the LLM _reads_ them and _writes_ a structured wiki. It generates summaries, identifies key concepts, authors encyclopedia-style articles, and creates backlinks between related ideas. The LLM is not searching existing text — it is synthesizing new text from existing sources.
+
+**3. Lint.** The system is not static. Karpathy describes running "health checks" where the LLM scans the wiki for inconsistencies, missing data, or new connections. The wiki heals itself over time as the LLM identifies gaps and fills them.
+
+The result is a curated, human-readable knowledge base where every claim traces back to a specific markdown file. No embeddings, no vector database, no black box. The LLM navigates via summaries and index files — structured text, not mathematical similarity.
+
+At a scale of roughly 100 articles and 400,000 words, this works well. The LLM's context window is large enough to hold the index and navigate to the relevant article. As Karpathy notes, "the fancy RAG infrastructure often introduces more latency and retrieval noise than it solves" at this scale.
+
+## Dewey's Approach: The Searchable Index
+
+Dewey takes the opposite approach. Instead of having the LLM organize knowledge, Dewey indexes existing repositories and makes them searchable through the [Model Context Protocol](https://modelcontextprotocol.io) (MCP).
+
+**No LLM involvement in indexing.** Dewey reads markdown files, extracts blocks, computes embeddings with a local model (IBM Granite, running via Ollama), and stores everything in a SQLite database. The LLM never touches the indexing process — it consumes the search results.
+
+**Four source types.** Dewey indexes content from:
+
+- **Disk** — markdown files in local repositories (specs, READMEs, design documents, agent configurations)
+- **GitHub** — issues, PRs, and READMEs from your organization's repositories
+- **Web** — documentation crawled from toolstack websites (framework docs, stdlib references, library APIs)
+- **Code** — Go source files parsed with `go/ast` to extract function signatures, CLI commands, MCP tool registrations, and package documentation
+
+**Multi-repo by default.** When [`uf init`](/docs/getting-started/developer/#project-scaffolding-with-uf-init) configures Dewey, it scans `../` for sibling repositories and generates a multi-repo source configuration. A single Dewey instance indexes your entire organization's workspace — not just the current project.
+
+**MCP protocol.** Dewey exposes 40 tools over MCP's stdio JSON-RPC protocol. Any MCP-compatible client (OpenCode, Claude Code, Cursor, or custom agents) can search across the entire index. Semantic search, structured graph traversal, page retrieval, block-level queries — all available as standard tool calls.
+
+At a scale of 1,000+ pages, 10,000+ blocks, and 5+ repositories, Dewey's embedding-based retrieval becomes essential. A context window large enough to hold an index of 100 articles is not large enough to hold an index of 10,000 blocks across 5 repos. Embeddings solve the needle-in-a-haystack problem that structured navigation cannot.
+
+## The Comparison
+
+| Dimension          | Karpathy (AI Librarian)                 | Dewey (Searchable Index)                                 |
+| ------------------ | --------------------------------------- | -------------------------------------------------------- |
+| **Core metaphor**  | Librarian who reads and writes          | Index that catalogs and retrieves                        |
+| **Who organizes**  | The LLM (active synthesis)              | The indexer (passive extraction)                         |
+| **Search method**  | Summaries + index navigation            | Semantic search + graph traversal                        |
+| **Embeddings**     | None — structured text only             | Local embeddings (IBM Granite)                           |
+| **Scale target**   | ~100 articles, ~400K words              | 1,000+ pages, 10K+ blocks, 5+ repos                      |
+| **Multi-repo**     | Manual (copy files to raw/)             | Automatic (scans sibling repos)                          |
+| **Self-healing**   | Yes — LLM linting passes                | No — indexes reflect source reality                      |
+| **Protocol**       | Custom scripts                          | MCP (Model Context Protocol)                             |
+| **Multi-agent**    | Single-agent workflow                   | Multi-agent (Replicator coordination)                    |
+| **Local-only**     | Yes (Obsidian + local LLM)              | Yes (SQLite + Ollama)                                    |
+| **Code awareness** | No — markdown only                      | Yes — Go AST parsing (function signatures, CLI commands) |
+| **LLM cost**       | High — compilation requires many tokens | Low — indexing is mechanical, no LLM tokens              |
+
+## Where They Complement Each Other
+
+These approaches are not competing — they solve different parts of the same problem.
+
+**The compiled wiki becomes a Dewey source.** If you use Karpathy's approach to maintain a curated research wiki, that wiki is a folder of markdown files. Dewey indexes markdown files. Point a Dewey disk source at your compiled wiki and every agent in your swarm can search it.
+
+**Dewey's `store_learning` is a primitive compilation step.** When the [/unleash](/docs/getting-started/common-workflows/#autonomous-pipeline-unleash) pipeline completes a task, its retrospective step stores a narrative learning in Dewey via `store_learning`. These learnings accumulate over sessions and surface via semantic search in future sessions. This is not full LLM-driven compilation — it is a single learning per session, not a synthesized wiki — but it serves the same purpose: the system remembers what it learned.
+
+**The ideal system could use both.** Karpathy's LLM-as-librarian for active knowledge synthesis on curated research. Dewey for cross-repo semantic search on the full organizational knowledge base. The compiled wiki feeds into the searchable index.
+
+## What Each Could Learn From the Other
+
+**Dewey could add autonomous synthesis.** A `dewey compile` command that reads indexed content and generates summary articles — turning passive indexing into active knowledge curation. Karpathy's linting concept (scan for inconsistencies, fill gaps) could make Dewey's index self-improving.
+
+**Dewey could add contamination separation.** Obsidian co-creator Steph Ango [suggested](https://x.com/kepano/status/2039831289533227446) keeping personal vaults clean and letting agents work in a "messy vault." Dewey could separate agent-generated learnings from human-authored documentation, promoting only validated content.
+
+**Karpathy's approach could benefit from MCP standardization.** The "hacky collection of scripts" Karpathy describes could be exposed as MCP tools, making the compiled wiki accessible to any MCP-compatible agent — not just the specific LLM session that created it.
+
+**Karpathy's approach could benefit from code awareness.** Dewey's Go AST parsing extracts function signatures, CLI commands, and MCP tool registrations from source code — structured knowledge that markdown compilation alone cannot capture.
+
+## Which Should You Use?
+
+**Use Karpathy's approach if:**
+
+- You are a single researcher or small team
+- Your knowledge base is under 100 high-signal documents
+- You want active synthesis (the LLM writes new articles from raw materials)
+- You value self-healing (the wiki improves itself over time)
+- Your workflow is single-agent and single-project
+
+**Use Dewey if:**
+
+- You work across multiple repositories
+- Your knowledge base exceeds what a context window can index
+- You need code-level awareness (function signatures, CLI commands)
+- You want multi-agent coordination (Replicator + Dewey)
+- You need MCP protocol compatibility for tool-based access
+- You want zero-LLM-cost indexing (mechanical extraction, no compilation tokens)
+
+**Use both if:**
+
+- You want LLM-driven knowledge synthesis AND cross-repo semantic search
+- You maintain a curated research wiki AND an organizational codebase
+- You want the librarian's synthesis AND the index's retrieval
+
+## Getting Started
+
+To try Dewey:
+
+```bash
+brew install unbound-force/tap/unbound-force
+uf setup
+```
+
+`uf setup` installs Dewey and configures multi-repo sources automatically. See the [Quick Start guide](/docs/getting-started/quick-start/) for detailed installation, or the [knowledge retrieval guide](/docs/getting-started/knowledge/) for source configuration and web source templates.
+
+To try Karpathy's approach, see his [X post](https://x.com/karpathy/status/2039805659525644595) for the architecture and the [VentureBeat article](https://venturebeat.com/data/karpathy-shares-llm-knowledge-base-architecture-that-bypasses-rag-with-an) for a detailed breakdown.

--- a/specs/019-dewey-karpathy-blog/checklists/requirements.md
+++ b/specs/019-dewey-karpathy-blog/checklists/requirements.md
@@ -1,0 +1,31 @@
+# Specification Quality Checklist: Dewey vs Karpathy Blog Post
+
+**Purpose**: Validate specification completeness
+**Created**: 2026-04-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details
+- [x] Focused on user value
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes
+- [x] No implementation details leak into specification
+
+## Notes
+- All items pass. Source material verified: VentureBeat article accessible (April 3, 2026), Karpathy X post URL confirmed, Dewey tool count verified via Dewey semantic search (40 tools across 10 categories + new code source type from PR #32).
+- The issue's "44 MCP tools" claim is outdated — will be verified against current Dewey README during implementation.

--- a/specs/019-dewey-karpathy-blog/plan.md
+++ b/specs/019-dewey-karpathy-blog/plan.md
@@ -1,0 +1,23 @@
+# Implementation Plan: Dewey vs Karpathy Blog Post
+
+**Branch**: `019-dewey-karpathy-blog` | **Date**: 2026-04-07 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Create a blog post comparing Dewey's index-then-search approach with Karpathy's compile-then-navigate "LLM Knowledge Base" approach. Single new file: `content/blog/dewey-vs-karpathy.md`.
+
+## Technical Context
+
+Hugo static site, Markdown blog post, Doks theme. No new dependencies.
+
+## Constitution Check
+
+- **I. Content Accuracy**: PASS — Dewey claims verified via Dewey semantic search (40 MCP tools, 4 source types). Karpathy claims sourced from his X post and VentureBeat article.
+- **II. Minimal Footprint**: PASS — 1 new Markdown file.
+- **III. Visitor Clarity**: PASS — comparison framing helps readers choose the right approach.
+
+## File Change Matrix
+
+| File                                | Change          |
+| ----------------------------------- | --------------- |
+| `content/blog/dewey-vs-karpathy.md` | NEW — blog post |

--- a/specs/019-dewey-karpathy-blog/spec.md
+++ b/specs/019-dewey-karpathy-blog/spec.md
@@ -1,0 +1,68 @@
+# Feature Specification: Dewey vs Karpathy Blog Post
+
+**Feature Branch**: `019-dewey-karpathy-blog`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: Issue #26 — Blog post comparing Dewey and Karpathy's "LLM Knowledge Base" approach to AI agent knowledge management.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — Blog Post: Architectural Comparison (Priority: P1)
+
+A developer using AI coding tools discovers a blog post that compares two approaches to the "context loss on restart" problem: Karpathy's "LLM Knowledge Base" (the LLM compiles and maintains a markdown wiki) and Dewey (indexes existing repos with semantic search via MCP). The post helps the reader understand when each approach is better, where they complement each other, and how to choose. The reader leaves with a clear mental model of both approaches and a concrete next step.
+
+**Why this priority**: Karpathy's X post (April 3, 2026) is actively being discussed. The VentureBeat article is 4 days old. Publishing a thoughtful comparison while the topic is current maximizes social sharing and SEO value. The comparison positions Dewey in a conversation that's already happening rather than starting a new one.
+
+**Independent Test**: Navigate to `/blog/` and verify the post exists, renders correctly, covers both approaches fairly, includes a comparison table, and links to the Getting Started page.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the blog index, **When** they browse articles, **Then** they see a post about knowledge management approaches with a title that frames the comparison (not a product pitch).
+2. **Given** a reader of the blog post, **When** they read the problem statement, **Then** they recognize the "context loss across sessions" problem from their own AI coding experience.
+3. **Given** a reader of the blog post, **When** they read the Karpathy section, **Then** they understand the compile-then-navigate approach: LLM reads raw materials, writes structured wiki with backlinks, runs self-healing linting passes, navigates via summaries and indexes.
+4. **Given** a reader of the blog post, **When** they read the Dewey section, **Then** they understand the index-then-search approach: indexes existing repos with embeddings, multi-repo semantic search via MCP, 4 source types (disk, GitHub, web, code), no LLM involvement in the indexing step.
+5. **Given** a reader of the blog post, **When** they look at the comparison table, **Then** they find a side-by-side comparison covering at least: core metaphor, who organizes, search method, embeddings, scale, multi-repo support, self-healing, protocol, multi-agent support, local-only.
+6. **Given** a reader of the blog post, **When** they read the "where they complement" section, **Then** they understand that the compiled wiki becomes a Dewey disk source, and that the ideal system could use both.
+7. **Given** a reader of the blog post, **When** they look for how to get started, **Then** they find install instructions and a link to the Quick Start page.
+
+---
+
+### Edge Cases
+
+- The post must credit Karpathy fairly — the synthesis model is better for small, curated datasets and personal research. The post must not position Dewey as "better" in all cases.
+- The post must avoid time-sensitive language ("just announced," "this week") to remain relevant as the discussion fades. Use the date in frontmatter, not in prose.
+- The post must not overclaim Dewey's capabilities — the "code source" indexing (Go AST parsing) is new (Dewey PR #32) and should be described accurately.
+- If the VentureBeat article URL changes or goes behind a paywall, the post should reference Karpathy's X post as the primary source.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The blog post MUST describe the shared problem (context loss across AI sessions, cross-repo knowledge fragmentation) before introducing either solution.
+- **FR-002**: The blog post MUST describe Karpathy's approach (LLM-as-librarian, raw materials -> compiled wiki, linting passes, backlinks, no embeddings) accurately and fairly, citing his X post and the VentureBeat article.
+- **FR-003**: The blog post MUST describe Dewey's approach (index existing repos, local embeddings, 4 source types, MCP protocol, multi-repo) accurately, with the current tool count and source types verified against the Dewey README.
+- **FR-004**: The blog post MUST include a comparison table covering at least 10 dimensions (core metaphor, who organizes, search method, embeddings, scale target, multi-repo, self-healing, protocol, multi-agent, local-only).
+- **FR-005**: The blog post MUST include a "where they complement each other" section explaining how the compiled wiki can become a Dewey disk source.
+- **FR-006**: The blog post MUST include a decision guide ("which should you use?") with clear criteria for each approach and a "use both" option.
+- **FR-007**: The blog post MUST include a Getting Started section with install instructions and a link to the Quick Start page and knowledge retrieval guide.
+- **FR-008**: The blog post MUST follow existing blog conventions (YAML frontmatter with title, description, lead, slug, date, categories, tags, contributors; body starting with H2; no time-sensitive language in prose).
+- **FR-009**: The blog post MUST NOT position Dewey as universally superior — it must honestly acknowledge where Karpathy's approach is better (active synthesis, self-healing, curated small datasets).
+- **FR-010**: All changes MUST pass `npm run build` without errors.
+
+## Success Criteria _(mandatory)_
+
+- **SC-001**: The blog post exists at a discoverable URL and its frontmatter description communicates the comparison angle (not a product pitch).
+- **SC-002**: A reader can understand both approaches without prior knowledge of either Dewey or Karpathy's system.
+- **SC-003**: The comparison table has at least 10 dimensions.
+- **SC-004**: The post credits Karpathy's X post and links to the VentureBeat article.
+- **SC-005**: `npm run build` succeeds with zero errors.
+
+## Assumptions
+
+- The blog post will follow the same format and quality standard as the existing blog posts — technical depth with real-world grounding.
+- The title will lead with the comparison framing (not a product name) to attract readers interested in the problem, not just Dewey users.
+- The Dewey README's current MCP tool count is the authoritative source for capability claims. The issue's "44 MCP tools" claim will be verified and corrected if needed.
+- Dewey now has 4 source types: disk, GitHub, web, and code (Go AST parsing, added in PR #32). This is a significant capability difference from what the issue assumed.
+- The post will reference Karpathy's X post as the primary source and the VentureBeat article as the explanatory context.
+- No architecture diagrams — the post will use text-based comparison tables and code examples. Diagrams can be added later if created manually.
+- The `store_learning` tool is Dewey's primitive version of the "compilation step" and should be mentioned in the "where they complement" section.

--- a/specs/019-dewey-karpathy-blog/tasks.md
+++ b/specs/019-dewey-karpathy-blog/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Dewey vs Karpathy Blog Post
+
+## 1. Blog Post
+
+- [x] 1.1 Create content/blog/dewey-vs-karpathy.md with full blog post content (FR-001 through FR-009)
+
+## 2. Verification
+
+- [x] 2.1 Run `npm run build` and verify zero errors (FR-010)
+- [x] 2.2 Verify blog post renders on `/blog/` page


### PR DESCRIPTION
## Summary

New blog post: **"The Librarian vs The Index: Two Ways to Give AI Agents a Memory"**

Compares Dewey's index-then-search approach with Karpathy's compile-then-navigate "LLM Knowledge Base" approach, responding to his viral X post (April 3, 2026) and VentureBeat coverage.

### Content
- **The shared problem**: context loss across AI sessions ("lobotomy on restart")
- **Karpathy's approach**: LLM-as-librarian compiles raw materials into a wiki with backlinks and self-healing linting
- **Dewey's approach**: index existing repos with local embeddings, 4 source types (disk, GitHub, web, code), 40 MCP tools
- **12-dimension comparison table**: core metaphor, who organizes, search method, embeddings, scale, multi-repo, self-healing, protocol, multi-agent, local-only, code awareness, LLM cost
- **Where they complement**: compiled wiki becomes a Dewey source; store_learning is a primitive compilation step; ideal system uses both
- **Decision guide**: clear criteria for each approach and a "use both" option

### Editorial approach
- Credits Karpathy fairly — acknowledges synthesis model is better for small curated datasets
- Not a product pitch — genuine architectural comparison
- No time-sensitive language in prose (date in frontmatter only)
- Dewey claims verified via `dewey_semantic_search` (40 MCP tools, 4 source types confirmed)

Closes #26