### PR TITLE
docs: add blog post on how Dewey became a knowledge curator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,6 +275,8 @@ GitHub Pages deployment via `.github/workflows/deploy-gh-pages.yml`:
 3. Always verify both light and dark mode rendering after style changes.
 
 ## Active Technologies
+- Markdown (Hugo content file) + Hugo (via @thulite), Doks theme (`@thulite/doks-core`) (021-dewey-curator-blog)
+- N/A (static Markdown file) (021-dewey-curator-blog)
 
 - Hugo (Go-based SSG) via `@thulite` npm packages + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3` (013-unleash-visibility)
 

--- a/content/blog/dewey-curator-blog.md
+++ b/content/blog/dewey-curator-blog.md
@@ -1,0 +1,93 @@
+---
+title: "How Dewey Became a Knowledge Curator: From Passive Index to Active Synthesis"
+description: "Dewey v3.0.0 shipped knowledge compilation, trust tiers, and linting — turning speculative ideas from the Karpathy comparison into real features."
+lead: "We compared approaches. Then we built the features. Here is what happened."
+slug: "dewey-curator"
+date: 2026-04-11T00:00:00+00:00
+draft: false
+weight: 58
+toc: true
+categories: ["Engineering"]
+tags:
+  [
+    "dewey",
+    "knowledge-management",
+    "knowledge-compilation",
+    "karpathy",
+    "event-sourcing",
+  ]
+contributors: ["Unbound Force"]
+---
+
+## The Problem — Learnings That Never Compound
+
+AI coding agents learn things. They discover that a particular test helper expects a specific argument order. They figure out that the CI pipeline needs a cache warm-up step before integration tests run. They learn that a naming convention exists, and why it exists, and what breaks when you ignore it.
+
+Then the session ends. The next agent starts blank.
+
+Dewey's `store_learning` tool addressed half of this problem. Agents could store a learning at the end of a session and future agents could retrieve it via semantic search. Learnings accumulated across sessions — hundreds of them, across dozens of repositories.
+
+But accumulation is not the same as synthesis. A learning stored in March might say "use the v1 API endpoint." A learning stored in April might say "the v1 endpoint is deprecated — use v2." Both exist in the index. Both surface in search results. The agent consuming those results has no way to know which one is current without reading both, reasoning about dates, and hoping there is not a third learning that contradicts both.
+
+Contradictions between sessions are invisible. There is no mechanism to distinguish a reviewed architectural decision from an unreviewed guess an agent made at 2 AM during an autonomous pipeline run. Learnings accumulate, but they never compound into something more than the sum of their parts.
+
+In [The Librarian vs The Index](/blog/dewey-vs-karpathy/), we compared Dewey's passive indexing approach with Karpathy's active synthesis model. The comparison table listed "Self-healing: No — indexes reflect source reality" for Dewey. That post speculated about two features that could change this: a `dewey compile` command that would turn passive indexing into active knowledge curation, and contamination separation that would distinguish agent-generated content from human-authored documentation.
+
+That post was a comparison. This one is an engineering story. Those speculative ideas became real features in Dewey v3.0.0 — the largest single feature addition in Dewey's history, spanning 8,598 additions across 39 files. Here is what happened.
+
+## From Karpathy to Code — Three Key Ideas
+
+The Karpathy comparison was not just an academic exercise. Three ideas from that comparison directly influenced what got built.
+
+**Autonomous synthesis became `dewey compile`.** Karpathy's core innovation is having the LLM _read_ raw materials and _write_ structured articles — not indexing, but synthesizing. Dewey adapted this for a multi-agent context: `dewey compile` clusters learnings by tag, then synthesizes a current-state article that resolves contradictions, deduplicates redundancies, and produces a single coherent view of what the system knows about a topic. The raw learnings remain intact. The compiled article is a synthesis layer on top.
+
+**Contamination separation became trust tiers.** Steph Ango's suggestion (referenced in the predecessor post) about keeping personal vaults clean while agents work in a "messy vault" pointed to a real problem: when agents and humans both contribute knowledge, how do you know which content has been reviewed? Dewey v3.0.0 introduces three trust tiers — _authored_ (human-written), _validated_ (machine-generated, human-reviewed), and _draft_ (machine-generated, not yet reviewed). The `dewey promote` command moves content between tiers after review, and search can filter by tier.
+
+**Self-healing quality became `dewey lint`.** Karpathy described running "health checks" where the LLM scans the wiki for inconsistencies and fills gaps. Dewey adapted this into a concrete linting system that detects four categories of quality issues and distinguishes between problems that machines can fix automatically and problems that require human judgment.
+
+Credit where it is due: Karpathy's approach excels in domains where it was designed to work — small, curated datasets for personal research, where a single researcher actively curates a wiki of roughly 100 high-signal articles. The ideas that inspired Dewey's features are genuine contributions to how we think about knowledge management for AI systems. The adaptation was not "make it better" — it was "make it work for multi-agent, multi-repo workflows at a different scale."
+
+## The Event Sourcing Insight
+
+The architectural insight that unlocked the design came from an unexpected direction: event sourcing.
+
+In event sourcing, you never modify or delete events. The raw event log is the source of truth — append-only, immutable. When you need a current-state view, you build a materialized view by replaying the events through a projection function. If the projection logic changes, you rebuild the view from the same events.
+
+Dewey's knowledge system follows this pattern exactly. Raw learnings are the append-only event log. They are never deleted, never modified after storage. Each learning carries a timestamp, a tag, and a category (decision, pattern, gotcha, context, or reference). Compiled articles are the materialized view — ephemeral, rebuilt from learnings whenever `dewey compile` runs.
+
+This matters because of category-aware resolution. Not all knowledge merges the same way. When `dewey compile` synthesizes an article from clustered learnings, it applies different strategies based on the category of each learning:
+
+- **Decisions** use temporal merge — the latest decision supersedes earlier ones. A decision from March that was overridden in April results in the April decision being authoritative, not both appearing side by side.
+- **Patterns** accumulate — all observed patterns are preserved and grouped by theme, because patterns do not supersede each other.
+- **Gotchas** deduplicate — if three sessions discovered the same gotcha independently, the compiled article contains it once, not three times.
+
+The second architectural pattern is the dual-mode LLM design. When an agent calls `dewey compile` via MCP, the agent's own LLM performs the synthesis. The agent already has a language model in context — why invoke another one? But when a human runs `dewey compile` from the CLI, there is no agent LLM available. For this path, Dewey uses a local Ollama model via the `llm/` package, keeping CLI compilation local and free — no API keys, no cloud calls, no data leaving the machine. This solves the "who pays for tokens" problem: agents already have an LLM, so use it; CLI users get a free local model.
+
+## Knowledge Linting — The Self-Healing Index
+
+The predecessor post's comparison table showed "Self-healing: No" for Dewey. That line is no longer accurate.
+
+`dewey lint` performs four quality checks against the knowledge base:
+
+1. **Stale decisions** — decisions older than 30 days that have not been reaffirmed or superseded. A decision made months ago might still be correct, but it might also reflect a context that no longer exists.
+2. **Uncompiled learnings** — learnings that have accumulated since the last compilation pass. These are raw events that have not been synthesized into a current-state view.
+3. **Embedding gaps** — stored content that lacks computed embeddings, making it invisible to semantic search.
+4. **Contradictions** — learnings within the same tag that assert conflicting things.
+
+The design distinguishes between mechanical fixes and semantic fixes. Embedding gaps are mechanical — the content exists, it just needs an embedding computed. The `--fix` flag handles these automatically: re-embed, re-index, done. Stale decisions, uncompiled learnings, and contradictions are semantic — they require either compilation (to synthesize a current-state view) or human judgment (to resolve a genuine disagreement). `dewey lint` reports these issues but does not auto-fix them.
+
+Trust tiers interact with linting. A compiled article starts as _draft_ — it was machine-generated and has not been reviewed. When a human reviews the article and confirms its accuracy, `dewey promote` moves it to _validated_. Human-authored content enters as _authored_ directly. Search queries can filter by tier, so an agent that needs high-confidence information can restrict results to _authored_ and _validated_ content, excluding unreviewed _draft_ articles.
+
+This is Dewey's version of Karpathy's "self-healing" concept, adapted for a context where machines and humans contribute knowledge at different levels of reliability. The system does not just index — it maintains quality over time, distinguishing between what it can fix mechanically and what needs intelligence.
+
+## What We Learned Building It
+
+Dewey v3.0.0's knowledge compilation was the largest single feature in the project's history — 124 new tests across 7 packages, a schema migration from v1 to v2 with backward compatibility, and three new CLI commands. Two engineering insights stood out.
+
+**Category-aware resolution lives in prompts, not code.** The decision to use temporal merge for decisions, accumulation for patterns, and deduplication for gotchas is not implemented in Go code — it is encoded in the synthesis prompts that drive compilation. This means the resolution strategy can be tuned, extended, or corrected without recompiling the binary. It is a prompt engineering insight: when the "business logic" is about how to reason over text, the right place for that logic is in the prompt that instructs the reasoner, not in the code that invokes it.
+
+**The `llm/` package is a leaf dependency.** The new package that wraps Ollama for CLI compilation has zero imports from the rest of the Dewey codebase. It knows about the `Synthesizer` interface and nothing else. This made it testable in complete isolation — the package's tests do not need a running Dewey server, a database, or any MCP infrastructure. For a feature that touches the core of the knowledge system, this level of decoupling was essential for maintaining test reliability. It is a reminder that the most important dependency is the one you do not take.
+
+We are not overclaiming the maturity of these features. Knowledge compilation is new. The resolution strategies are the first iteration. Trust tiers work, but the workflow of reviewing and promoting content is still being refined through real usage across the Unbound Force swarm. What shipped is a foundation — a sound architecture that can evolve, not a finished product.
+
+If you want to try these features, the [knowledge getting-started guide](/docs/getting-started/knowledge/) covers the CLI commands and configuration for compilation, linting, and trust tiers. The [Dewey project page](/docs/projects/dewey/) has the full feature overview, including the 48 MCP tools available across 12 categories.

--- a/specs/021-dewey-curator-blog/checklists/requirements.md
+++ b/specs/021-dewey-curator-blog/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: How Dewey Became a Knowledge Curator Blog Post
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-11  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- FR-009 explicitly prohibits drifting implementation details (CLI syntax, parameters) in the blog post — this is a deliberate constraint to keep the post narrative-focused and reduce maintenance burden.
+- FR-014/FR-015 reference `npm run build` and light/dark mode — these are project-standard verification steps from AGENTS.md, not implementation details.
+- The post length assumption (1200-1800 words) is documented and matches the predecessor post. This is guidance, not a hard requirement.

--- a/specs/021-dewey-curator-blog/plan.md
+++ b/specs/021-dewey-curator-blog/plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan: How Dewey Became a Knowledge Curator Blog Post
+
+**Branch**: `021-dewey-curator-blog` | **Date**: 2026-04-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/021-dewey-curator-blog/spec.md`
+
+## Summary
+
+Create a blog post that tells the engineering story of how Dewey v3.0.0 shipped knowledge compilation, linting, and trust tiers — transforming Dewey from a passive index into an active knowledge curator. The post is a narrative sequel to the existing "The Librarian vs The Index" blog post (spec 019), closing the loop on speculative ideas that became real features. Single new file: `content/blog/dewey-curator-blog.md`.
+
+## Technical Context
+
+**Language/Version**: Markdown (Hugo content file)  
+**Primary Dependencies**: Hugo (via @thulite), Doks theme (`@thulite/doks-core`)  
+**Storage**: N/A (static Markdown file)  
+**Testing**: `npm run build` (zero errors), visual verification in `npm run dev`  
+**Target Platform**: GitHub Pages (static site)  
+**Project Type**: Static site content (blog post)  
+**Performance Goals**: N/A (static content)  
+**Constraints**: 1200–1800 words, five-section outline per issue #30  
+**Scale/Scope**: 1 new Markdown file
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### I. Content Accuracy — PASS
+
+All factual claims in the blog post are derived from verified upstream sources:
+
+- **Dewey PR #42** (8,598 additions, 152 deletions across 39 files): "feat: add knowledge compilation, temporal intelligence, linting, and trust tiers." Verified via `gh pr view 42 --repo unbound-force/dewey`.
+- **Spec 013-knowledge-compile**: 6 user stories, 28 FRs, 40 tasks (all complete), 124 new tests across 7 packages.
+- **Existing website docs** (updated by spec 020): Knowledge lifecycle, trust tiers, compile/lint/promote commands documented on the [knowledge getting-started guide](/docs/getting-started/knowledge/) and [Dewey project page](/docs/projects/dewey/).
+- **Predecessor blog post** (spec 019): "The Librarian vs The Index" at `content/blog/dewey-vs-karpathy.md`, which explicitly speculated about `dewey compile` and contamination separation.
+
+No capabilities are fabricated. The post describes what was built, sourced from the PR and spec artifacts.
+
+### II. Minimal Footprint — PASS
+
+- 1 new Markdown file. No custom HTML, CSS, JavaScript, or template overrides.
+- No new dependencies added to `package.json`.
+- Blog section already exists (5 published posts). No navigation or section setup needed.
+- CLI syntax and API details are linked to existing docs pages, not duplicated in the post.
+
+### III. Visitor Clarity — PASS
+
+- The post follows the established blog format (same frontmatter structure, categories, tags as existing posts).
+- The five-section narrative structure (Problem → Karpathy to Code → Event Sourcing → Knowledge Linting → Lessons Learned) provides a clear reading path.
+- Readers familiar with the predecessor post get narrative continuity; readers without prior context get a self-contained engineering story.
+- Internal links to docs pages provide a clear path for readers who want to try the features.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/021-dewey-curator-blog/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — upstream source material
+├── quickstart.md        # Phase 1 output — verification steps
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+No `data-model.md` or `contracts/` — this is a single blog post file with no data model or API contracts.
+
+### Source Code (repository root)
+
+```text
+content/blog/
+├── _index.md                      # Blog section index (existing)
+├── dewey-vs-karpathy.md           # Predecessor post (existing, not modified)
+├── dewey-knowledge-retrieval.md   # Existing post (not modified)
+├── dewey-curator-blog.md          # NEW — this spec's deliverable
+├── gaze-in-practice.md            # Existing post (not modified)
+├── unleash-in-practice.md         # Existing post (not modified)
+└── why-contract-coverage.md       # Existing post (not modified)
+```
+
+**Structure Decision**: Single new Markdown file in the existing `content/blog/` directory. No structural changes to the site.
+
+## File Change Matrix
+
+| File                                 | Change          | Rationale                         |
+| ------------------------------------ | --------------- | --------------------------------- |
+| `content/blog/dewey-curator-blog.md` | NEW — blog post | The sole deliverable of this spec |
+
+## Constitution Re-Check (Post-Design)
+
+### I. Content Accuracy — PASS (confirmed)
+
+Research phase (see [research.md](research.md)) verified all source material:
+
+- PR #42 body confirms: 4 interconnected capabilities, event sourcing model, 124 tests across 7 packages, schema v1→v2 migration, 3 new MCP tools (#45-47), 3 new CLI commands, new `llm/` package.
+- Category-aware resolution confirmed: decisions=temporal merge, patterns=accumulate, gotchas=dedup.
+- Dual-mode LLM pattern confirmed: `OllamaSynthesizer` in new `llm/` package for CLI compilation; agent's own LLM for MCP tool calls.
+- Trust tiers confirmed: authored/validated/draft via new `tier` column, `dewey promote` for tier transitions.
+
+### II. Minimal Footprint — PASS (confirmed)
+
+No design decisions introduced any additional files, dependencies, or custom elements beyond the single Markdown blog post.
+
+### III. Visitor Clarity — PASS (confirmed)
+
+The five-section outline maps directly to the spec's user stories:
+
+- Sections 1-2 serve US1 (narrative journey from comparison to implementation)
+- Sections 3-4 serve US2 (architectural insights for technical readers)
+- Internal links throughout serve US3 (links to updated documentation)
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification needed.

--- a/specs/021-dewey-curator-blog/quickstart.md
+++ b/specs/021-dewey-curator-blog/quickstart.md
@@ -1,0 +1,110 @@
+# Quickstart: How Dewey Became a Knowledge Curator Blog Post
+
+**Branch**: `021-dewey-curator-blog` | **Date**: 2026-04-11
+
+## Design Decisions
+
+### D1: Blog Post File Location
+
+**Decision**: `content/blog/dewey-curator-blog.md`
+
+**Rationale**: Follows the existing blog post naming convention (`dewey-vs-karpathy.md`, `dewey-knowledge-retrieval.md`). The `dewey-curator-blog` slug is descriptive and URL-friendly.
+
+### D2: Frontmatter Weight
+
+**Decision**: `weight: 58`
+
+**Rationale**: Places the post between the Karpathy comparison post (weight 60) and the unleash-in-practice post (weight 50) in sidebar ordering. This positions it as a natural follow-up to the comparison post.
+
+### D3: No CLI Syntax in Post Body
+
+**Decision**: All CLI command syntax is linked to docs pages, never inlined in the post.
+
+**Rationale**: Per FR-009 and the Minimal Footprint principle, CLI syntax lives in the docs (updated by spec 020). The blog post describes concepts and architecture. Duplicating syntax creates maintenance burden and drift risk.
+
+### D4: Five-Section Structure
+
+**Decision**: Follow the outline from issue #30 exactly:
+
+1. The Problem: Learnings That Never Compound
+2. From Karpathy to Code: Three Key Ideas
+3. The Event Sourcing Insight
+4. Knowledge Linting: The Self-Healing Index
+5. What We Learned Building It
+
+**Rationale**: This structure maps to the spec's user stories — sections 1-2 serve US1 (narrative journey), sections 3-4 serve US2 (architectural insights), and internal links throughout serve US3 (links to docs).
+
+### D5: Karpathy Credit Tone
+
+**Decision**: Frame as "inspired by" not "better than." Acknowledge where Karpathy's approach excels (small curated datasets, personal research). The narrative is "we learned from the comparison and built on those ideas."
+
+**Rationale**: Per FR-011 and the edge cases in the spec, the predecessor post took a balanced approach. This sequel maintains that tone.
+
+## Verification Steps
+
+### V1: Build Verification
+
+```bash
+# From repo root
+npm run build
+```
+
+**Expected**: Zero errors. The new blog post renders in the build output.
+
+### V2: Dev Server Visual Verification
+
+```bash
+npm run dev
+# Navigate to http://localhost:1313/blog/dewey-curator/
+```
+
+**Expected**:
+
+- Post renders with correct title, lead text, and table of contents
+- Five sections visible with proper heading hierarchy (H2 for sections)
+- Internal links to docs pages are clickable and resolve correctly
+- Link to predecessor post (`/blog/dewey-vs-karpathy/`) works
+
+### V3: Dark Mode Verification
+
+```bash
+npm run dev
+# Toggle dark mode in the Doks theme UI
+```
+
+**Expected**: Post renders correctly in both light and dark mode. No contrast issues, no broken styling.
+
+### V4: Internal Link Verification
+
+Check that all internal links in the post resolve:
+
+| Link Target                        | Expected Destination            |
+| ---------------------------------- | ------------------------------- |
+| `/blog/dewey-vs-karpathy/`         | Predecessor blog post           |
+| `/docs/getting-started/knowledge/` | Knowledge getting-started guide |
+| `/docs/projects/dewey/`            | Dewey project page              |
+
+### V5: Content Accuracy Spot-Check
+
+Verify key claims against upstream sources:
+
+| Claim in Post                                                        | Source                       |
+| -------------------------------------------------------------------- | ---------------------------- |
+| "124 new tests across 7 packages"                                    | PR #42 body                  |
+| Event sourcing model (append-only log, materialized views)           | PR #42 body                  |
+| Category-aware resolution (decisions, patterns, gotchas)             | PR #42 body                  |
+| Four lint checks (stale decisions, uncompiled, gaps, contradictions) | PR #42 body, docs pages      |
+| Trust tiers (authored/validated/draft)                               | PR #42 body, docs pages      |
+| Dual-mode LLM (Ollama for CLI, agent LLM for MCP)                    | PR #42 body (`llm/` package) |
+
+### V6: Word Count Verification
+
+**Expected**: 1200–1800 words (per spec constraint). Count body text only, excluding frontmatter.
+
+### V7: No Time-Sensitive Language
+
+**Expected**: No instances of "just shipped," "this week," "recently," "now available," or similar time-sensitive phrases in the post body. The frontmatter `date` field provides temporal context.
+
+### V8: No Duplicated CLI Syntax
+
+**Expected**: No fenced code blocks containing `dewey compile`, `dewey lint`, or `dewey promote` CLI examples. These live in the docs. The post may mention command names in prose but does not show usage syntax.

--- a/specs/021-dewey-curator-blog/research.md
+++ b/specs/021-dewey-curator-blog/research.md
@@ -1,0 +1,181 @@
+# Research: How Dewey Became a Knowledge Curator Blog Post
+
+**Branch**: `021-dewey-curator-blog` | **Date**: 2026-04-11
+
+## R1: Upstream Source Material — Dewey PR #42
+
+**Question**: What exactly shipped in Dewey v3.0.0 that the blog post needs to describe?
+
+**Source**: `gh pr view 42 --repo unbound-force/dewey` (verified 2026-04-11)
+
+**Findings**:
+
+PR #42 title: "feat: add knowledge compilation, temporal intelligence, linting, and trust tiers"
+
+- **Scale**: 8,598 additions, 152 deletions across 39 files. Largest feature in Dewey's history.
+- **Four interconnected capabilities**:
+  1. **Temporal Awareness**: `store_learning` gains required `tag`, optional `category` (decision/pattern/gotcha/context/reference), `{tag}-{sequence}` identity, and `created_at` timestamp. Breaking API change with backward-compat fallback.
+  2. **Knowledge Compilation**: `dewey compile` clusters learnings by tag, synthesizes current-state articles via configurable LLM with category-aware resolution (decisions=temporal merge, patterns=accumulate, gotchas=dedup). New `llm/` package with `Synthesizer` interface + `OllamaSynthesizer`.
+  3. **Knowledge Linting**: `dewey lint` detects stale decisions (>30 days), uncompiled learnings, embedding gaps, and potential contradictions. `--fix` auto-repairs mechanical issues.
+  4. **Contamination Separation**: Trust tiers (authored/validated/draft) via new `tier` column. `dewey promote` moves draft→validated after human review. `semantic_search_filtered` gains `tier` parameter.
+- **Event Sourcing Model**: Raw learnings are the append-only event log (never deleted). Compiled articles are the materialized view (ephemeral, rebuilt from learnings).
+- **Deliverables**: Schema v1→v2 migration, 3 new MCP tools (#45-47), 3 new CLI commands, 2 new slash commands, new `llm/` package (leaf dependency, zero Dewey imports), 124 new tests across 7 packages.
+- **Spec artifacts**: Full Speckit spec in `specs/013-knowledge-compile/` — spec (6 user stories, 28 FRs), plan, research (13 items), quickstart (10 design decisions), 6 contracts, tasks (40 tasks, all complete).
+
+**Decision**: Use PR #42 body as the authoritative source for all technical claims. Cross-reference with the website's already-published docs pages (updated by spec 020) for consistency.
+
+## R2: Predecessor Blog Post — Narrative Thread
+
+**Question**: What did the predecessor post ("The Librarian vs The Index") speculate about that this post needs to close the loop on?
+
+**Source**: `content/blog/dewey-vs-karpathy.md` (spec 019, published)
+
+**Findings**:
+
+The predecessor post's "What Each Could Learn From the Other" section explicitly speculated about two features that Dewey v3.0.0 shipped:
+
+1. **"Dewey could add autonomous synthesis."** — Quote: "A `dewey compile` command that reads indexed content and generates summary articles — turning passive indexing into active knowledge curation. Karpathy's linting concept (scan for inconsistencies, fill gaps) could make Dewey's index self-improving."
+   - **Status**: Shipped. `dewey compile` does exactly this.
+
+2. **"Dewey could add contamination separation."** — Quote: "Dewey could separate agent-generated learnings from human-authored documentation, promoting only validated content."
+   - **Status**: Shipped. Trust tiers (authored/validated/draft) with `dewey promote` for tier transitions.
+
+The predecessor post also established key framing:
+
+- Karpathy as "AI Librarian" (active synthesis), Dewey as "Searchable Index" (passive extraction)
+- The comparison table showed "Self-healing: No — indexes reflect source reality" for Dewey
+- The post credited Karpathy fairly and positioned the approaches as complementary, not competing
+
+**Decision**: The sequel post should reference these specific speculations and show they became real features. The framing shifts from "Dewey is a passive index" to "Dewey became an active curator" — but must maintain the fair, complementary tone toward Karpathy's approach.
+
+## R3: Existing Documentation Pages (Spec 020)
+
+**Question**: What docs pages exist that the blog post should link to instead of duplicating?
+
+**Source**: Website content pages (updated by spec 020, now merged)
+
+**Findings**:
+
+1. **Knowledge getting-started guide** (`/docs/getting-started/knowledge/`):
+   - Knowledge Lifecycle section with `dewey compile`, `dewey lint`, `dewey promote` CLI usage
+   - Trust Tiers section with authored/validated/draft definitions
+   - Storing and Retrieving Learnings section with `store_learning` parameters
+   - Full CLI flag reference
+
+2. **Dewey project page** (`/docs/projects/dewey/`):
+   - Knowledge Lifecycle feature summary (compile, lint, promote)
+   - "48 MCP tools across 12 categories" (updated from 40)
+
+3. **Dewey team page** (`/docs/team/dewey/`):
+   - Knowledge Management tools table (compile, lint, promote) — "New in Dewey v3.0.0"
+   - Learning tools table (store_learning with required tag and optional category)
+
+**Decision**: The blog post links to the knowledge getting-started guide for CLI details and the Dewey project page for feature overview. No CLI syntax is duplicated in the post — concepts and architecture only.
+
+## R4: Blog Post Frontmatter Pattern
+
+**Question**: What frontmatter format do existing blog posts use?
+
+**Source**: Existing blog posts in `content/blog/`
+
+**Findings**:
+
+All existing blog posts use this frontmatter pattern:
+
+```yaml
+---
+title: "Post Title"
+description: "SEO description."
+lead: "Brief intro shown at top."
+slug: "url-slug"
+date: 2026-MM-DDT00:00:00+00:00
+draft: false
+weight: NN
+toc: true
+categories: ["Engineering"]
+tags: ["tag1", "tag2"]
+contributors: ["Unbound Force"]
+---
+```
+
+Weight values for existing posts: 50 (unleash), 55 (gaze), 60 (dewey-vs-karpathy), 65 (why-contract-coverage), 70 (dewey-knowledge-retrieval).
+
+**Decision**: Use weight 58 to place the new post between the Karpathy comparison (60) and the unleash post (50) in sidebar ordering. Use `slug: "dewey-curator"` for a clean URL. Categories: `["Engineering"]`. Tags: `["dewey", "knowledge-management", "knowledge-compilation", "karpathy", "event-sourcing"]`.
+
+## R5: Dual-Mode LLM Pattern
+
+**Question**: How does the dual-mode LLM pattern work, and what makes it architecturally interesting?
+
+**Source**: PR #42 body, `llm/` package structure
+
+**Findings**:
+
+Dewey uses two different LLM invocation modes:
+
+1. **Agent-as-LLM (MCP tool calls)**: When an agent calls `dewey compile` via MCP, the agent's own LLM (Claude, GPT-4, etc.) is the synthesizer. The MCP tool returns the clustered learnings and the agent generates the compiled article. This works because the agent already has context and can reason about the learnings.
+
+2. **Local Ollama (CLI compilation)**: When a human runs `dewey compile` from the CLI, Dewey uses a local Ollama model via the new `llm/` package (`Synthesizer` interface + `OllamaSynthesizer`). This keeps CLI compilation local and free — no API keys, no cloud calls, no data leaving the machine.
+
+The `llm/` package is a leaf dependency with zero Dewey imports — it only knows about the `Synthesizer` interface. This makes it testable in isolation and reusable.
+
+**Decision**: This dual-mode pattern is a genuinely novel architectural insight worth highlighting in the blog post. It solves the "who pays for LLM tokens" problem elegantly: agents already have an LLM, so use it; CLI users get a free local model.
+
+## R6: Category-Aware Resolution
+
+**Question**: What is category-aware resolution and why does it matter?
+
+**Source**: PR #42 body
+
+**Findings**:
+
+When `dewey compile` clusters learnings by tag and synthesizes articles, it uses category-aware resolution strategies:
+
+- **Decisions** → temporal merge (latest decision supersedes earlier ones)
+- **Patterns** → accumulate (all patterns are preserved, grouped by theme)
+- **Gotchas** → dedup (duplicate gotchas are merged, unique ones preserved)
+
+This means the compiled article is not a naive concatenation — it understands the _type_ of knowledge and applies the appropriate synthesis strategy. A decision from March that was superseded by a decision in April results in the April decision being authoritative, not both decisions appearing side by side.
+
+**Decision**: This is a concrete engineering detail that makes the "event sourcing" section more tangible. Include it as an example of how materialized views are rebuilt intelligently.
+
+## R7: Knowledge Linting — Mechanical vs Semantic
+
+**Question**: What is the distinction between mechanical and semantic fixes in `dewey lint`?
+
+**Source**: Website docs (`/docs/getting-started/knowledge/`), PR #42
+
+**Findings**:
+
+`dewey lint` detects four quality issues:
+
+1. **Stale decisions** (>30 days old) — semantic fix (requires human review or recompilation)
+2. **Uncompiled learnings** — semantic fix (requires `dewey compile` to synthesize)
+3. **Embedding gaps** — mechanical fix (auto-fixable with `--fix`, just needs embedding generation)
+4. **Contradictions** — semantic fix (requires human judgment to resolve)
+
+The `--fix` flag auto-repairs mechanical issues only. Semantic issues are reported but not auto-fixed — they require compilation or human judgment.
+
+**Decision**: This mechanical/semantic distinction is the "self-healing index" concept from Karpathy's approach, adapted for Dewey. The blog post should explain this as Dewey adopting Karpathy's linting concept but distinguishing between what machines can fix and what requires intelligence.
+
+## R8: Test Coverage and Engineering Rigor
+
+**Question**: What concrete engineering metrics can the "What We Learned" section cite?
+
+**Source**: PR #42 body, Dewey GitHub PRs
+
+**Findings**:
+
+- 124 new tests across 7 packages in PR #42
+- Schema v1→v2 migration with backward compatibility
+- `llm/` package as a leaf dependency (zero Dewey imports) — clean separation of concerns
+- Category-aware resolution in compilation prompts
+- 6 contracts in the spec (compile-tool, lint-tool, llm-interface, promote-tool, schema-migration, store-learning)
+- 40 tasks in the spec, all completed
+- Breaking API change on `store_learning` with backward-compat fallback
+
+Earlier Dewey PRs for context:
+
+- PR #2 (core implementation): 308 tests across 10 packages
+- PR #4 (quality ratchets): CRAPload 48→15, 245+ tests
+
+**Decision**: The "What We Learned" section should cite: (1) category-aware resolution as a prompt engineering insight, (2) the leaf dependency pattern for the `llm/` package, and (3) the 124 tests / 7 packages metric as evidence of engineering rigor. Avoid overclaiming — these are genuine insights, not marketing claims.

--- a/specs/021-dewey-curator-blog/spec.md
+++ b/specs/021-dewey-curator-blog/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: How Dewey Became a Knowledge Curator Blog Post
+
+**Feature Branch**: `021-dewey-curator-blog`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "issue #30 — blog: How Dewey Became a Knowledge Curator — From Passive Index to Active Synthesis"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — Narrative Journey from Comparison to Implementation (Priority: P1)
+
+A reader who followed the earlier "The Librarian vs The Index" blog post (which compared Dewey and Karpathy's approaches and speculated about future features like `dewey compile`) reads this new post and learns how those speculative ideas became real, shipped features in Dewey v3.0.0. The post tells the engineering story: what problem was solved, what architectural insights emerged, and what the team learned building it.
+
+**Why this priority**: This is the core purpose of the blog post. The predecessor post explicitly speculated about `dewey compile` and trust tiers as future possibilities. This post closes that narrative loop with "we built it, here's what happened." Without this narrative thread, the post is a generic feature announcement rather than a compelling sequel.
+
+**Independent Test**: A reader who has read the Karpathy comparison post can follow this post as a natural continuation. A reader who has NOT read the Karpathy post can still understand the core story without feeling lost.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader familiar with the Karpathy comparison post, **When** they read this post, **Then** they recognize references to the earlier comparison and understand how the speculative ideas became features.
+2. **Given** a reader with no prior Dewey knowledge, **When** they read this post, **Then** they understand the problem (learnings that never compound), the solution (compile, lint, promote), and the architectural insight (event sourcing) without needing to read the predecessor post.
+3. **Given** a reader, **When** they finish the post, **Then** they have a clear understanding of what knowledge compilation does and why it matters for AI agent workflows.
+
+---
+
+### User Story 2 — Architectural Insights for Technical Readers (Priority: P1)
+
+A technical reader (developer, architect, or AI tooling enthusiast) reads the post and gains insight into two architectural patterns: the event sourcing model for knowledge management (raw learnings as append-only events, compiled articles as materialized views) and the dual-mode LLM pattern (agent-as-LLM for MCP tool calls, local Ollama for CLI compilation).
+
+**Why this priority**: Architectural insights are what make a blog post shareable and referenceable. Feature announcements are quickly forgotten; novel patterns persist. These two insights are genuinely novel and differentiate this post from a changelog.
+
+**Independent Test**: A technical reader can identify and articulate at least two architectural patterns from the post that they could apply to their own projects.
+
+**Acceptance Scenarios**:
+
+1. **Given** a technical reader, **When** they read the event sourcing section, **Then** they understand the distinction between raw learnings (events) and compiled articles (materialized views) and why this model was chosen.
+2. **Given** a technical reader, **When** they read the dual-mode LLM section, **Then** they understand why a local LLM is used for CLI compilation while MCP tool calls use the agent's own LLM.
+3. **Given** a technical reader, **When** they read the knowledge linting section, **Then** they understand the four quality checks (stale decisions, uncompiled learnings, embedding gaps, contradictions) and the mechanical vs semantic fix distinction.
+
+---
+
+### User Story 3 — Links to Updated Documentation (Priority: P2)
+
+A reader who wants to try the features described in the post can follow links to the updated Dewey documentation pages (which were synced in spec 020). The post references docs for CLI details rather than embedding reference material that will drift.
+
+**Why this priority**: The blog post should drive readers to the authoritative reference docs rather than duplicating them. This reduces maintenance burden (Minimal Footprint principle) and keeps the post focused on narrative rather than syntax.
+
+**Independent Test**: Every internal link in the post resolves to a valid page. CLI command syntax mentioned in the post matches what the linked docs describe.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader who wants to try `dewey compile`, **When** they click a link in the post, **Then** they arrive at the knowledge getting-started guide's Knowledge Lifecycle section with full CLI usage details.
+2. **Given** a reader interested in trust tiers, **When** they click a link, **Then** they arrive at the Trust Tiers documentation on the knowledge guide.
+3. **Given** a reader who reads the post in full, **When** they count internal links, **Then** they find links to at least the Dewey project page and the knowledge getting-started guide.
+
+---
+
+### Edge Cases
+
+- The post must credit Karpathy fairly — the original comparison post took a balanced approach and this sequel must maintain that tone. The framing is "we learned from the comparison" not "we won."
+- The post must avoid time-sensitive language ("just shipped," "this week") to remain relevant over time. The date in frontmatter provides temporal context.
+- The post must not duplicate CLI syntax or API parameter details that live in the docs pages updated by spec 020. Reference docs by linking, not by inlining.
+- The post must not overclaim the maturity of knowledge compilation — it is a new feature shipped in v3.0.0. Describe what it does accurately without implying production-hardened reliability across all environments.
+- If the Karpathy comparison post's URL changes, internal links use site-relative paths (`/blog/dewey-vs-karpathy/`) so they remain valid.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The blog post MUST be a single Markdown file at `content/blog/dewey-curator-blog.md` with valid Hugo/Doks frontmatter (title, description, lead, slug, date, draft, weight, toc, categories, tags, contributors).
+- **FR-002**: The post MUST follow the five-section outline from issue #30: (1) The Problem: Learnings That Never Compound, (2) From Karpathy to Code: Three Key Ideas, (3) The Event Sourcing Insight, (4) Knowledge Linting: The Self-Healing Index, (5) What We Learned Building It.
+- **FR-003**: The post MUST reference the predecessor blog post ("The Librarian vs The Index") by linking to it, establishing the narrative continuity between comparison and implementation.
+- **FR-004**: The post MUST explain the event sourcing architecture: raw learnings as an append-only event log, compiled articles as materialized views rebuilt from learnings.
+- **FR-005**: The post MUST explain the knowledge linting system with its four quality checks (stale decisions, uncompiled learnings, embedding gaps, contradictions) and distinguish between mechanical fixes and semantic fixes.
+- **FR-006**: The post MUST explain trust tiers (authored/validated/draft) and how they distinguish human-reviewed content from machine-generated content.
+- **FR-007**: The post MUST explain the dual-mode LLM pattern: agent LLM for MCP tool calls, local Ollama for CLI compilation.
+- **FR-008**: The post MUST link to the updated Dewey documentation pages (updated in spec 020) for CLI syntax and API reference details rather than duplicating that content.
+- **FR-009**: The post MUST NOT contain implementation details that will drift (specific CLI flag syntax, parameter names, response formats). These details live in the docs. The post describes concepts and architecture.
+- **FR-010**: The post MUST NOT use time-sensitive language ("just shipped," "this week," "recently"). The frontmatter date provides temporal context.
+- **FR-011**: The post MUST credit Karpathy's approach fairly and acknowledge where it excels (small curated datasets, personal research). The tone is "inspired by" not "better than."
+- **FR-012**: The post MUST source all factual claims from upstream Dewey PR #42 (spec 013-knowledge-compile), the Dewey repository, and the predecessor blog post. No capabilities may be fabricated or overstated.
+- **FR-013**: The post MUST include the "What We Learned Building It" section with at least two genuine engineering insights from the v3.0.0 development (e.g., category-aware resolution in prompts, 124 tests across 7 packages).
+- **FR-014**: The site MUST build successfully (`npm run build`) with no errors after adding the new blog post.
+- **FR-015**: The post MUST render correctly in both light and dark mode with the Doks theme.
+
+## Scope & Constraints
+
+### In Scope
+
+- One new blog post file at `content/blog/dewey-curator-blog.md`.
+- The five-section narrative structure from issue #30.
+- Links to existing documentation pages (updated by spec 020).
+
+### Out of Scope
+
+- Changes to existing blog posts (the Karpathy comparison post is not modified).
+- Changes to documentation pages (spec 020 already handled this).
+- Changes to homepage, navigation, or site structure.
+- Social media assets, press releases, or announcement drafts.
+- Updates to the blog post's stale "40 tools" reference in `dewey-vs-karpathy.md` (that is a separate consideration, not part of this spec).
+
+## Dependencies & Assumptions
+
+### Dependencies
+
+- **Spec 020 (dewey-v3-docs-sync)**: The documentation pages linked from this post were updated by spec 020. Spec 020 is now complete and merged. The blog post links to the current-state docs, not to stale content.
+- **Spec 019 (dewey-karpathy-blog)**: Created the predecessor blog post ("The Librarian vs The Index"). This new post is a narrative sequel. Spec 019 is complete.
+- **Upstream Dewey PR #42**: The source of truth for all v3.0.0 feature details. Content must be derived from this PR and the associated spec 013-knowledge-compile.
+
+### Assumptions
+
+- The blog section already exists on the site (5 published posts as of spec 019). No navigation or section setup is needed.
+- The post will use the same frontmatter format as existing blog posts (weight, categories, tags, contributors).
+- The post targets a technical audience familiar with AI coding agents but not necessarily with Dewey specifically. It should be accessible without prior Dewey knowledge.
+- The post will be approximately 1200-1800 words — long enough for depth, short enough to read in one sitting. This matches the length of the predecessor Karpathy comparison post.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A reader who has read the Karpathy comparison post recognizes this as a natural sequel and can follow the narrative thread from comparison to implementation.
+- **SC-002**: A reader with no prior Dewey knowledge can understand the problem (learnings that never compound), the solution (compile/lint/promote), and at least one architectural insight (event sourcing or dual-mode LLM) after reading the post.
+- **SC-003**: The post contains zero duplicated reference material — all CLI syntax, API parameters, and configuration details are linked to docs, not inlined.
+- **SC-004**: The site builds successfully (`npm run build`) with zero errors and the post renders correctly in both light and dark mode.
+- **SC-005**: All internal links in the post resolve to valid pages. All factual claims are traceable to upstream source material (PR #42, spec 013, predecessor blog post).

--- a/specs/021-dewey-curator-blog/tasks.md
+++ b/specs/021-dewey-curator-blog/tasks.md
@@ -1,0 +1,123 @@
+# Tasks: How Dewey Became a Knowledge Curator Blog Post
+
+**Input**: Design documents from `/specs/021-dewey-curator-blog/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, quickstart.md
+
+**Tests**: No automated tests. Validation is manual: `npm run build` (zero errors) + visual verification in `npm run dev`.
+
+**Organization**: Tasks are grouped by user story. All tasks modify a single file (`content/blog/dewey-curator-blog.md`), so there are no parallel opportunities — tasks are strictly sequential.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify the build environment is healthy before creating new content.
+
+- [x] T001 Run `npm run build` and confirm zero errors — baseline build health before changes
+
+**Checkpoint**: Build passes. No pre-existing issues that could be confused with regressions from the new post.
+
+---
+
+## Phase 2: User Story 1 — Narrative Journey from Comparison to Implementation (Priority: P1) 🎯 MVP
+
+**Goal**: Write the blog post with the five-section narrative structure from issue #30. A reader who followed the Karpathy comparison post recognizes this as a natural sequel. A reader without prior context gets a self-contained engineering story.
+
+**Independent Test**: The post reads as a coherent narrative from problem → solution → architectural insight → lessons learned. The predecessor post link works. No CLI syntax is duplicated from docs.
+
+### Implementation for User Story 1
+
+- [x] T002 [US1] Create `content/blog/dewey-curator-blog.md` with frontmatter: title, description, lead, slug (`dewey-curator`), date (`2026-04-11T00:00:00+00:00`), draft (`false`), weight (`58`), toc (`true`), categories (`["Engineering"]`), tags (`["dewey", "knowledge-management", "knowledge-compilation", "karpathy", "event-sourcing"]`), contributors (`["Unbound Force"]`). Match format from `content/blog/dewey-vs-karpathy.md`.
+- [x] T003 [US1] Write Section 1 — "The Problem: Learnings That Never Compound" in `content/blog/dewey-curator-blog.md`. Describe the problem of AI agent learnings that accumulate but never synthesize. Reference the predecessor post ("The Librarian vs The Index") with a link to `/blog/dewey-vs-karpathy/`. Establish the narrative thread: that post speculated about `dewey compile` and contamination separation — this post tells the story of building them. Per FR-003, FR-012.
+- [x] T004 [US1] Write Section 2 — "From Karpathy to Code: Three Key Ideas" in `content/blog/dewey-curator-blog.md`. Describe the three ideas from Karpathy's approach that inspired Dewey v3.0.0: (1) autonomous synthesis (compile), (2) contamination separation (trust tiers), (3) self-healing linting. Credit Karpathy fairly per FR-011 — frame as "inspired by" not "better than." Acknowledge where Karpathy's approach excels (small curated datasets, personal research). Per FR-011, FR-012.
+- [x] T005 [US1] Write Section 3 — "The Event Sourcing Insight" in `content/blog/dewey-curator-blog.md`. Explain the event sourcing architecture: raw learnings as an append-only event log, compiled articles as materialized views rebuilt from learnings. Include category-aware resolution (decisions=temporal merge, patterns=accumulate, gotchas=dedup) as a concrete example. Explain the dual-mode LLM pattern (agent LLM for MCP, local Ollama for CLI). Per FR-004, FR-007, research items R5, R6.
+- [x] T006 [US1] Write Section 4 — "Knowledge Linting: The Self-Healing Index" in `content/blog/dewey-curator-blog.md`. Explain the four quality checks (stale decisions, uncompiled learnings, embedding gaps, contradictions). Distinguish mechanical fixes (auto-fixable with `--fix`) from semantic fixes (require compilation or human judgment). Explain trust tiers (authored/validated/draft) and how `dewey promote` moves content between tiers. Per FR-005, FR-006, research items R7.
+- [x] T007 [US1] Write Section 5 — "What We Learned Building It" in `content/blog/dewey-curator-blog.md`. Include at least two genuine engineering insights per FR-013: (1) category-aware resolution as a prompt engineering insight, (2) the leaf dependency pattern for the `llm/` package (zero Dewey imports). Cite the 124 tests / 7 packages metric. Do not overclaim maturity. End the section with a brief call-to-action paragraph directing readers to try the features — link to the [knowledge getting-started guide](/docs/getting-started/knowledge/) and the [Dewey project page](/docs/projects/dewey/). Per FR-013, BA-001 (narrative arc with conclusion/CTA), research item R8.
+
+**Checkpoint**: The five-section blog post is complete. The narrative flows from problem → inspiration → architecture → quality → lessons. All content is sourced from research.md (PR #42, spec 013, predecessor post). No CLI syntax is inlined.
+
+---
+
+## Phase 3: User Story 2 — Architectural Insights for Technical Readers (Priority: P1)
+
+**Goal**: Review and polish the post to ensure architectural insights (event sourcing, dual-mode LLM) are clearly communicated and independently valuable. A technical reader can identify and articulate at least two patterns they could apply to their own projects.
+
+**Independent Test**: A technical reader can identify the event sourcing pattern and the dual-mode LLM pattern from the post without needing external context.
+
+### Implementation for User Story 2
+
+- [x] T008 [US2] Review Section 3 (Event Sourcing) and Section 4 (Knowledge Linting) in `content/blog/dewey-curator-blog.md` for architectural clarity. Verify: (1) the event sourcing analogy is explicit — "raw learnings are events, compiled articles are materialized views," (2) the dual-mode LLM pattern is clearly explained — why agent LLM for MCP and local Ollama for CLI, (3) the mechanical vs semantic fix distinction is clear. Refine prose as needed. Per US2 acceptance scenarios.
+- [x] T009 [US2] Verify the four knowledge linting checks are each named and explained in `content/blog/dewey-curator-blog.md`: stale decisions (>30 days), uncompiled learnings, embedding gaps, contradictions. Verify the mechanical/semantic distinction is clear. Per US2 acceptance scenario 3.
+
+**Checkpoint**: Architectural insights are clearly communicated. A technical reader can identify event sourcing and dual-mode LLM as reusable patterns.
+
+---
+
+## Phase 4: User Story 3 — Links to Updated Documentation (Priority: P2)
+
+**Goal**: Verify all internal links resolve to valid pages and point to updated docs (spec 020). CLI syntax is linked, not duplicated.
+
+**Independent Test**: Every internal link in the post resolves. No fenced code blocks contain CLI usage syntax.
+
+### Implementation for User Story 3
+
+- [x] T010 [US3] Verify all internal links in `content/blog/dewey-curator-blog.md` resolve to valid pages. Required links per quickstart.md V4: `/blog/dewey-vs-karpathy/` (predecessor post), `/docs/getting-started/knowledge/` (knowledge guide), `/docs/projects/dewey/` (Dewey project page). Fix any broken or missing links. Per FR-008, US3 acceptance scenarios.
+- [x] T011 [US3] Verify no fenced code blocks in `content/blog/dewey-curator-blog.md` contain `dewey compile`, `dewey lint`, or `dewey promote` CLI usage syntax. Command names may appear in prose but usage examples must link to docs. Per FR-009, quickstart.md V8.
+
+**Checkpoint**: All internal links resolve. No duplicated CLI syntax. Readers can follow links to authoritative reference docs.
+
+---
+
+## Phase 5: Polish & Verification
+
+**Purpose**: Final quality checks across all user stories before merge.
+
+- [x] T012 Verify word count of `content/blog/dewey-curator-blog.md` body text (excluding frontmatter) is 1200–1800 words. Adjust if outside range. Per spec constraint, quickstart.md V6.
+- [x] T013 Verify no time-sensitive language in `content/blog/dewey-curator-blog.md`: no "just shipped," "this week," "recently," "now available," or similar phrases. The frontmatter `date` field provides temporal context. Per FR-010, quickstart.md V7.
+- [x] T014 Run `npm run build` and confirm zero errors with the new blog post included. Per FR-014, quickstart.md V1.
+- [x] T015 Run `npm run dev` and visually verify `content/blog/dewey-curator-blog.md` renders correctly: title, lead text, table of contents, five sections with H2 headings, internal links clickable. Verify both light and dark mode. Per FR-015, quickstart.md V2, V3.
+
+**Checkpoint**: Post is publication-ready. Build passes, visual rendering is correct, all quality checks pass.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — confirms build health
+- **US1 (Phase 2)**: Depends on Phase 1 — creates the blog post file and writes all content
+- **US2 (Phase 3)**: Depends on Phase 2 — reviews and polishes architectural sections
+- **US3 (Phase 4)**: Depends on Phase 2 — verifies links and no duplicated CLI syntax
+- **Polish (Phase 5)**: Depends on Phases 2, 3, 4 — final quality gate
+
+### Parallel Opportunities
+
+**None.** All tasks modify or review a single file (`content/blog/dewey-curator-blog.md`). Tasks must be executed sequentially.
+
+### Execution Strategy
+
+Sequential, single-file workflow:
+
+1. Phase 1: Verify build health (T001)
+2. Phase 2: Write the complete blog post (T002–T007)
+3. Phase 3: Polish architectural clarity (T008–T009)
+4. Phase 4: Verify links and no CLI duplication (T010–T011)
+5. Phase 5: Final quality checks (T012–T015)
+
+---
+
+## Notes
+
+- All content is sourced from research.md (PR #42, spec 013, predecessor post). No fabrication.
+- The post is a narrative sequel to `content/blog/dewey-vs-karpathy.md` — maintain the same balanced, fair tone toward Karpathy's approach.
+- CLI syntax lives in docs (updated by spec 020). The blog post describes concepts and architecture only.
+- Commit after each phase checkpoint, not after individual tasks.
+
+<!-- spec-review: passed -->


### PR DESCRIPTION
## Summary

Adds a narrative blog post — "How Dewey Became a Knowledge Curator: From Passive Index to Active Synthesis" — telling the engineering story of how Dewey v3.0.0 shipped knowledge compilation, trust tiers, and linting.

- Sequel to "The Librarian vs The Index" (the Karpathy comparison post) — closes the narrative loop from "we speculated about these features" to "we built them"
- Five sections: the problem (learnings that never compound), three ideas adapted from Karpathy, the event sourcing architecture, knowledge linting as a self-healing system, and engineering lessons learned
- Links to the updated Dewey docs (spec 020) for CLI reference — no duplicated syntax
- 1,621 words, zero fenced code blocks, no time-sensitive language

## Review Results

- **Spec review**: APPROVE (unanimous, 5/5 Divisor reviewers)
- **Code review**: APPROVE (unanimous, first pass)
- **Build**: passes with zero errors

Closes #30
