### PR TITLE
docs: add blog post introducing The Curator — automated documentation governance

### DIFF
--- a/.opencode/agents/divisor-curator.md
+++ b/.opencode/agents/divisor-curator.md
@@ -1,0 +1,252 @@
+---
+description: "Documentation & content pipeline triage — owns documentation gaps, blog/tutorial opportunities, and website issue filing."
+mode: subagent
+model: google-vertex-anthropic/claude-opus-4-6@default
+temperature: 0.2
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  webfetch: false
+---
+<!-- scaffolded by uf vdev -->
+
+# Role: The Curator
+
+You are the documentation and content pipeline triage agent for this project. Your exclusive domain is **Documentation & Content Pipeline Triage**: documentation gap detection, blog opportunity identification, tutorial opportunity identification, and cross-repo issue filing in `unbound-force/website`.
+
+**You operate in one of two modes depending on how the caller invokes you: Code Review Mode (default) or Spec Review Mode.** The caller will tell you which mode to use.
+
+---
+
+## Bash Access Restriction
+
+Your bash access is restricted to exactly two operations:
+
+1. `gh issue list --repo unbound-force/website ...`
+   — Search existing issues to prevent duplicates
+2. `gh issue create --repo unbound-force/website ...`
+   — File new documentation, blog, or tutorial issues
+
+Any other bash usage is a violation of your operating contract. The Adversary agent's "Gate Tampering" check covers this.
+
+---
+
+## Step 0: Prior Learnings (optional)
+
+If Dewey MCP tools are available (`dewey_semantic_search`):
+1. Query for learnings related to documentation patterns
+   and content gaps:
+   `dewey_semantic_search({ query: "documentation gaps content pipeline website issues" })`
+2. Query for learnings related to the files being reviewed:
+   `dewey_semantic_search({ query: "<file paths from diff>" })`
+3. Include relevant learnings as "Prior Knowledge" context
+   in your review — reference specific learnings by ID.
+
+If Dewey is not available, skip this step with an
+informational note and proceed with the standard review.
+
+---
+
+## Source Documents
+
+Before reviewing, read:
+
+1. `AGENTS.md` -- Project overview, behavioral constraints, recent changes, project structure
+2. `.specify/memory/constitution.md` -- Constitution (if present)
+3. The relevant spec, plan, and tasks files under `specs/` for the current work
+4. `.opencode/uf/packs/severity.md` -- Shared severity definitions (MUST load for consistent severity classification)
+5. `.opencode/uf/packs/content.md` -- Content writing standards (optional — skip content quality checks on issue descriptions if not loaded)
+6. `README.md` -- Project description and installation steps
+7. Existing website issues — query via `gh issue list --repo unbound-force/website --state open` before filing any new issues
+
+---
+
+## Code Review Mode
+
+This is the default mode. Use this when the caller asks you to review code changes.
+
+### Review Scope
+
+Evaluate all recent changes (staged, unstaged, and untracked files). Use `git diff` and `git status` to identify what has changed. Classify changed files as user-facing or internal to determine whether documentation checks apply.
+
+### User-Facing Change Detection Heuristic
+
+Classify files as user-facing or internal based on path patterns:
+
+**User-facing paths** (trigger documentation checks):
+- `cmd/` — CLI commands and flags
+- `.opencode/agents/` — agent capabilities
+- `.opencode/command/` — slash commands
+- `.opencode/skill/` — swarm skills
+- `internal/scaffold/` — scaffold output (affects what `uf init` deploys)
+- `AGENTS.md` — project documentation
+- `README.md` — project documentation
+- `unbound-force.md` — hero descriptions
+
+**Internal paths** (skip documentation checks):
+- `internal/` (excluding `scaffold/`) — business logic
+- `*_test.go` — test files
+- `.github/` — CI/CD configuration
+- `specs/` — specification artifacts
+- `openspec/` — tactical change artifacts
+
+**If all changed files are internal-only, skip all audit checklist items and APPROVE with no findings.**
+
+### Audit Checklist
+
+#### 1. Documentation Gap Detection
+
+- Does this change modify user-facing behavior (CLI commands, agent capabilities, installation steps, workflows)?
+- If yes:
+  - Was `AGENTS.md` updated (Recent Changes, Project Structure, Active Technologies as applicable)?
+  - Was `README.md` updated if project description or install steps changed?
+- If documentation updates were needed but missing, flag as MEDIUM.
+- Skip for internal-only changes (refactoring, test-only, CI-only).
+
+#### 2. Website Documentation Issue Check
+
+- Does this change require website documentation updates (new commands, changed workflows, new agent capabilities)?
+- If yes, check whether a GitHub issue was filed in `unbound-force/website` with label `docs`:
+  ```bash
+  gh issue list --repo unbound-force/website --label docs --search "<keyword>" --state open
+  ```
+- If no matching issue exists, file one:
+  ```bash
+  gh issue create --repo unbound-force/website \
+    --title "docs: <brief description of what changed>" \
+    --label "docs" \
+    --body "<what changed, why it matters, which pages need updating>"
+  ```
+- Flag missing website documentation issue as HIGH.
+- Skip for internal-only changes.
+
+#### 3. Duplicate Issue Check
+
+- Before filing any issue (docs, blog, or tutorial), MUST search existing open issues:
+  ```bash
+  gh issue list --repo unbound-force/website --label <label> --search "<keyword>" --state open
+  ```
+- If a matching issue already exists, reference it in your findings instead of creating a duplicate.
+- If no match exists, proceed with filing.
+
+#### 4. Blog Opportunity Identification
+
+- Does this change introduce a significant new capability? Significance thresholds:
+  - New agent added (`divisor-*.md`, `*-coach.md`, etc.)
+  - New CLI command or subcommand
+  - Architectural migration (renamed directories, replaced tools)
+  - New hero capability
+- If yes, check whether a blog issue exists in `unbound-force/website` with label `blog`.
+- If no matching blog issue exists, file one:
+  ```bash
+  gh issue create --repo unbound-force/website \
+    --title "blog: <suggested topic>" \
+    --label "blog" \
+    --body "<topic, suggested angle, key points, PR reference>"
+  ```
+- Flag missing blog issue for significant changes as MEDIUM.
+- Skip for routine changes (bug fixes, minor refactoring, test-only).
+
+#### 5. Tutorial Opportunity Identification
+
+- Does this change introduce a new workflow that engineers need to learn? Significance thresholds:
+  - New slash command with multi-step workflow
+  - New tool integration requiring setup steps
+  - New workflow pattern (e.g., new speckit stage)
+- If yes, check whether a tutorial issue exists in `unbound-force/website` with label `tutorial`.
+- If no matching tutorial issue exists, file one:
+  ```bash
+  gh issue create --repo unbound-force/website \
+    --title "tutorial: <suggested topic>" \
+    --label "tutorial" \
+    --body "<topic, target audience, suggested structure, prerequisites>"
+  ```
+- Flag missing tutorial issue for workflow changes as MEDIUM.
+- Skip for changes that don't introduce new workflows.
+
+### Internal-Only Change Exemption
+
+Changes that are purely internal MUST NOT trigger any documentation or content findings:
+- Refactoring with no user-facing behavior change
+- Test-only changes (`*_test.go`)
+- CI/CD pipeline changes (`.github/`)
+- Spec artifacts (`specs/`, `openspec/`)
+- Dependency management (`go.mod`, `go.sum`)
+
+If all changed files fall into internal-only paths, produce no findings and APPROVE.
+
+---
+
+## Spec Review Mode
+
+Use this mode when the caller instructs you to review specification artifacts instead of code.
+
+### Review Scope
+
+Read **all files** under `specs/` recursively. Focus on documentation completeness within the specs themselves.
+
+### Audit Checklist
+
+#### 1. Documentation Completeness
+
+- Does the spec identify which documentation files need updating upon implementation?
+- Are there user-facing changes described in the spec that would require AGENTS.md, README.md, or website updates?
+- If the spec describes user-facing changes but does not mention documentation impact, flag as MEDIUM.
+
+#### 2. Content Coverage Assessment
+
+- Does the spec describe changes significant enough to warrant blog coverage?
+- Does the spec introduce workflows that would benefit from tutorials?
+- If content opportunities exist but are not acknowledged in the spec, note as LOW (informational).
+
+---
+
+## Output Format
+
+For each finding, provide:
+
+```
+### [SEVERITY] Finding Title
+
+**File**: `path/to/file:line` (or `specs/NNN-feature/artifact.md` in spec review mode)
+**Constraint**: Documentation Completeness / Content Pipeline
+**Description**: What documentation is missing and why it matters
+**Recommendation**: What to update or what issue to file
+```
+
+Severity levels: CRITICAL, HIGH, MEDIUM, LOW (per `.opencode/uf/packs/severity.md`)
+
+## Decision Criteria
+
+- **APPROVE** if all documentation is current, all required website issues exist (or were just filed), and no content opportunities were missed for significant changes.
+- **REQUEST CHANGES** if any documentation gap (MEDIUM+) or missing content issue (MEDIUM+) is found.
+
+End your review with a clear **APPROVE** or **REQUEST CHANGES** verdict and a summary of findings.
+
+## Graceful Degradation
+
+| Condition | Behavior |
+|-----------|----------|
+| `gh` not available | Report failure as a finding with the issue text you would have filed, so the developer can file it manually. Include the full `gh issue create` command in the recommendation. |
+| Website repo inaccessible | Report failure as a finding with the issue text for manual filing. Do not block the review — report the issue content and let the developer file it. |
+| Dewey not available | Skip Step 0 (Prior Learnings), proceed with standard review. Note the skip as informational. |
+| No content pack loaded | Skip content quality checks on issue descriptions. File issues with best-effort descriptions. |
+
+---
+
+## Out of Scope
+
+These domains are owned by other agents — do NOT produce findings for them:
+
+- **Writing documentation** → The Scribe (technical docs, READMEs, API docs)
+- **Writing blog posts** → The Herald (blog content, announcements)
+- **Writing PR communications** → The Envoy (release notes, PR descriptions)
+- **Code quality** → The Architect (conventions, patterns, DRY)
+- **Security** → The Adversary (secrets, CVEs, error handling)
+- **Test quality** → The Tester (coverage, assertions, isolation)
+- **Intent drift** → The Guard (plan alignment, zero-waste, constitution)
+- **Operational readiness** → The SRE (deployment, performance, config)
+
+The Curator identifies **what** needs documenting and files tracking issues. The Curator does NOT write the documentation, blog posts, or tutorials — that is the responsibility of the content agents (Scribe, Herald, Envoy) and the development team.

--- a/.opencode/command/cobalt-crush.md
+++ b/.opencode/command/cobalt-crush.md
@@ -7,6 +7,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /cobalt-crush

--- a/.opencode/command/constitution-check.md
+++ b/.opencode/command/constitution-check.md
@@ -4,6 +4,7 @@ agent: constitution-check
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/finale.md
+++ b/.opencode/command/finale.md
@@ -6,6 +6,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Command: /finale
 

--- a/.opencode/command/opsx-apply.md
+++ b/.opencode/command/opsx-apply.md
@@ -20,16 +20,29 @@ Implement tasks from an OpenSpec change.
 2. **Validate branch**
 
    Run `git rev-parse --abbrev-ref HEAD` to get the current branch.
-
    - If the current branch is `opsx/<change-name>`: proceed.
    - If the current branch is NOT `opsx/<change-name>`: **STOP** with error:
      > "Must be on branch `opsx/<change-name>` to implement this change.
      > Run: `git checkout opsx/<change-name>`"
 
+### Retrieve Implementation Context from Dewey
+
+Before implementing, query Dewey for relevant patterns:
+
+- `dewey_semantic_search` with the task description to find similar implementations in other repos
+- `dewey_semantic_search_filtered` with `source_type: "web"` to find relevant toolstack documentation
+- `dewey_search` for convention pack references related to the task's domain
+
+Use the retrieved context to follow established patterns and avoid reinventing solutions that already exist in the ecosystem.
+
+If Dewey is unavailable, proceed with direct file reads of convention packs and local code examples.
+
 3. **Check status to understand the schema**
+
    ```bash
    openspec status --change "<name>" --json
    ```
+
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
    - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
@@ -141,6 +154,7 @@ What would you like to do?
 ```
 
 **Guardrails**
+
 - Keep going through tasks until done or blocked
 - Always read context files before starting (from the apply instructions output)
 - If task is ambiguous, pause and ask before implementing

--- a/.opencode/command/opsx-propose.md
+++ b/.opencode/command/opsx-propose.md
@@ -5,6 +5,7 @@ description: Propose a new change - create it and generate all artifacts in one 
 Propose a new change - create the change and generate all artifacts in one step.
 
 I'll create a change with artifacts:
+
 - proposal.md (what & why)
 - design.md (how)
 - tasks.md (implementation steps)
@@ -20,6 +21,7 @@ When ready to implement, run /opsx-apply
 1. **If no input provided, ask what they want to build**
 
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+
    > "What change do you want to work on? Describe what you want to build or fix."
 
    From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
@@ -27,9 +29,11 @@ When ready to implement, run /opsx-apply
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
 2. **Create the change directory**
+
    ```bash
    openspec new change "<name>"
    ```
+
    This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
 
 3. **Create and checkout a branch**
@@ -43,10 +47,24 @@ When ready to implement, run /opsx-apply
    - If on a different `opsx/*` branch: **STOP** with error: "Already on branch `opsx/<other>` -- finish or archive that change first."
    - If on `main` or any non-opsx branch: create and checkout `opsx/<name>`.
 
+### Retrieve Context from Dewey
+
+Before drafting the proposal, query Dewey for relevant context:
+
+- `dewey_semantic_search` with the change description to find related specs, past proposals, and similar changes
+- `dewey_semantic_search_filtered` with `source_type: "github"` to find related issues across the organization
+- `dewey_traverse` on any discovered related specs to understand dependencies
+
+Use the retrieved context to inform the proposal's scope, identify potential conflicts with existing work, and reference relevant prior decisions.
+
+If Dewey is unavailable, proceed without cross-repo context — use direct file reads of local specs and backlog items instead.
+
 4. **Get the artifact build order**
+
    ```bash
    openspec status --change "<name>" --json
    ```
+
    Parse the JSON to get:
    - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
    - `artifacts`: list of all artifacts with their status and dependencies
@@ -58,30 +76,30 @@ When ready to implement, run /opsx-apply
    Loop through artifacts in dependency order (artifacts with no pending dependencies first):
 
    a. **For each artifact that is `ready` (dependencies satisfied)**:
-      - Get instructions:
-        ```bash
-        openspec instructions <artifact-id> --change "<name>" --json
-        ```
-      - The instructions JSON includes:
-        - `context`: Project background (constraints for you - do NOT include in output)
-        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
-        - `template`: The structure to use for your output file
-        - `instruction`: Schema-specific guidance for this artifact type
-        - `outputPath`: Where to write the artifact
-        - `dependencies`: Completed artifacts to read for context
-      - Read any completed dependency files for context
-      - Create the artifact file using `template` as the structure
-      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
-      - Show brief progress: "Created <artifact-id>"
+   - Get instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - The instructions JSON includes:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance for this artifact type
+     - `outputPath`: Where to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - Read any completed dependency files for context
+   - Create the artifact file using `template` as the structure
+   - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+   - Show brief progress: "Created <artifact-id>"
 
    b. **Continue until all `applyRequires` artifacts are complete**
-      - After creating each artifact, re-run `openspec status --change "<name>" --json`
-      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
-      - Stop when all `applyRequires` artifacts are done
+   - After creating each artifact, re-run `openspec status --change "<name>" --json`
+   - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+   - Stop when all `applyRequires` artifacts are done
 
    c. **If an artifact requires user input** (unclear context):
-      - Use **AskUserQuestion tool** to clarify
-      - Then continue with creation
+   - Use **AskUserQuestion tool** to clarify
+   - Then continue with creation
 
 6. **Show final status**
    ```bash
@@ -91,6 +109,7 @@ When ready to implement, run /opsx-apply
 **Output**
 
 After completing all artifacts, summarize:
+
 - Change name and location
 - List of artifacts created with brief descriptions
 - What's ready: "All artifacts created! Ready for implementation."
@@ -107,6 +126,7 @@ After completing all artifacts, summarize:
   - These guide what you write, but should never appear in the output
 
 **Guardrails**
+
 - Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
 - Always read dependency artifacts before creating a new one
 - If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum

--- a/.opencode/command/review-council.md
+++ b/.opencode/command/review-council.md
@@ -3,6 +3,7 @@ description: Run the reviewer governance council to audit codebase or spec compl
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 # Command: /review-council
 
@@ -112,6 +113,7 @@ This table documents known Divisor persona roles and their focus areas. It is us
 | `divisor-guard` | The Guard | Intent drift/plan alignment, zero-waste mandate, constitution alignment, cross-component value [PACK] | Intent fidelity, scope discipline, inter-spec consistency, status accuracy, user value, constitution alignment |
 | `divisor-testing` | The Tester | Test architecture [PACK], coverage strategy, assertion depth, test isolation, regression protection, convention compliance [PACK] | Testability of requirements, test strategy coverage, fixture feasibility, coverage expectations, contract surface |
 | `divisor-sre` | The Operator | File permissions/config, efficiency/performance, release pipeline [PACK], dependency health [PACK], runtime observability, upgrade paths, operational docs, backup/recovery | Deployment feasibility, operational requirements, config management, dependency risk, maintenance burden |
+| `divisor-curator` | The Curator | Documentation gaps, blog/tutorial opportunities, website issue filing | Documentation completeness in specs, content coverage |
 
 For any discovered agent not in this table, delegate with a generic review prompt appropriate to the current review mode.
 

--- a/.opencode/command/speckit.analyze.md
+++ b/.opencode/command/speckit.analyze.md
@@ -3,6 +3,7 @@ description: Perform a non-destructive cross-artifact consistency and quality an
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/speckit.checklist.md
+++ b/.opencode/command/speckit.checklist.md
@@ -3,6 +3,7 @@ description: Generate a custom checklist for the current feature based on user r
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/speckit.clarify.md
+++ b/.opencode/command/speckit.clarify.md
@@ -7,6 +7,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/speckit.constitution.md
+++ b/.opencode/command/speckit.constitution.md
@@ -7,6 +7,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/speckit.implement.md
+++ b/.opencode/command/speckit.implement.md
@@ -3,6 +3,7 @@ description: Execute the implementation plan by processing and executing all tas
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/speckit.plan.md
+++ b/.opencode/command/speckit.plan.md
@@ -11,6 +11,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/speckit.specify.md
+++ b/.opencode/command/speckit.specify.md
@@ -11,6 +11,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/speckit.tasks.md
+++ b/.opencode/command/speckit.tasks.md
@@ -12,6 +12,7 @@ handoffs:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/speckit.taskstoissues.md
+++ b/.opencode/command/speckit.taskstoissues.md
@@ -4,6 +4,7 @@ tools: ['github/github-mcp-server/issue_write']
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 

--- a/.opencode/command/uf-init.md
+++ b/.opencode/command/uf-init.md
@@ -7,6 +7,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Command: /uf-init
@@ -359,3 +360,22 @@ modified (had at least one `✅` insertion):
 
 Finally, remind the user:
 > Run `git diff` to review all changes before committing.
+
+### Next Steps
+
+After customizations are applied:
+
+- Run `/cobalt-crush` to start implementing — it
+  auto-detects your active workflow (Speckit or OpenSpec)
+  and delegates to the correct implementation command.
+  Preferred over calling `/opsx-apply` directly.
+
+### When to Re-run
+
+Re-run `/uf-init` after:
+- Running `uf init` or `uf setup` (new tool versions
+  may reset third-party files)
+- Updating the OpenSpec CLI (`npm update`)
+- Upgrading the `uf` binary (`brew upgrade unbound-force`
+  — new versions may add scaffold files that need
+  customization)

--- a/.opencode/command/unleash.md
+++ b/.opencode/command/unleash.md
@@ -8,6 +8,7 @@ description: >
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Command: /unleash
 

--- a/.opencode/skill/speckit-workflow/SKILL.md
+++ b/.opencode/skill/speckit-workflow/SKILL.md
@@ -8,6 +8,7 @@ tags:
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Speckit Workflow — Swarm Skill

--- a/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/.opencode/skills/openspec-apply-change/SKILL.md
@@ -27,16 +27,45 @@ Implement tasks from an OpenSpec change.
 2. **Validate branch**
 
    Run `git rev-parse --abbrev-ref HEAD` to get the current branch.
-
    - If the current branch is `opsx/<change-name>`: proceed.
    - If the current branch is NOT `opsx/<change-name>`: **STOP** with error:
      > "Must be on branch `opsx/<change-name>` to implement this change.
      > Run: `git checkout opsx/<change-name>`"
 
+### Retrieve Implementation Context from Dewey
+
+Before implementing, query Dewey for relevant patterns:
+
+- `dewey_semantic_search` with the task description to find similar implementations in other repos
+- `dewey_semantic_search_filtered` with `source_type: "web"` to find relevant toolstack documentation
+- `dewey_search` for convention pack references related to the task's domain
+
+Use the retrieved context to follow established patterns and avoid reinventing solutions that already exist in the ecosystem.
+
+If Dewey is unavailable, proceed with direct file reads of convention packs and local code examples.
+
+### Dewey Availability Tiers
+
+Adjust context retrieval based on Dewey availability:
+
+**Tier 3 (Full Dewey)**: Use `dewey_semantic_search`, `dewey_search`, `dewey_traverse`, and `dewey_semantic_search_filtered` for comprehensive cross-repo and toolstack context.
+
+**Tier 2 (Graph-only, no embedding model)**: Use `dewey_search` and `dewey_traverse` for keyword-based and structural queries. Semantic search is unavailable.
+
+**Tier 1 (No Dewey)**: Fall back to direct file operations:
+
+- Use the Read tool to read local specs, backlog items, and convention packs
+- Use the Grep tool for keyword search across the codebase
+- Reference `.opencode/uf/packs/` for coding standards
+
+All tiers produce valid results. Higher tiers provide richer cross-repo context but are never required.
+
 3. **Check status to understand the schema**
+
    ```bash
    openspec status --change "<name>" --json
    ```
+
    Parse the JSON to understand:
    - `schemaName`: The workflow being used (e.g., "spec-driven")
    - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
@@ -148,6 +177,7 @@ What would you like to do?
 ```
 
 **Guardrails**
+
 - Keep going through tasks until done or blocked
 - Always read context files before starting (from the apply instructions output)
 - If task is ambiguous, pause and ask before implementing

--- a/.opencode/skills/openspec-explore/SKILL.md
+++ b/.opencode/skills/openspec-explore/SKILL.md
@@ -28,29 +28,64 @@ Enter explore mode. Think deeply. Visualize freely. Follow the conversation wher
 
 ---
 
+### Use Dewey for Investigation
+
+When exploring ideas or investigating problems, use Dewey as the primary context source:
+
+- `dewey_semantic_search` to find conceptually related content across all indexed sources (specs, issues, docs)
+- `dewey_similar` to find documents similar to the one being explored
+- `dewey_traverse` to follow relationships between related documents
+- `dewey_semantic_search_filtered` to narrow searches by source type (e.g., only GitHub issues, only web docs)
+
+Dewey provides cross-repo context that direct file reads cannot — it finds related content even when different terminology is used.
+
+If Dewey is unavailable, fall back to direct file reads using the Read and Grep tools, and reference convention packs for standards.
+
+### Dewey Availability Tiers
+
+Adjust context retrieval based on Dewey availability:
+
+**Tier 3 (Full Dewey)**: Use `dewey_semantic_search`, `dewey_search`, `dewey_traverse`, and `dewey_semantic_search_filtered` for comprehensive cross-repo and toolstack context.
+
+**Tier 2 (Graph-only, no embedding model)**: Use `dewey_search` and `dewey_traverse` for keyword-based and structural queries. Semantic search is unavailable.
+
+**Tier 1 (No Dewey)**: Fall back to direct file operations:
+
+- Use the Read tool to read local specs, backlog items, and convention packs
+- Use the Grep tool for keyword search across the codebase
+- Reference `.opencode/uf/packs/` for coding standards
+
+All tiers produce valid results. Higher tiers provide richer cross-repo context but are never required.
+
+---
+
 ## What You Might Do
 
 Depending on what the user brings, you might:
 
 **Explore the problem space**
+
 - Ask clarifying questions that emerge from what they said
 - Challenge assumptions
 - Reframe the problem
 - Find analogies
 
 **Investigate the codebase**
+
 - Map existing architecture relevant to the discussion
 - Find integration points
 - Identify patterns already in use
 - Surface hidden complexity
 
 **Compare options**
+
 - Brainstorm multiple approaches
 - Build comparison tables
 - Sketch tradeoffs
 - Recommend a path (if asked)
 
 **Visualize**
+
 ```
 ┌─────────────────────────────────────────┐
 │     Use ASCII diagrams liberally        │
@@ -69,6 +104,7 @@ Depending on what the user brings, you might:
 ```
 
 **Surface risks and unknowns**
+
 - Identify what could go wrong
 - Find gaps in understanding
 - Suggest spikes or investigations
@@ -82,11 +118,13 @@ You have full context of the OpenSpec system. Use it naturally, don't force it.
 ### Check for context
 
 At the start, quickly check what exists:
+
 ```bash
 openspec list --json
 ```
 
 This tells you:
+
 - If there are active changes
 - Their names, schemas, and status
 - What the user might be working on
@@ -114,14 +152,14 @@ If the user mentions a change or you detect one is relevant:
 
 3. **Offer to capture when decisions are made**
 
-   | Insight Type | Where to Capture |
-   |--------------|------------------|
+   | Insight Type               | Where to Capture             |
+   | -------------------------- | ---------------------------- |
    | New requirement discovered | `specs/<capability>/spec.md` |
-   | Requirement changed | `specs/<capability>/spec.md` |
-   | Design decision made | `design.md` |
-   | Scope changed | `proposal.md` |
-   | New work identified | `tasks.md` |
-   | Assumption invalidated | Relevant artifact |
+   | Requirement changed        | `specs/<capability>/spec.md` |
+   | Design decision made       | `design.md`                  |
+   | Scope changed              | `proposal.md`                |
+   | New work identified        | `tasks.md`                   |
+   | Assumption invalidated     | Relevant artifact            |
 
    Example offers:
    - "That's a design decision. Capture it in design.md?"
@@ -146,6 +184,7 @@ If the user mentions a change or you detect one is relevant:
 ## Handling Different Entry Points
 
 **User brings a vague idea:**
+
 ```
 User: I'm thinking about adding real-time collaboration
 
@@ -169,6 +208,7 @@ You: Real-time collab is a big space. Let me think about this...
 ```
 
 **User brings a specific problem:**
+
 ```
 User: The auth system is a mess
 
@@ -200,6 +240,7 @@ You: [reads codebase]
 ```
 
 **User is stuck mid-implementation:**
+
 ```
 User: /opsx-explore add-auth-system
       The OAuth integration is more complex than expected
@@ -217,6 +258,7 @@ You: [reads change artifacts]
 ```
 
 **User wants to compare options:**
+
 ```
 User: Should we use Postgres or SQLite?
 

--- a/.opencode/skills/openspec-propose/SKILL.md
+++ b/.opencode/skills/openspec-propose/SKILL.md
@@ -12,6 +12,7 @@ metadata:
 Propose a new change - create the change and generate all artifacts in one step.
 
 I'll create a change with artifacts:
+
 - proposal.md (what & why)
 - design.md (how)
 - tasks.md (implementation steps)
@@ -27,6 +28,7 @@ When ready to implement, run /opsx-apply
 1. **If no clear input provided, ask what they want to build**
 
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+
    > "What change do you want to work on? Describe what you want to build or fix."
 
    From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
@@ -34,9 +36,11 @@ When ready to implement, run /opsx-apply
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
 2. **Create the change directory**
+
    ```bash
    openspec new change "<name>"
    ```
+
    This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
 
 3. **Create and checkout a branch**
@@ -50,10 +54,40 @@ When ready to implement, run /opsx-apply
    - If on a different `opsx/*` branch: **STOP** with error: "Already on branch `opsx/<other>` -- finish or archive that change first."
    - If on `main` or any non-opsx branch: create and checkout `opsx/<name>`.
 
+### Retrieve Context from Dewey
+
+Before drafting the proposal, query Dewey for relevant context:
+
+- `dewey_semantic_search` with the change description to find related specs, past proposals, and similar changes
+- `dewey_semantic_search_filtered` with `source_type: "github"` to find related issues across the organization
+- `dewey_traverse` on any discovered related specs to understand dependencies
+
+Use the retrieved context to inform the proposal's scope, identify potential conflicts with existing work, and reference relevant prior decisions.
+
+If Dewey is unavailable, proceed without cross-repo context — use direct file reads of local specs and backlog items instead.
+
+### Dewey Availability Tiers
+
+Adjust context retrieval based on Dewey availability:
+
+**Tier 3 (Full Dewey)**: Use `dewey_semantic_search`, `dewey_search`, `dewey_traverse`, and `dewey_semantic_search_filtered` for comprehensive cross-repo and toolstack context.
+
+**Tier 2 (Graph-only, no embedding model)**: Use `dewey_search` and `dewey_traverse` for keyword-based and structural queries. Semantic search is unavailable.
+
+**Tier 1 (No Dewey)**: Fall back to direct file operations:
+
+- Use the Read tool to read local specs, backlog items, and convention packs
+- Use the Grep tool for keyword search across the codebase
+- Reference `.opencode/uf/packs/` for coding standards
+
+All tiers produce valid results. Higher tiers provide richer cross-repo context but are never required.
+
 4. **Get the artifact build order**
+
    ```bash
    openspec status --change "<name>" --json
    ```
+
    Parse the JSON to get:
    - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
    - `artifacts`: list of all artifacts with their status and dependencies
@@ -65,30 +99,30 @@ When ready to implement, run /opsx-apply
    Loop through artifacts in dependency order (artifacts with no pending dependencies first):
 
    a. **For each artifact that is `ready` (dependencies satisfied)**:
-      - Get instructions:
-        ```bash
-        openspec instructions <artifact-id> --change "<name>" --json
-        ```
-      - The instructions JSON includes:
-        - `context`: Project background (constraints for you - do NOT include in output)
-        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
-        - `template`: The structure to use for your output file
-        - `instruction`: Schema-specific guidance for this artifact type
-        - `outputPath`: Where to write the artifact
-        - `dependencies`: Completed artifacts to read for context
-      - Read any completed dependency files for context
-      - Create the artifact file using `template` as the structure
-      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
-      - Show brief progress: "Created <artifact-id>"
+   - Get instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - The instructions JSON includes:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance for this artifact type
+     - `outputPath`: Where to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - Read any completed dependency files for context
+   - Create the artifact file using `template` as the structure
+   - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+   - Show brief progress: "Created <artifact-id>"
 
    b. **Continue until all `applyRequires` artifacts are complete**
-      - After creating each artifact, re-run `openspec status --change "<name>" --json`
-      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
-      - Stop when all `applyRequires` artifacts are done
+   - After creating each artifact, re-run `openspec status --change "<name>" --json`
+   - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+   - Stop when all `applyRequires` artifacts are done
 
    c. **If an artifact requires user input** (unclear context):
-      - Use **AskUserQuestion tool** to clarify
-      - Then continue with creation
+   - Use **AskUserQuestion tool** to clarify
+   - Then continue with creation
 
 6. **Show final status**
    ```bash
@@ -98,6 +132,7 @@ When ready to implement, run /opsx-apply
 **Output**
 
 After completing all artifacts, summarize:
+
 - Change name and location
 - List of artifacts created with brief descriptions
 - What's ready: "All artifacts created! Ready for implementation."
@@ -114,6 +149,7 @@ After completing all artifacts, summarize:
   - These guide what you write, but should never appear in the output
 
 **Guardrails**
+
 - Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
 - Always read dependency artifacts before creating a new one
 - If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum

--- a/.opencode/uf/packs/content.md
+++ b/.opencode/uf/packs/content.md
@@ -4,6 +4,7 @@ language: Any
 version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Convention Pack: Content (Documentation, Blog, PR/Comms)
 

--- a/.opencode/uf/packs/default.md
+++ b/.opencode/uf/packs/default.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Default (Language-Agnostic)

--- a/.opencode/uf/packs/go.md
+++ b/.opencode/uf/packs/go.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: Go

--- a/.opencode/uf/packs/severity.md
+++ b/.opencode/uf/packs/severity.md
@@ -2,6 +2,7 @@
 description: "Shared severity level definitions for all Divisor Council personas."
 ---
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 
 # Severity Convention Pack
 

--- a/.opencode/uf/packs/typescript.md
+++ b/.opencode/uf/packs/typescript.md
@@ -5,6 +5,7 @@ version: 1.0.0
 ---
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vv0.6.1 -->
 
 # Convention Pack: TypeScript

--- a/.uf/replicator/replicator.log
+++ b/.uf/replicator/replicator.log
@@ -1,3 +1,0 @@
-2026/04/11 13:14:58 INFO tool call tool=comms_init duration=20.445709ms success=true
-2026/04/11 13:15:06 INFO tool call tool=comms_reserve duration=5.752083ms success=true
-2026/04/11 13:16:09 INFO tool call tool=comms_release duration=2.637625ms success=true

--- a/content/blog/curator-blog.md
+++ b/content/blog/curator-blog.md
@@ -1,0 +1,105 @@
+---
+title: "Introducing The Curator: Automated Documentation Governance for AI Agent Teams"
+description: "The Curator is a Divisor agent that detects documentation gaps during code review and auto-files tracking issues — the first with bash access."
+lead: "Documentation drift is the most common quality gap in AI agent workflows. The Curator catches it."
+slug: "introducing-the-curator"
+date: 2026-04-11T00:00:00+00:00
+draft: false
+weight: 56
+toc: true
+categories: ["Engineering"]
+tags: ["divisor", "documentation", "code-review", "agents"]
+contributors: ["Unbound Force"]
+---
+
+## The Problem — Documentation Drift
+
+Every AI coding agent in a swarm can ship features. They can write code, add tests, refactor internals, and open pull requests. What they do not do — unless someone explicitly tells them to — is check whether the documentation still matches.
+
+This is not a hypothetical gap. It is the default outcome. A new CLI command ships. The README does not mention it. A new agent persona gets added to the swarm. The team page still says the old count. A feature lands that deserves a blog post. Nobody notices, because noticing is not in anyone's job description.
+
+The problem compounds silently. Each merged PR that changes user-facing behavior without a corresponding documentation update widens the gap between what the software does and what the documentation says it does. After enough PRs, the documentation is not wrong in any single dramatic way — it is wrong in dozens of small ways that erode trust in the entire docs surface.
+
+AI agents are excellent at the task in front of them. They write the code they are asked to write. They review the code they are asked to review. But they do not spontaneously ask themselves: "Does the getting-started guide still work after this change?" That question requires a perspective that sits outside the scope of any individual coding or review task.
+
+The problem is not that documentation is hard. It is that nobody is assigned to check.
+
+## The Solution — A Dedicated Triage Agent
+
+The Curator is the 9th Divisor persona, joining the existing five review personas (Guard, Architect, Adversary, SRE, Tester) and three content creation personas (Scribe, Herald, Envoy). It runs during every code review alongside the rest of the council.
+
+It does one thing: detect documentation gaps and file GitHub issues to track them.
+
+During every code review, The Curator evaluates the PR against five audit checklist items:
+
+1. **Documentation gap detection** — Were AGENTS.md or README files updated when the PR changes user-facing behavior?
+2. **Website documentation issue check** — Should an issue be filed in the website repository to track the needed documentation update?
+3. **Duplicate issue check** — Does an open issue already cover this gap, or would filing a new one create noise?
+4. **Blog opportunity identification** — Does this PR introduce a significant new capability that deserves a blog post?
+5. **Tutorial opportunity identification** — Does this PR introduce a new workflow that users need to learn?
+
+When The Curator detects a gap, it files a GitHub issue with the appropriate label — `docs`, `blog`, or `tutorial` — in the website repository. That issue becomes a trackable work item that the content agents can pick up.
+
+This is the important distinction: The Curator triages. It identifies what needs documenting. It does not create the documentation itself. The Scribe handles technical documentation. The Herald writes blog posts and announcements. The Envoy handles communications. The Curator files the ticket; the content agents fill it.
+
+The separation is deliberate. Detection and creation are different tasks that require different capabilities, different perspectives, and different tool access. A triage agent that also writes documentation would need a broader set of permissions than either task alone requires. By keeping the roles separate, each agent operates with only the access it needs.
+
+For the full breakdown of all nine personas and how they coordinate during code review, see the [Divisor team page](/docs/team/the-divisor/).
+
+## The Interesting Bits — Design Decisions
+
+Three design decisions from building The Curator are worth sharing, because they reveal patterns that apply broadly to multi-agent system design.
+
+### First Divisor Agent with Bash Access
+
+All eight previous Divisor personas have their bash access disabled. The Guard cannot run shell commands. The Architect cannot. The Adversary — whose entire job is security auditing — cannot. This is a deliberate constraint. Code review agents that can execute arbitrary shell commands have an attack surface that is difficult to reason about.
+
+The Curator breaks this pattern. It is the first Divisor persona with bash access enabled.
+
+The reason is straightforward: filing GitHub issues requires running `gh issue create`, and checking for duplicates requires running `gh issue list`. These are shell commands. There is no way to file a GitHub issue from a code review context without bash access.
+
+The restriction is minimal. The Curator's permitted operations are limited to those two `gh` CLI commands, scoped to the website repository. No other shell operations are authorized.
+
+But a self-imposed restriction in an agent's instructions is not the same as enforcement. This is where the trust architecture becomes interesting. The Adversary — another Divisor persona that runs during the same code review — includes a "Gate Tampering" check that monitors for bash misuse across the council. The Curator's bash access is constrained not just by its own instructions, but by a peer agent that actively verifies compliance.
+
+This is a pattern worth naming: grant the minimum capability needed, then have a peer verify that the capability is not being misused. It is the principle of least privilege with a peer audit layer — trust, but verify, with the verification built into the same system that grants the trust.
+
+### The Bootstrap Paradox
+
+The Curator cannot review the PR that creates it, because it does not exist until that PR merges.
+
+This is not a thought experiment. It is what happened during PR #89 in the upstream repository. That PR added The Curator's agent definition file to the codebase. The Divisor review council discovers personas by scanning for agent definition files in the repository. During the review of PR #89, The Curator's file existed in the diff — it was part of the proposed change — but it was not yet deployed. The review council runs against the current state of the repository, not the proposed state.
+
+The result: PR #89 was reviewed by the existing eight personas. The Curator could not participate in its own review because it did not exist as a running agent yet. After PR #89 merged, The Curator became active for all subsequent PRs. The first PR that The Curator actually reviewed was the one after its own creation.
+
+This means The Curator's first act of documentation governance could not apply to the documentation of its own creation. The PR that added a documentation triage agent to the review council was itself not triaged for documentation gaps by that agent.
+
+This is a genuine self-referential problem in self-modifying agent systems. Any agent that is added to a review pipeline through the same review pipeline it participates in will encounter this bootstrap boundary. The first instance is always unreviewed by itself. There is no clean solution — only the acknowledgment that the bootstrap case is handled by the existing agents, and the new agent picks up from the next review forward.
+
+### Triage vs Creation — Why The Curator Does Not Write Docs
+
+The Divisor council now operates across three functional layers:
+
+- **Review** (5 personas) — Guard, Architect, Adversary, SRE, Tester evaluate code quality, security, and operational readiness
+- **Triage** (1 persona) — The Curator identifies documentation gaps and files tracking issues
+- **Creation** (3 personas) — Scribe, Herald, Envoy produce documentation, blog posts, and communications
+
+The flow is directional. A PR changes user-facing behavior. The Curator detects the gap during review and files a GitHub issue. The content agents pick up that issue and create the actual content.
+
+Why not combine triage and creation in a single agent? Because they require different tool access. Detection needs the ability to read diffs and file issues — read access and bash access for `gh` CLI commands. Creation needs the ability to write and edit files — write and edit access to produce content. Combining both in one agent would grant it all four capabilities, violating the principle of least privilege.
+
+The Curator files the ticket. The Scribe writes the docs. The Herald writes the blog post. No single agent does everything.
+
+This separation of concerns mirrors a pattern that works well in human organizations too. The person who notices that documentation is outdated is rarely the best person to write the update. Noticing requires breadth — awareness of what changed and what the documentation currently says. Writing requires depth — understanding the feature well enough to explain it clearly. Different skills, different roles, different agents.
+
+## Honest Limitations
+
+The Curator uses heuristic file-path matching, not semantic understanding. It classifies files as user-facing or internal based on where they live in the repository structure. A change to a CLI command file triggers a documentation check. A change to an internal utility file does not. This is a proxy — a reasonable one, but a proxy nonetheless.
+
+The Curator does not read the content of changed files to determine whether documentation is actually needed. A cosmetic refactoring of a CLI command — renaming a variable, cleaning up error messages with no behavioral change — would still trigger a documentation gap warning if the file lives in a user-facing path. The Curator does not understand whether existing documentation already covers the change. It checks whether documentation files were modified in the same PR, not whether the existing docs are already accurate.
+
+Duplicate detection is keyword-based. The Curator searches existing open issues before filing new ones, but the search uses keyword matching, not semantic similarity. Two issues describing the same documentation gap with different wording might not be recognized as duplicates.
+
+The Curator is a first-pass filter, not an oracle. It catches the obvious gaps — the ones where user-facing code changed and no documentation file was touched. It misses the subtle ones — the cases where documentation exists but is now semantically inaccurate. This is a starting point, not a finished solution.
+
+For how The Curator integrates into the broader review workflow, see the [common workflows guide](/docs/getting-started/common-workflows/). For the full persona breakdown — all nine agents, their roles, and their access levels — see the [Divisor team page](/docs/team/the-divisor/).

--- a/openspec/schemas/unbound-force/schema.yaml
+++ b/openspec/schemas/unbound-force/schema.yaml
@@ -68,3 +68,4 @@ apply:
 # scaffolded by uf vv0.6.1
 # scaffolded by uf vdev
 # scaffolded by uf vdev
+# scaffolded by uf vdev

--- a/openspec/schemas/unbound-force/templates/design.md
+++ b/openspec/schemas/unbound-force/templates/design.md
@@ -20,3 +20,4 @@
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/proposal.md
+++ b/openspec/schemas/unbound-force/templates/proposal.md
@@ -57,3 +57,4 @@ Are components testable in isolation? -->
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/spec.md
+++ b/openspec/schemas/unbound-force/templates/spec.md
@@ -23,3 +23,4 @@
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/openspec/schemas/unbound-force/templates/tasks.md
+++ b/openspec/schemas/unbound-force/templates/tasks.md
@@ -9,3 +9,4 @@
 <!-- scaffolded by uf vv0.6.1 -->
 <!-- scaffolded by uf vdev -->
 <!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf vdev -->

--- a/specs/022-curator-blog/checklists/requirements.md
+++ b/specs/022-curator-blog/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Introducing The Curator Blog Post
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-11  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- FR-009 explicitly prohibits drifting implementation details (agent prompts, heuristic rules, CLI syntax) — same pattern as spec 021.
+- FR-011 notes that the persona count should be verified at implementation time against the upstream source, since the count may change before this spec is implemented.
+- FR-012 references upstream PR #89 and spec 026 — these must be accessible during implementation for factual sourcing.

--- a/specs/022-curator-blog/plan.md
+++ b/specs/022-curator-blog/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: Introducing The Curator Blog Post
+
+**Branch**: `022-curator-blog` | **Date**: 2026-04-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/022-curator-blog/spec.md`
+
+## Summary
+
+Create a blog post introducing The Curator — the 9th Divisor persona and the first with bash access — that tells the story of why documentation drift is a persistent problem in AI agent workflows and how a dedicated triage agent addresses it. The post follows the three-section structure from issue #36: (1) The Problem — documentation drift, (2) The Solution — a dedicated triage agent, (3) The Interesting Bits — bash access restriction, bootstrap paradox, triage vs creation separation. Single new file: `content/blog/curator-blog.md`.
+
+## Technical Context
+
+**Language/Version**: Markdown (Hugo content file)
+**Primary Dependencies**: Hugo (via @thulite), Doks theme (`@thulite/doks-core`)
+**Storage**: N/A (static Markdown file)
+**Testing**: `npm run build` (zero errors), visual verification in `npm run dev`
+**Target Platform**: GitHub Pages (static site)
+**Project Type**: Static site content (blog post)
+**Performance Goals**: N/A (static content)
+**Constraints**: 1200-1800 words, three-section outline per issue #36
+**Scale/Scope**: 1 new Markdown file
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### I. Content Accuracy — PASS
+
+All factual claims in the blog post are derived from verified upstream sources:
+
+- **Upstream PR #89** (unbound-force/unbound-force): "feat: add Divisor Curator agent for documentation & content pipeline triage (Spec 026)." Merged 2026-04-11. Verified via `gh pr view 89 --repo unbound-force/unbound-force`.
+- **PR #89 body confirms**: 1 new file (`divisor-curator.md`, ~250 lines), 4 modified files, 5 audit checklist items, bash restricted to `gh issue list` and `gh issue create` only, temperature 0.2, Divisor agent count 8→9, asset count 54→55.
+- **Spec 026-documentation-curation**: Full Speckit spec pipeline (spec, plan, tasks, research, data-model, quickstart, contracts, checklists) in the upstream repo.
+- **The Curator agent definition** (`.opencode/agents/divisor-curator.md`): Already committed locally. Confirms bash restriction, five audit checklist items, triage-only scope, out-of-scope boundaries.
+- **Existing Divisor team page** (`content/docs/team/the-divisor.md`): Currently documents 8 personas (5 review + 3 content creation). The Curator is the 9th.
+
+No capabilities are fabricated. The post describes what was built, sourced from PR #89 and the agent definition file.
+
+### II. Minimal Footprint — PASS
+
+- 1 new Markdown file. No custom HTML, CSS, JavaScript, or template overrides.
+- No new dependencies added to `package.json`.
+- Blog section already exists (6 published posts). No navigation or section setup needed.
+- Agent configuration syntax and `gh` CLI commands are linked to docs, not duplicated in the post.
+
+### III. Visitor Clarity — PASS
+
+- The post follows the established blog format (same frontmatter structure, categories, tags as existing posts).
+- The three-section narrative structure (Problem → Solution → Interesting Bits) provides a clear reading path.
+- Readers unfamiliar with Unbound Force get a self-contained explanation of the documentation drift problem.
+- Internal links to the Divisor team page and getting-started guides provide a clear path for readers who want to learn more.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-curator-blog/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — upstream source material
+├── quickstart.md        # Phase 1 output — verification steps
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+No `data-model.md` or `contracts/` — this is a single blog post file with no data model or API contracts.
+
+### Source Code (repository root)
+
+```text
+content/blog/
+├── _index.md                      # Blog section index (existing)
+├── dewey-curator-blog.md          # Existing post (not modified)
+├── dewey-vs-karpathy.md           # Existing post (not modified)
+├── dewey-knowledge-retrieval.md   # Existing post (not modified)
+├── gaze-in-practice.md            # Existing post (not modified)
+├── unleash-in-practice.md         # Existing post (not modified)
+├── why-contract-coverage.md       # Existing post (not modified)
+└── curator-blog.md                # NEW — this spec's deliverable
+```
+
+**Structure Decision**: Single new Markdown file in the existing `content/blog/` directory. No structural changes to the site.
+
+## File Change Matrix
+
+| File                           | Change          | Rationale                         |
+| ------------------------------ | --------------- | --------------------------------- |
+| `content/blog/curator-blog.md` | NEW — blog post | The sole deliverable of this spec |
+
+## Constitution Re-Check (Post-Design)
+
+### I. Content Accuracy — PASS (confirmed)
+
+Research phase (see [research.md](research.md)) verified all source material:
+
+- PR #89 body confirms: The Curator is a documentation & content pipeline triage agent, temperature 0.2, bash restricted to `gh issue list` and `gh issue create` only, 5 audit checklist items, Divisor agent count 8→9.
+- Bootstrap paradox confirmed: The Curator cannot review the PR that creates it because it does not exist until that PR merges. PR #89 was reviewed by the existing 8 personas without Curator participation.
+- Triage/creation separation confirmed: The Curator's "Out of Scope" section explicitly lists The Scribe (tech docs), The Herald (blog), and The Envoy (comms) as the content creators. The Curator identifies gaps and files issues only.
+- Bash restriction confirmed: Agent definition frontmatter shows `bash: true` with body text restricting usage to exactly two operations (`gh issue list` and `gh issue create`). The Adversary's "Gate Tampering" check enforces this.
+- Heuristic detection confirmed: The Curator uses file-path pattern matching (user-facing paths vs internal paths) to determine whether documentation checks apply, not semantic understanding of content.
+
+### II. Minimal Footprint — PASS (confirmed)
+
+No design decisions introduced any additional files, dependencies, or custom elements beyond the single Markdown blog post.
+
+### III. Visitor Clarity — PASS (confirmed)
+
+The three-section outline maps directly to the spec's user stories:
+
+- Section 1 (The Problem) serves US1 — explains documentation drift and why it matters
+- Section 2 (The Solution) serves US1 — explains The Curator's role and triage model
+- Section 3 (The Interesting Bits) serves US2 — three design insights for technical readers
+- Internal links throughout serve US3 — links to Divisor team page and docs
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification needed.

--- a/specs/022-curator-blog/quickstart.md
+++ b/specs/022-curator-blog/quickstart.md
@@ -1,0 +1,125 @@
+# Quickstart: Introducing The Curator Blog Post
+
+**Branch**: `022-curator-blog` | **Date**: 2026-04-11
+
+## Design Decisions
+
+### D1: Blog Post File Location
+
+**Decision**: `content/blog/curator-blog.md`
+
+**Rationale**: Follows the existing blog post naming convention. The filename `curator-blog` is descriptive and distinguishes this post from the Dewey Curator blog post (`dewey-curator-blog.md`). The slug `introducing-the-curator` provides a clean, descriptive URL.
+
+### D2: Frontmatter Weight
+
+**Decision**: `weight: 56`
+
+**Rationale**: Places the post above the Dewey Curator blog post (weight 58) in sidebar ordering, making it the most recent post. Lower weight = higher position in the Doks sidebar.
+
+### D3: Three-Section Structure
+
+**Decision**: Follow the outline from issue #36:
+
+1. The Problem — Documentation Drift
+2. The Solution — A Dedicated Triage Agent
+3. The Interesting Bits — Bash Access, Bootstrap Paradox, Triage vs Creation
+
+**Rationale**: This structure maps to the spec's user stories — section 1 serves US1 (documentation drift problem and Curator's role), section 2 continues US1 (how The Curator works), and section 3 serves US2 (design insights for technical readers). Internal links throughout serve US3.
+
+### D4: No Agent Configuration or CLI Syntax in Post Body
+
+**Decision**: All agent configuration syntax, `gh` CLI commands, and heuristic rules are linked to docs pages, never inlined in the post.
+
+**Rationale**: Per FR-009 and the Minimal Footprint principle, implementation details that will drift (prompt contents, heuristic rules, CLI syntax) live in the agent definition file and docs. The blog post describes concepts and design decisions. Duplicating syntax creates maintenance burden and drift risk — the exact problem The Curator is designed to catch.
+
+### D5: Honest Limitations Acknowledgment
+
+**Decision**: Explicitly state that The Curator uses heuristic file-path matching, not semantic understanding. Acknowledge it as a first-pass filter.
+
+**Rationale**: Per FR-013 and the spec's edge cases, the post must not overclaim The Curator's intelligence. The Curator does not understand whether documentation is actually needed — it uses path patterns as a proxy. This honesty is consistent with the tone established in spec 021 ("We are not overclaiming the maturity of these features").
+
+### D6: Bootstrap Paradox as Narrative Hook
+
+**Decision**: Present the bootstrap paradox as a real engineering story from PR #89, not a hypothetical scenario.
+
+**Rationale**: Per FR-007, the post must describe how the bootstrap paradox was handled in practice. PR #89 was reviewed by the existing 8 personas. The Curator could not participate in its own review. This is a concrete, verifiable fact that makes the design insight tangible.
+
+### D7: Persona Count
+
+**Decision**: State "9th Divisor persona" explicitly, noting it joins 5 review + 3 content creation personas.
+
+**Rationale**: Per FR-011 and the spec's edge cases, the persona count must be accurate. The existing team page says 8. The Curator makes 9. The post states the updated count clearly without modifying the team page (out of scope).
+
+## Verification Steps
+
+### V1: Build Verification
+
+```bash
+# From repo root
+npm run build
+```
+
+**Expected**: Zero errors. The new blog post renders in the build output.
+
+### V2: Dev Server Visual Verification
+
+```bash
+npm run dev
+# Navigate to http://localhost:1313/blog/introducing-the-curator/
+```
+
+**Expected**:
+
+- Post renders with correct title, lead text, and table of contents
+- Three sections visible with proper heading hierarchy (H2 for sections, H3 for subsections)
+- Internal links to docs pages are clickable and resolve correctly
+
+### V3: Dark Mode Verification
+
+```bash
+npm run dev
+# Toggle dark mode in the Doks theme UI
+```
+
+**Expected**: Post renders correctly in both light and dark mode. No contrast issues, no broken styling.
+
+### V4: Internal Link Verification
+
+Check that all internal links in the post resolve:
+
+| Link Target                               | Expected Destination            |
+| ----------------------------------------- | ------------------------------- |
+| `/docs/team/the-divisor/`                 | Divisor team page               |
+| `/docs/getting-started/common-workflows/` | Common workflows (code review)  |
+| `/docs/getting-started/developer/`        | Developer getting-started guide |
+
+### V5: Content Accuracy Spot-Check
+
+Verify key claims against upstream sources:
+
+| Claim in Post                                              | Source                                                    |
+| ---------------------------------------------------------- | --------------------------------------------------------- |
+| The Curator is the 9th Divisor persona                     | PR #89 body (8→9 count)                                   |
+| First Divisor agent with bash access                       | Agent definition frontmatter                              |
+| Bash restricted to `gh issue list` and `gh issue create`   | Agent definition "Bash Access" section                    |
+| Five audit checklist items                                 | Agent definition "Audit Checklist"                        |
+| Triage only — does not write docs, blog, or tutorials      | Agent definition "Out of Scope" section                   |
+| Heuristic file-path matching, not semantic understanding   | Agent definition "User-Facing Change Detection Heuristic" |
+| The Adversary enforces bash restriction                    | Agent definition "Bash Access" section                    |
+| PR #89 reviewed by existing 8 personas (bootstrap paradox) | PR #89 review history                                     |
+
+### V6: Word Count Verification
+
+**Expected**: 1200-1800 words (per spec constraint). Count body text only, excluding frontmatter.
+
+### V7: No Time-Sensitive Language
+
+**Expected**: No instances of "just shipped," "this week," "recently," "now available," or similar time-sensitive phrases in the post body. The frontmatter `date` field provides temporal context.
+
+### V8: No Duplicated Configuration or CLI Syntax
+
+**Expected**: No fenced code blocks containing agent frontmatter YAML, `gh issue create` commands, or heuristic path patterns. These live in the agent definition file and docs. The post may mention concepts in prose but does not show implementation syntax.
+
+### V9: No Overclaiming
+
+**Expected**: The post explicitly acknowledges The Curator's heuristic limitations. No claims of "semantic understanding," "intelligent detection," or similar overclaims. The Curator is described as a first-pass filter using file-path matching.

--- a/specs/022-curator-blog/research.md
+++ b/specs/022-curator-blog/research.md
@@ -1,0 +1,227 @@
+# Research: Introducing The Curator Blog Post
+
+**Branch**: `022-curator-blog` | **Date**: 2026-04-11
+
+## R1: Upstream Source Material — PR #89
+
+**Question**: What exactly shipped in PR #89 that the blog post needs to describe?
+
+**Source**: `gh pr view 89 --repo unbound-force/unbound-force` (verified 2026-04-11)
+
+**Findings**:
+
+PR #89 title: "feat: add Divisor Curator agent for documentation & content pipeline triage (Spec 026)"
+State: MERGED (2026-04-11T19:53:18Z)
+
+- **The Curator agent** (`divisor-curator.md`, ~250 lines):
+  - Role: Documentation & content pipeline triage
+  - Temperature: 0.2 (judgment-based decisions)
+  - Tools: `read: true, write: false, edit: false, bash: true`
+  - Bash restriction: Only `gh issue list` and `gh issue create` against `unbound-force/website`
+  - The Adversary's "Gate Tampering" check enforces the bash restriction
+  - Operates in two modes: Code Review Mode (default) and Spec Review Mode
+
+- **Five audit checklist items**:
+  1. Documentation Gap Detection — checks if AGENTS.md/README were updated for user-facing changes
+  2. Website Documentation Issue Check — auto-files `docs`-labeled issues in `unbound-force/website`
+  3. Duplicate Issue Check — searches existing open issues before filing new ones
+  4. Blog Opportunity Identification — files `blog`-labeled issues for significant new capabilities
+  5. Tutorial Opportunity Identification — files `tutorial`-labeled issues for new workflows
+
+- **Guard Enhancement**: Added `#### 6. Documentation Completeness` to the Guard's Code Review audit
+
+- **Scale**: 1 new file + scaffold copy, 4 modified files, AGENTS.md updated, asset count 54→55, Divisor agents 8→9
+
+- **Website repo labels created**: `docs`, `blog`, `tutorial`
+
+**Decision**: Use PR #89 body as the authoritative source for all technical claims about The Curator. Cross-reference with the local agent definition file for implementation details.
+
+## R2: The Curator Agent Definition — Key Design Details
+
+**Question**: What are the specific design decisions in The Curator's agent file that make good blog material?
+
+**Source**: `.opencode/agents/divisor-curator.md` (local copy, committed)
+
+**Findings**:
+
+### Bash Access Restriction
+
+The Curator is the first Divisor persona with `bash: true` in its frontmatter. All other Divisor agents have `bash: false`. The restriction is enforced at two levels:
+
+1. **Self-documented**: The agent file's "Bash Access Restriction" section explicitly states only two operations are permitted: `gh issue list` and `gh issue create`
+2. **Cross-agent enforcement**: "The Adversary agent's 'Gate Tampering' check covers this" — meaning another Divisor persona actively monitors for bash misuse
+
+This is a trust architecture pattern: grant the minimum capability needed, then have a peer agent verify compliance.
+
+### User-Facing Change Detection Heuristic
+
+The Curator classifies files as user-facing or internal based on path patterns:
+
+- **User-facing paths** (trigger documentation checks): `cmd/`, `.opencode/agents/`, `.opencode/command/`, `.opencode/skill/`, `internal/scaffold/`, `AGENTS.md`, `README.md`, `unbound-force.md`
+- **Internal paths** (skip documentation checks): `internal/` (excluding scaffold), `*_test.go`, `.github/`, `specs/`, `openspec/`
+
+This is heuristic file-path matching, not semantic understanding. The Curator does not read the content of changed files to determine whether documentation is needed — it uses path patterns as a proxy.
+
+### Triage-Only Scope (Out of Scope Section)
+
+The agent file explicitly lists what The Curator does NOT do:
+
+- Writing documentation → The Scribe
+- Writing blog posts → The Herald
+- Writing PR communications → The Envoy
+- Code quality → The Architect
+- Security → The Adversary
+- Test quality → The Tester
+- Intent drift → The Guard
+- Operational readiness → The SRE
+
+The Curator identifies **what** needs documenting and files tracking issues. The content agents and development team create the actual content.
+
+### Internal-Only Change Exemption
+
+If all changed files fall into internal-only paths, The Curator produces no findings and APPROVEs. This prevents noise — a refactoring PR that touches only `internal/` code should not trigger documentation gap warnings.
+
+**Decision**: The bash restriction, heuristic detection, and triage/creation separation are the three design insights worth highlighting in the "Interesting Bits" section. The internal-only exemption is a supporting detail.
+
+## R3: The Bootstrap Paradox
+
+**Question**: What is the bootstrap paradox and how was it handled in practice?
+
+**Source**: PR #89 context, agent definition file
+
+**Findings**:
+
+The bootstrap paradox: The Curator cannot review the PR that creates it, because it does not exist until that PR merges.
+
+PR #89 adds `divisor-curator.md` to the repository. The review council discovers Divisor personas by scanning for `divisor-*.md` files in `.opencode/agents/`. During the review of PR #89, the file `divisor-curator.md` exists in the diff but is not yet deployed — the review council runs against the current state of the repository, not the proposed state.
+
+This means:
+
+1. PR #89 was reviewed by the existing 8 personas (Guard, Architect, Adversary, SRE, Tester, Scribe, Herald, Envoy)
+2. The Curator could not participate in its own review because it did not exist yet
+3. After PR #89 merged, The Curator became active for all subsequent PRs
+4. The first PR that The Curator actually reviewed was the one after its own creation
+
+This is a genuine self-referential problem in self-modifying agent systems. The Curator's first act of documentation governance could not apply to the documentation of its own creation.
+
+**Decision**: The bootstrap paradox is the most narratively interesting design insight. Frame it as a real engineering problem, not a hypothetical — describe what actually happened during PR #89's review cycle.
+
+## R4: Existing Divisor Team Page — Current State
+
+**Question**: What does the Divisor team page currently say, and how does The Curator change the count?
+
+**Source**: `content/docs/team/the-divisor.md` (local)
+
+**Findings**:
+
+The current team page describes:
+
+- **Title/description**: "eight sub-personas for code review and content creation"
+- **5 review personas**: Guard, Architect, Adversary, SRE (Operator), Tester
+- **3 content creation personas**: Scribe, Herald, Envoy
+- **Total**: 8 personas
+
+The Curator is the 9th persona. It is neither a pure review persona nor a pure content creation persona — it is a triage persona that bridges the gap. It reviews code for documentation impact and files issues for the content agents to act on.
+
+The blog post should state: The Curator is the 9th Divisor persona, joining the existing five review personas and three content creation personas. It occupies a new category — documentation triage — that connects the review and content creation sides of the council.
+
+**Decision**: State "9th persona" clearly. Note the new category (triage) that The Curator occupies. Do not modify the team page — that is out of scope per the spec.
+
+## R5: Triage vs Creation Separation — The Content Pipeline
+
+**Question**: How does the triage/creation separation work across the Divisor council?
+
+**Source**: Agent definition files (Curator, Scribe, Herald, Envoy), PR #84 (content agents)
+
+**Findings**:
+
+The Divisor council now has three functional layers:
+
+1. **Review** (5 personas): Guard, Architect, Adversary, SRE, Tester — evaluate code quality
+2. **Triage** (1 persona): Curator — identifies documentation gaps and files tracking issues
+3. **Creation** (3 personas): Scribe, Herald, Envoy — produce documentation, blog posts, and communications
+
+The flow is:
+
+1. A PR changes user-facing behavior (e.g., new CLI command)
+2. The Curator detects the documentation gap during review
+3. The Curator files a GitHub issue in `unbound-force/website` with the appropriate label (`docs`, `blog`, or `tutorial`)
+4. The content agents (Scribe, Herald, Envoy) pick up those issues and create the content
+
+This separation exists because detection and creation require different capabilities:
+
+- Detection needs `read` + `bash` (to read diffs and file issues)
+- Creation needs `write` + `edit` (to produce content files)
+- Combining both in one agent would violate the principle of least privilege
+
+**Decision**: The triage/creation separation is a clean separation of concerns story. Frame it as: "The Curator files the ticket. The Scribe writes the docs. The Herald writes the blog post. No single agent does everything."
+
+## R6: Blog Post Frontmatter Pattern
+
+**Question**: What frontmatter format and weight should the new post use?
+
+**Source**: Existing blog posts in `content/blog/`
+
+**Findings**:
+
+Current blog post weights (lower = higher in sidebar):
+
+| Weight | Post                       | Slug                      |
+| ------ | -------------------------- | ------------------------- |
+| 58     | Dewey Curator blog         | dewey-curator             |
+| 60     | Librarian vs Index         | dewey-vs-karpathy         |
+| 70     | AI Agent Doesn't Read Docs | dewey-knowledge-retrieval |
+| 80     | From Spec to Demo          | unleash-in-practice       |
+| 90     | Gaze in Practice           | gaze-in-practice          |
+| 100    | Why Contract Coverage      | why-contract-coverage     |
+
+All posts use:
+
+```yaml
+categories: ["Engineering"]
+contributors: ["Unbound Force"]
+```
+
+Tags vary by topic. Slugs are descriptive and URL-friendly.
+
+**Decision**: Use `weight: 56` to place the new post above the Dewey Curator blog post (58) in sidebar ordering — it is the most recent post. Use `slug: "introducing-the-curator"` for a descriptive URL. Tags: `["divisor", "documentation", "code-review", "agents"]`. Categories: `["Engineering"]`.
+
+## R7: Predecessor Blog Post Pattern — Spec 021
+
+**Question**: What pattern did the Dewey Curator blog post (spec 021) establish that this post should follow?
+
+**Source**: `specs/021-dewey-curator-blog/plan.md`, `content/blog/dewey-curator-blog.md`
+
+**Findings**:
+
+Spec 021 established these patterns:
+
+1. **Narrative structure**: Problem → Technical details → Lessons learned. Not a feature announcement.
+2. **No CLI duplication**: All CLI syntax linked to docs pages, never inlined in the post.
+3. **Internal links**: Link to getting-started guides and project pages for readers who want to try features.
+4. **Honest scoping**: "We are not overclaiming the maturity of these features" — acknowledge limitations.
+5. **Word count**: 1200-1800 words target.
+6. **No time-sensitive language**: No "just shipped," "this week," "recently."
+7. **Source attribution**: Every factual claim traceable to a specific PR or spec.
+
+**Decision**: Follow the same pattern. The three-section structure (Problem → Solution → Interesting Bits) is this post's equivalent of spec 021's five-section structure. Same rules apply: no CLI duplication, honest scoping, source attribution.
+
+## R8: Heuristic Limitations — Honest Scoping
+
+**Question**: What are The Curator's actual limitations that the post must acknowledge?
+
+**Source**: Agent definition file, spec edge cases
+
+**Findings**:
+
+The Curator's detection is heuristic, not semantic:
+
+1. **File-path matching**: The Curator classifies files as user-facing or internal based on path patterns. A change to `cmd/foo.go` triggers documentation checks. A change to `internal/bar.go` does not. But a change to `internal/scaffold/baz.go` does (because scaffold output affects what `uf init` deploys).
+
+2. **No content analysis**: The Curator does not read the content of changed files to determine whether documentation is actually needed. It uses path patterns as a proxy. A cosmetic refactoring of a CLI command (no behavior change) would still trigger a documentation gap warning if the file is in a user-facing path.
+
+3. **No semantic understanding**: The Curator does not understand whether existing documentation already covers the change. It checks whether documentation files were modified in the same PR, not whether the existing docs are already accurate.
+
+4. **Duplicate detection is keyword-based**: The `gh issue list --search` command uses keyword matching, not semantic similarity. A documentation gap issue titled "docs: update CLI reference for new flag" might not match a search for "CLI documentation update."
+
+**Decision**: The post must acknowledge these limitations per FR-013 and the spec's edge cases. Frame as: "The Curator uses heuristic file-path matching, not semantic understanding. It is a first-pass filter, not an oracle."

--- a/specs/022-curator-blog/spec.md
+++ b/specs/022-curator-blog/spec.md
@@ -1,0 +1,127 @@
+# Feature Specification: Introducing The Curator Blog Post
+
+**Feature Branch**: `022-curator-blog`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "issue #36 — blog: Introducing The Curator — automated documentation governance for AI agent teams"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — The Curator's Role and Why It Exists (Priority: P1)
+
+A reader learns what The Curator is, why documentation drift is a persistent problem in AI agent workflows, and how The Curator addresses it. The post explains the gap: agents can ship features without documentation updates because no one checks. The Curator is a Divisor persona that runs during every code review, detects documentation gaps, and auto-files GitHub issues to track them.
+
+**Why this priority**: This is the core premise of the blog post. Without explaining what The Curator does and why it matters, the rest of the post has no foundation. The problem (documentation drift in AI agent teams) is relatable to anyone using AI coding agents.
+
+**Independent Test**: A reader with no prior knowledge of the Unbound Force swarm can understand the documentation drift problem and the Curator's solution after reading this section. The post is self-contained — it does not require reading prior blog posts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader unfamiliar with Unbound Force, **When** they read the post, **Then** they understand the documentation drift problem and how The Curator addresses it.
+2. **Given** a reader familiar with AI coding agents, **When** they read the post, **Then** they recognize the documentation drift pattern from their own experience.
+3. **Given** a reader, **When** they finish reading, **Then** they understand that The Curator triages documentation gaps (identifies and files issues) but does not create the documentation itself — that separation of concerns is deliberate.
+
+---
+
+### User Story 2 — Technical Design Insights (Priority: P1)
+
+A technical reader learns three interesting design decisions from building The Curator: (1) it is the first Divisor agent with bash access, restricted to `gh` CLI only, (2) the bootstrap paradox — The Curator cannot review its own creation because it does not exist yet during its own PR, and (3) the separation between triage (Curator) and creation (Scribe/Herald/Envoy).
+
+**Why this priority**: Design insights are what make technical blog posts shareable. The bootstrap paradox is a genuinely interesting problem that developers encounter in self-referential systems. These insights elevate the post beyond a feature announcement.
+
+**Independent Test**: A technical reader can identify and articulate at least two design patterns from the post (bash restriction, bootstrap paradox, or triage/creation separation) that they could apply to their own agent architectures.
+
+**Acceptance Scenarios**:
+
+1. **Given** a technical reader, **When** they read about bash access, **Then** they understand why The Curator needs shell access (to run `gh issue create`) and why it is restricted to only `gh` CLI commands.
+2. **Given** a technical reader, **When** they read about the bootstrap paradox, **Then** they understand the self-referential problem: The Curator cannot review the PR that creates it, because it does not exist until that PR merges.
+3. **Given** a technical reader, **When** they read about triage vs creation, **Then** they understand why The Curator files issues rather than creating documentation directly — and how Scribe, Herald, and Envoy handle the creation side.
+
+---
+
+### User Story 3 — Links to Documentation and Context (Priority: P2)
+
+A reader who wants to learn more about The Divisor council, the existing personas, or how to configure The Curator can follow links to the relevant documentation pages on the Unbound Force website.
+
+**Why this priority**: The blog post should drive readers to authoritative reference material rather than duplicating it. This is the same pattern established in spec 021 (Dewey curator blog) — narrative in the post, reference in the docs.
+
+**Independent Test**: Every internal link in the post resolves to a valid page. The post links to at least the Divisor team page and the getting-started guide.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader who wants to understand the full Divisor council, **When** they click a link, **Then** they arrive at the Divisor team page with all persona descriptions.
+2. **Given** a reader who wants to configure The Curator, **When** they look for setup instructions, **Then** the post links to the relevant docs or notes that The Curator is auto-discovered by the review council.
+
+---
+
+### Edge Cases
+
+- The post must not overclaim The Curator's intelligence — it uses heuristic checks (file paths in the diff vs documentation pages), not semantic understanding of whether documentation is actually needed. Be honest about the limitations.
+- The post must handle the persona count carefully — the existing team page says 8 personas (5 review + 3 content creation). The Curator is a 9th persona. The post should state the updated count clearly.
+- The post must not duplicate agent configuration syntax or `gh` CLI commands — link to docs instead.
+- The post must avoid time-sensitive language ("just shipped," "this week") — the frontmatter date provides temporal context.
+- The bootstrap paradox story must be technically accurate — describe what actually happened during the PR, not a hypothetical scenario.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The blog post MUST be a single Markdown file at `content/blog/curator-blog.md` with valid Hugo/Doks frontmatter (title, description, lead, slug, date, draft, weight, toc, categories, tags, contributors).
+- **FR-002**: The post MUST follow the three-section structure from issue #36: (1) The Problem — documentation drift, (2) The Solution — a dedicated triage agent, (3) The Interesting Bits — bash access, bootstrap paradox, triage vs creation separation.
+- **FR-003**: The post MUST explain the documentation drift problem: agents ship features without documentation updates, and without a dedicated checker, these gaps accumulate silently.
+- **FR-004**: The post MUST explain The Curator's role: it runs during every code review, checks for documentation gaps, and auto-files GitHub issues to track them.
+- **FR-005**: The post MUST explain the triage vs creation separation: The Curator identifies gaps and files issues, while The Scribe (tech docs), The Herald (blog/announcements), and The Envoy (communications) handle content creation.
+- **FR-006**: The post MUST describe The Curator's restricted bash access — the first Divisor agent with shell access, limited to `gh` CLI commands only.
+- **FR-007**: The post MUST describe the bootstrap paradox: The Curator cannot review the PR that creates it, because it does not exist yet during its own review. Describe how this was handled in practice.
+- **FR-008**: The post MUST link to the Divisor team page and at least one other internal documentation page for deeper context.
+- **FR-009**: The post MUST NOT contain implementation details that will drift (agent prompt contents, specific heuristic rules, `gh` CLI syntax). These details live in the agent definition file and docs.
+- **FR-010**: The post MUST NOT use time-sensitive language ("just shipped," "this week," "recently"). The frontmatter date provides temporal context.
+- **FR-011**: The post MUST accurately state that The Curator is the 9th Divisor persona (or whatever the correct count is at implementation time), joining the existing review and content creation personas.
+- **FR-012**: The post MUST source all factual claims from upstream PR #89 (unbound-force/unbound-force) and spec 026-documentation-curation. No capabilities may be fabricated or overstated.
+- **FR-013**: The post MUST NOT overclaim The Curator's capabilities — acknowledge that it uses heuristic file-path matching, not semantic understanding, to detect documentation gaps.
+- **FR-014**: The site MUST build successfully (`npm run build`) with no errors after adding the new blog post.
+- **FR-015**: The post MUST render correctly in both light and dark mode with the Doks theme.
+
+## Scope & Constraints
+
+### In Scope
+
+- One new blog post file at `content/blog/curator-blog.md`.
+- The three-section narrative structure from issue #36.
+- Links to existing documentation pages (Divisor team page, getting-started guides).
+
+### Out of Scope
+
+- Changes to existing blog posts or documentation pages.
+- Updates to the Divisor team page to add The Curator persona (that should be a separate spec if the team page is not already updated).
+- Changes to the homepage, navigation, or site structure.
+- The Curator's agent definition file (`.opencode/agents/divisor-curator.md`) — that lives in the upstream `unbound-force/unbound-force` repo.
+- Documentation of The Curator's heuristic rules or prompt contents.
+
+## Dependencies & Assumptions
+
+### Dependencies
+
+- **Spec 021 (dewey-curator-blog)**: Established the pattern of narrative blog posts that link to docs instead of duplicating reference material. This spec follows the same pattern.
+- **Spec 019 (dewey-karpathy-blog)**: Established the blog post frontmatter format and style conventions.
+- **Upstream PR #89 (unbound-force/unbound-force)**: The source of truth for The Curator's implementation. Content must be derived from this PR and spec 026-documentation-curation.
+- **Divisor Architecture (Spec 005, upstream)**: Defines the Divisor framework and persona architecture that The Curator extends.
+
+### Assumptions
+
+- The blog section already exists on the site (6 published posts as of spec 021). No navigation or section setup is needed.
+- The post will use the same frontmatter format as existing blog posts (weight, categories, tags, contributors).
+- The Divisor team page already lists the 8 existing personas. The blog post will reference the updated count (9) but does not modify the team page itself. This means a reader who follows the blog post's link to the team page will temporarily see a stale count until a separate spec updates the team page.
+- The post targets a technical audience familiar with AI coding agents and code review automation, but not necessarily with the Unbound Force swarm. It should be accessible without prior Unbound Force knowledge.
+- The post will be approximately 1200-1800 words, matching the length of previous blog posts (dewey-vs-karpathy, dewey-curator).
+- The upstream PR #89 and spec 026 are the authoritative sources for all factual claims about The Curator's behavior and design.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: A reader with no prior Unbound Force knowledge can understand the documentation drift problem and The Curator's role after reading the post.
+- **SC-002**: A technical reader can identify at least two design insights (bash restriction, bootstrap paradox, or triage/creation separation) from the post.
+- **SC-003**: The post contains zero duplicated reference material — all agent configuration, CLI syntax, and heuristic rules are linked to docs, not inlined.
+- **SC-004**: The site builds successfully (`npm run build`) with zero errors and the post renders correctly in both light and dark mode.
+- **SC-005**: All internal links in the post resolve to valid pages. All factual claims are traceable to upstream source material (PR #89, spec 026).

--- a/specs/022-curator-blog/tasks.md
+++ b/specs/022-curator-blog/tasks.md
@@ -1,0 +1,122 @@
+# Tasks: Introducing The Curator Blog Post
+
+**Input**: Design documents from `/specs/022-curator-blog/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, quickstart.md
+
+**Tests**: No automated tests. Validation is manual: `npm run build` (zero errors) + visual verification in `npm run dev`.
+
+**Organization**: Tasks are grouped by user story. All tasks modify a single file (`content/blog/curator-blog.md`), so there are no parallel opportunities — tasks are strictly sequential.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify the build environment is healthy before creating new content.
+
+- [x] T001 Run `npm run build` and confirm zero errors — baseline build health before changes
+
+**Checkpoint**: Build passes. No pre-existing issues that could be confused with regressions from the new post.
+
+---
+
+## Phase 2: User Story 1 — The Curator's Role and Why It Exists (Priority: P1) 🎯 MVP
+
+**Goal**: Write the blog post with the three-section narrative structure from issue #36. A reader with no prior knowledge of Unbound Force understands the documentation drift problem and how The Curator addresses it. The post is self-contained.
+
+**Independent Test**: The post reads as a coherent narrative from problem → solution → interesting design insights. No CLI syntax or agent configuration is duplicated from docs.
+
+### Implementation for User Story 1
+
+- [x] T002 [US1] Create `content/blog/curator-blog.md` with frontmatter: title (`"Introducing The Curator — Automated Documentation Governance for AI Agent Teams"`), description, lead, slug (`introducing-the-curator`), date (`2026-04-11T00:00:00+00:00`), draft (`false`), weight (`56`), toc (`true`), categories (`["Engineering"]`), tags (`["divisor", "documentation", "code-review", "agents"]`), contributors (`["Unbound Force"]`). Match format from existing blog posts per research item R6.
+- [x] T003 [US1] Write Section 1 — "The Problem: Documentation Drift" in `content/blog/curator-blog.md`. Describe the documentation drift problem: AI agents ship features without documentation updates, and without a dedicated checker these gaps accumulate silently. Make the problem relatable to anyone using AI coding agents — the gap between code velocity and documentation velocity. Per FR-003, FR-012, spec US1 acceptance scenario 2.
+- [x] T004 [US1] Write Section 2 — "The Solution: A Dedicated Triage Agent" in `content/blog/curator-blog.md`. Explain The Curator's role: the 9th Divisor persona, runs during every code review, detects documentation gaps using file-path heuristics, and auto-files GitHub issues to track them. Explain the triage model — The Curator identifies gaps and files issues, while The Scribe (tech docs), The Herald (blog), and The Envoy (communications) handle content creation. State the persona count clearly: 9th persona joining 5 review + 3 content creation. Per FR-004, FR-005, FR-011, FR-013, research items R1, R2, R4, R5.
+- [x] T005 [US1] Write Section 3 — "The Interesting Bits" in `content/blog/curator-blog.md`. Cover three design insights: (1) **Bash access restriction** — first Divisor agent with shell access, restricted to `gh` CLI only, with The Adversary's "Gate Tampering" check enforcing compliance. Describe this as a trust architecture pattern: minimum capability + peer verification. (2) **The bootstrap paradox** — The Curator cannot review the PR that creates it because it does not exist until that PR merges. Describe what actually happened during PR #89: reviewed by existing 8 personas, The Curator's first review was the PR after its own creation. Frame as a real engineering story, not a hypothetical. (3) **Triage vs creation separation** — The Curator files the ticket, The Scribe writes the docs, The Herald writes the blog post. Detection needs `read` + `bash`; creation needs `write` + `edit`. Combining both would violate least privilege. Per FR-006, FR-007, FR-013, research items R2, R3, R5.
+- [x] T006 [US1] Write a brief closing paragraph in `content/blog/curator-blog.md`. Acknowledge The Curator's heuristic limitations honestly — file-path matching, not semantic understanding; a first-pass filter, not an oracle. Direct readers to the [Divisor team page](/docs/team/the-divisor/) for the full persona roster and the [getting-started guide](/docs/getting-started/developer/) for setup. No time-sensitive language. Per FR-008, FR-009, FR-010, FR-013, research item R8, quickstart.md D5.
+
+**Checkpoint**: The three-section blog post is complete. The narrative flows from problem → solution → design insights. All content is sourced from research.md (PR #89, spec 026, agent definition). No CLI syntax is inlined. Heuristic limitations are acknowledged.
+
+---
+
+## Phase 3: User Story 2 — Technical Design Insights (Priority: P1)
+
+**Goal**: Review and polish the post to ensure the three design insights (bash restriction, bootstrap paradox, triage/creation separation) are clearly communicated and independently valuable. A technical reader can identify and articulate at least two patterns they could apply to their own agent architectures.
+
+**Independent Test**: A technical reader can identify the trust architecture pattern (bash restriction + peer enforcement) and the triage/creation separation from the post without needing external context.
+
+### Implementation for User Story 2
+
+- [x] T007 [US2] Review Section 3 (The Interesting Bits) in `content/blog/curator-blog.md` for technical clarity. Verify: (1) the bash restriction is framed as a trust architecture pattern — minimum capability + peer verification, not just a configuration detail, (2) the bootstrap paradox is told as a concrete story from PR #89, not a hypothetical, (3) the triage/creation separation is explained with the capability rationale (read+bash vs write+edit). Refine prose as needed. Per US2 acceptance scenarios.
+- [x] T008 [US2] Verify The Curator's capabilities are not overclaimed in `content/blog/curator-blog.md`. Check: no claims of "semantic understanding," "intelligent detection," or similar. The Curator is described as using heuristic file-path matching. The limitations acknowledgment in the closing paragraph is clear and honest. Per FR-013, quickstart.md V9, research item R8.
+
+**Checkpoint**: Design insights are clearly communicated. A technical reader can identify at least two reusable patterns. No overclaiming.
+
+---
+
+## Phase 4: User Story 3 — Links to Documentation and Context (Priority: P2)
+
+**Goal**: Verify all internal links resolve to valid pages. CLI syntax and agent configuration are linked, not duplicated.
+
+**Independent Test**: Every internal link in the post resolves. No fenced code blocks contain agent configuration YAML, `gh` CLI commands, or heuristic path patterns.
+
+### Implementation for User Story 3
+
+- [x] T009 [US3] Verify all internal links in `content/blog/curator-blog.md` resolve to valid pages. Required links per quickstart.md V4: `/docs/team/the-divisor/` (Divisor team page), `/docs/getting-started/common-workflows/` (common workflows / code review), `/docs/getting-started/developer/` (developer getting-started guide). Fix any broken or missing links. Per FR-008, US3 acceptance scenarios.
+- [x] T010 [US3] Verify no fenced code blocks in `content/blog/curator-blog.md` contain agent frontmatter YAML, `gh issue create` commands, or heuristic path patterns. Command names and concepts may appear in prose but implementation syntax must link to docs. Per FR-009, quickstart.md V8.
+
+**Checkpoint**: All internal links resolve. No duplicated configuration or CLI syntax. Readers can follow links to authoritative reference docs.
+
+---
+
+## Phase 5: Polish & Verification
+
+**Purpose**: Final quality checks across all user stories before merge.
+
+- [x] T011 Verify word count of `content/blog/curator-blog.md` body text (excluding frontmatter) is 1200–1800 words. Adjust if outside range. Per spec constraint, quickstart.md V6.
+- [x] T012 Verify no time-sensitive language in `content/blog/curator-blog.md`: no "just shipped," "this week," "recently," "now available," or similar phrases. The frontmatter `date` field provides temporal context. Per FR-010, quickstart.md V7.
+- [x] T013 Run `npm run build` and confirm zero errors with the new blog post included. Per FR-014, quickstart.md V1.
+- [x] T014 Run `npm run dev` and visually verify `content/blog/curator-blog.md` renders correctly: title, lead text, table of contents, three sections with H2 headings, internal links clickable. Verify both light and dark mode. Per FR-015, quickstart.md V2, V3.
+
+**Checkpoint**: Post is publication-ready. Build passes, visual rendering is correct, all quality checks pass.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — confirms build health
+- **US1 (Phase 2)**: Depends on Phase 1 — creates the blog post file and writes all content
+- **US2 (Phase 3)**: Depends on Phase 2 — reviews and polishes design insight sections
+- **US3 (Phase 4)**: Depends on Phase 2 — verifies links and no duplicated syntax
+- **Polish (Phase 5)**: Depends on Phases 2, 3, 4 — final quality gate
+
+### Parallel Opportunities
+
+**None.** All tasks modify or review a single file (`content/blog/curator-blog.md`). Tasks must be executed sequentially.
+
+### Execution Strategy
+
+Sequential, single-file workflow:
+
+1. Phase 1: Verify build health (T001)
+2. Phase 2: Write the complete blog post (T002–T006)
+3. Phase 3: Polish design insight clarity (T007–T008)
+4. Phase 4: Verify links and no syntax duplication (T009–T010)
+5. Phase 5: Final quality checks (T011–T014)
+
+---
+
+## Notes
+
+- All content is sourced from research.md (PR #89, spec 026, agent definition file). No fabrication.
+- The post follows the same pattern established by spec 021 (dewey-curator-blog): narrative blog post that links to docs instead of duplicating reference material.
+- Agent configuration syntax, `gh` CLI commands, and heuristic rules live in the agent definition file and docs. The blog post describes concepts and design decisions only.
+- Commit after each phase checkpoint, not after individual tasks.
+
+<!-- spec-review: passed -->


### PR DESCRIPTION
## Summary

Adds a narrative blog post — "Introducing The Curator: Automated Documentation Governance for AI Agent Teams" — about the 9th Divisor persona that detects documentation gaps during code review and auto-files GitHub issues.

- Explains the documentation drift problem: agents ship features without updating docs, and nobody checks
- Introduces The Curator's role: runs during every code review, files `docs`/`blog`/`tutorial` issues for content agents (Scribe/Herald/Envoy) to fill
- Three design insights: bash access restriction with peer enforcement by The Adversary, the bootstrap paradox (Curator can't review its own creation PR), and triage vs creation separation
- Honest limitations section acknowledging heuristic file-path matching, not semantic understanding
- 1,664 words, zero fenced code blocks, no time-sensitive language

## Review Results

- **Spec review**: APPROVE (unanimous, 5/5 Divisor reviewers)
- **Code review**: APPROVE (unanimous, first pass, 13 factual claims verified)
- **Build**: passes with zero errors

Closes #36
