### PR TITLE
docs: sync v0.10.0/v0.11.0 upstream changes — Curator, gatekeeping, gitignore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,7 @@ GitHub Pages deployment via `.github/workflows/deploy-gh-pages.yml`:
 ## Active Technologies
 - Markdown (Hugo content file) + Hugo (via @thulite), Doks theme (`@thulite/doks-core`) (021-dewey-curator-blog)
 - N/A (static Markdown file) (021-dewey-curator-blog)
+- Markdown (Hugo content files) + Hugo (via @thulite), Doks theme (`@thulite/doks-core`) + N/A (static Markdown file edits only) (023-docs-v10-v11-sync)
 
 - Hugo (Go-based SSG) via `@thulite` npm packages + `thulite ^2.6.3`, `@thulite/doks-core ^1.8.3` (013-unleash-visibility)
 

--- a/content/docs/contributing/_index.md
+++ b/content/docs/contributing/_index.md
@@ -30,7 +30,7 @@ We follow the standard GitHub pull request workflow:
 4. Submit a pull request against the `main` branch
 5. Address any review feedback from The Divisor council
 
-All pull requests are reviewed by The Divisor — a council of eight sub-personas. Five review personas (The Guard, The Architect, The Adversary, The Operator (SRE), and The Tester) evaluate intent, structure, resilience, operational readiness, and test quality. Three content personas (The Scribe, The Herald, and The Envoy) ensure documentation, blog posts, and public communications meet quality standards. Collective approval from all active personas is required before merge.
+All pull requests are reviewed by The Divisor — a council of nine sub-personas. Six review personas (The Guard, The Architect, The Adversary, The Operator (SRE), The Tester, and The Curator) evaluate intent, structure, resilience, operational readiness, and test quality. Three content personas (The Scribe, The Herald, and The Envoy) ensure documentation, blog posts, and public communications meet quality standards. Collective approval from all active personas is required before merge.
 
 ## Conventional Commits
 

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -370,6 +370,7 @@ The council discovers available Divisor persona agents in `.opencode/agents/divi
 | **Adversary** | Security vulnerabilities, error handling, resilience, dependency risks                   |
 | **Testing**   | Test architecture, coverage strategy, assertion depth, test isolation                    |
 | **SRE**       | Release pipeline, dependency health, configuration, runtime observability                |
+| **Curator**   | Documentation gaps, blog/tutorial opportunities, website issue filing                    |
 
 ### CI Gate (Phase 1a and 1b)
 

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -254,6 +254,23 @@ Cobalt-Crush integrates with two feedback systems:
 - **Gaze feedback**: After writing code, checks `.uf/artifacts/quality-report/` for quality findings. High CRAP scores trigger complexity reduction; low contract coverage triggers test improvements.
 - **Divisor feedback**: Before submitting for review, validates against a pre-review checklist. After review, addresses findings by persona and severity (CRITICAL and HIGH first).
 
+### Gatekeeping Value Protection
+
+Certain values in the project are protected from modification by AI agents. When an agent encounters a quality gate it cannot meet, it stops and reports the conflict rather than weakening the gate. Modifying a gate without human authorization is a CRITICAL-severity constitution violation.
+
+The eight categories of protected values are:
+
+1. Coverage thresholds and CRAP scores
+2. Severity definitions and auto-fix policies
+3. Convention pack rule classifications (MUST/SHOULD)
+4. CI flags and linter configuration
+5. Agent temperature and tool-access settings
+6. Constitution MUST rules
+7. Review iteration limits and worker concurrency caps
+8. Workflow gate markers (e.g., `<!-- spec-review: passed -->`)
+
+The Guard checks for "Gatekeeping Integrity" during code review and the Adversary checks for "Gate Tampering" — both will flag unauthorized modifications to these values.
+
 ## Project Scaffolding with `uf init`
 
 `uf init` scaffolds the project files needed to work with the Unbound Force swarm -- agents, commands, templates, scripts, convention packs, OpenSpec schema, and skills. It runs automatically as the final step of `uf setup`, but you can also run it independently to re-scaffold, initialize a new project, or deploy a subset of the swarm.
@@ -276,14 +293,17 @@ uf init [--divisor] [--lang go|typescript] [--force]
 
 `uf init` deploys approximately 50 files across these categories:
 
-| Category         | Files | Examples                                                                                   |
-| ---------------- | ----- | ------------------------------------------------------------------------------------------ |
-| Agents           | ~12   | 5 Divisor personas, Cobalt-Crush, Constitution Check, Mx F Coach                           |
-| Commands         | ~15   | 9 Speckit commands, review-council, constitution-check, cobalt-crush                       |
-| Convention Packs | 9     | default, go, typescript, content (each with tool-owned and user-owned variants) + severity |
-| Templates        | ~6    | spec, plan, tasks, checklist, constitution, agent-file templates                           |
-| Scripts          | ~5    | check-prerequisites, setup-plan, create-new-feature, update-agent-context                  |
-| OpenSpec         | ~6    | config, schema, 4 templates (design, proposal, spec, tasks)                                |
+| Category         | Files   | Examples                                                                                   |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------ |
+| Agents           | ~12     | 6 Divisor personas, Cobalt-Crush, Constitution Check, Mx F Coach                           |
+| Commands         | ~15     | 9 Speckit commands, review-council, constitution-check, cobalt-crush                       |
+| Convention Packs | 9       | default, go, typescript, content (each with tool-owned and user-owned variants) + severity |
+| Templates        | ~6      | spec, plan, tasks, checklist, constitution, agent-file templates                           |
+| Scripts          | ~5      | check-prerequisites, setup-plan, create-new-feature, update-agent-context                  |
+| OpenSpec         | ~6      | config, schema, 4 templates (design, proposal, spec, tasks)                                |
+| `.gitignore`     | Managed | UF runtime and legacy tool ignore patterns                                                 |
+
+`uf init` also manages `.gitignore` entries. It appends a standard Unbound Force ignore block (marked with `# Unbound Force — managed by uf init`) that covers `.uf/` runtime data (databases, caches, locks, logs) and legacy tool directories (`.dewey/`, `.hive/`, `.unbound-force/`, `.muti-mind/`, `.mx-f/`). The behavior is append-only — existing `.gitignore` content is never modified or removed. If `.gitignore` does not exist, it is created. The operation is idempotent: running `uf init` multiple times does not duplicate the ignore block.
 
 File counts are approximate and may change between versions.
 

--- a/content/docs/getting-started/product-owner.md
+++ b/content/docs/getting-started/product-owner.md
@@ -106,7 +106,7 @@ If the spec looks right, approve it and the swarm proceeds. If intent drifted, p
 After implementation (stage 2), validation (stage 3), and review (stage 4) -- all run autonomously by the swarm -- the workflow pauses and the increment returns to you for acceptance:
 
 1. Review the **Gaze quality report** -- check contract coverage, CRAP scores, and over-specification
-2. Review the **Divisor review verdict** -- check that all 5 personas approved (or understand why they didn't)
+2. Review the **Divisor review verdict** -- check that all 6 personas approved (or understand why they didn't)
 3. Compare results against your **acceptance criteria** from stage 1
 4. Make your decision: accept, reject, or conditional
 

--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -22,7 +22,7 @@ uf setup
 - **Core tools** -- OpenCode (AI coding environment), Gaze (quality analysis), Mx F (manager hero), GitHub CLI
 - **Development tools** -- Node.js, OpenSpec CLI, Replicator (multi-agent coordination)
 - **Knowledge layer** -- Ollama (local model runtime), Dewey (semantic search), IBM Granite embedding model
-- **Project scaffolding** -- agents, commands, convention packs, templates, and workflow configuration via `uf init`
+- **Project scaffolding** -- agents, commands, convention packs, templates, workflow configuration, and `.gitignore` management via `uf init`
 
 Setup detects your version managers (goenv, nvm, fnm, Homebrew) and installs through them. Use `--dry-run` to preview what would be installed without making changes.
 

--- a/content/docs/getting-started/tester.md
+++ b/content/docs/getting-started/tester.md
@@ -101,7 +101,7 @@ As a tester, you can invoke the review council to get a comprehensive code revie
 /review-council
 ```
 
-The council launches 5 Divisor personas in parallel. The **Testing persona** is particularly relevant -- it evaluates:
+The council launches 6 Divisor personas in parallel. The **Testing persona** is particularly relevant -- it evaluates:
 
 - Test architecture and organization
 - Coverage strategy (is the right code being tested?)

--- a/content/docs/team/_index.md
+++ b/content/docs/team/_index.md
@@ -28,7 +28,7 @@ _The Quality Sentinel and Predictive Validation Engine._ Gaze protects the produ
 
 ### [The Divisor](/docs/team/the-divisor/) — PR Reviewer Council
 
-_The Architectural Conscience and Code Integrity Guardian._ The Divisor operates as a council of eight sub-personas — five for code review (The Guard, The Architect, The Adversary, The Operator (SRE), and The Tester) and three for content creation (The Scribe, The Herald, and The Envoy) — providing comprehensive, multi-faceted validation of every code and content submission.
+_The Architectural Conscience and Code Integrity Guardian._ The Divisor operates as a council of nine sub-personas — six for code review (The Guard, The Architect, The Adversary, The Operator (SRE), The Tester, and The Curator) and three for content creation (The Scribe, The Herald, and The Envoy) — providing comprehensive, multi-faceted validation of every code and content submission.
 
 ### [Mx F](/docs/team/mx-f/) — Manager
 

--- a/content/docs/team/the-divisor.md
+++ b/content/docs/team/the-divisor.md
@@ -1,6 +1,6 @@
 ---
 title: "The Divisor"
-description: "The Divisor is the PR Reviewer Council — eight sub-personas for code review and content creation, serving as the Code Integrity Guardian."
+description: "The Divisor is the PR Reviewer Council — nine sub-personas for code review and content creation, serving as the Code Integrity Guardian."
 lead: "The Architectural Conscience and Code Integrity Guardian"
 date: 2026-02-23T00:00:00+00:00
 draft: false
@@ -14,7 +14,7 @@ toc: true
 
 The Divisor is the PR Reviewer of the Unbound Force swarm — the architectural conscience and code integrity guardian. Their mission is to ensure that all code changes proposed by Cobalt-Crush, once validated by Gaze, adhere strictly to established architectural standards, best practices, security policies, and maintainability requirements.
 
-The Divisor acts as the final technical gate before integration, translating high-level architectural standards into actionable review criteria. What makes The Divisor unique is its structure: it operates as a **council of eight dynamically discovered personas** -- eight canonical roles ship by default (five review, three content creation), with users able to add or remove personas freely. Each provides a different lens on every code submission.
+The Divisor acts as the final technical gate before integration, translating high-level architectural standards into actionable review criteria. What makes The Divisor unique is its structure: it operates as a **council of nine dynamically discovered personas** -- nine canonical roles ship by default (six review, three content creation), with users able to add or remove personas freely. Each provides a different lens on every code submission.
 
 ## The Council
 
@@ -26,6 +26,7 @@ The Guard focuses on the _"Why"_ of the code. They ensure the pull request:
 - Adheres to the original user intent and acceptance criteria
 - Does not introduce feature bloat (**Zero-Waste Mandate**)
 - Is cohesive and does not negatively impact adjacent modules (**Neighborhood Rule**)
+- **Gatekeeping Integrity**: Checks whether any quality gates, thresholds, severity definitions, or governance rules were modified to make an implementation pass. Modifications to gates without human authorization are CRITICAL-severity findings.
 
 ### The Architect — Structure and Sustainability
 
@@ -44,6 +45,7 @@ The Adversary focuses on _"Where it breaks."_ They act as a skeptical auditor:
 - Identifying security vulnerabilities (SQLi, XSS, insecure mTLS)
 - Finding performance bottlenecks (O(n^2) loops, excessive API calls)
 - Enforcing behavioral constraints and robust error handling
+- **Gate Tampering**: Detects unauthorized modifications to coverage thresholds, CRAP scores, convention pack classifications, CI flags, agent temperature/tool-access settings, review iteration limits, or workflow gate markers.
 
 ### The Operator (SRE) — Deployment and Operational Readiness
 
@@ -102,28 +104,47 @@ The Envoy focuses on _"Does this build trust?"_ They produce and review public-f
 
 Temperature: **0.5** (most creative). Public communications benefit from the most creative latitude, but The Envoy's credibility constraints prevent overclaims.
 
+## Triage Persona
+
+### The Curator — Documentation & Content Pipeline Triage
+
+The Curator focuses on _"Is the documentation keeping up with the code?"_ It detects documentation gaps during every code review and files tracking issues for the content agents to fill:
+
+- Checking whether AGENTS.md and README are updated when user-facing code changes
+- Filing `docs`-labeled GitHub issues in the website repository for missing documentation
+- Identifying blog-worthy changes and filing `blog`-labeled issues
+- Identifying tutorial-worthy workflows and filing `tutorial`-labeled issues
+- Checking for duplicate issues before filing new ones
+
+Temperature: **0.2** (judgment-based). The Curator makes classification decisions (is this change user-facing? does documentation exist?) that benefit from consistent, conservative judgment.
+
+The Curator is the first Divisor persona with bash access, restricted to `gh issue list` and `gh issue create`. The Adversary's "Gate Tampering" check monitors for bash misuse — a trust architecture pattern where minimum capability is granted and a peer agent verifies compliance.
+
+**Important**: The Curator triages — it identifies what needs documenting and files tracking issues. It does not write documentation, blog posts, or communications. Those responsibilities belong to The Scribe, The Herald, and The Envoy respectively.
+
 ## Exclusive Ownership Boundaries
 
 Each review dimension is owned by exactly one Divisor persona, eliminating duplicate findings across personas:
 
-| Dimension                                   | Owner     |
-| ------------------------------------------- | --------- |
-| Secrets/credentials                         | Adversary |
-| Dependency CVEs/supply chain                | Adversary |
-| Error handling/resilience                   | Adversary |
-| Test isolation/coverage/depth               | Tester    |
-| Plan alignment/intent drift                 | Guard     |
-| Zero-waste mandate                          | Guard     |
-| Constitution alignment                      | Guard     |
-| File permissions/hardcoded config           | SRE       |
-| Efficiency/performance (O(n²), allocations) | SRE       |
-| Architectural patterns/conventions          | Architect |
+| Dimension                                   | Owner                                                                                                                   |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Secrets/credentials                         | Adversary                                                                                                               |
+| Dependency CVEs/supply chain                | Adversary                                                                                                               |
+| Error handling/resilience                   | Adversary                                                                                                               |
+| Test isolation/coverage/depth               | Tester                                                                                                                  |
+| Plan alignment/intent drift                 | Guard                                                                                                                   |
+| Zero-waste mandate                          | Guard                                                                                                                   |
+| Constitution alignment                      | Guard                                                                                                                   |
+| File permissions/hardcoded config           | SRE                                                                                                                     |
+| Efficiency/performance (O(n²), allocations) | SRE                                                                                                                     |
+| Architectural patterns/conventions          | Architect                                                                                                               |
+| **The Curator**                             | Documentation & content pipeline triage — gap detection, website issue filing, blog/tutorial opportunity identification |
 
 This ownership model ensures that a finding like "missing error handling" is raised by exactly one persona (Adversary), not duplicated across Adversary and Architect.
 
 ## Shared Severity Standard
 
-All eight personas share a calibration standard defined in the `severity.md` convention pack (`.opencode/uf/packs/severity.md`):
+All nine personas share a calibration standard defined in the `severity.md` convention pack (`.opencode/uf/packs/severity.md`):
 
 | Level        | Definition                                                                           | Auto-Fix?                    |
 | ------------ | ------------------------------------------------------------------------------------ | ---------------------------- |
@@ -136,7 +157,7 @@ Each level includes domain-specific examples per persona — for example, an Adv
 
 ## Prior Learnings Integration
 
-All eight Divisor personas include a "Prior Learnings" step at the start of their review workflow:
+All nine Divisor personas include a "Prior Learnings" step at the start of their review workflow:
 
 1. Search Dewey for learnings tagged with the repo name and relevant file paths
 2. Include found learnings as prior knowledge in the review context
@@ -148,11 +169,11 @@ This means the review council learns from past reviews. If a particular pattern 
 
 The Divisor holds the ultimate authority to approve and merge code into the main branch. Approval requires collective consensus — **no outstanding REQUEST CHANGES from any persona** is mandatory. Gaze's functional validation serves as a prerequisite: the CI pipeline must be green before The Divisor begins review.
 
-This structure ensures that only code which passes all eight lenses — intent, architecture, resilience, operational readiness, test quality, documentation accuracy, narrative clarity, and public communication — is deployed.
+This structure ensures that only code which passes all nine lenses — intent, architecture, resilience, operational readiness, test quality, documentation governance, documentation accuracy, narrative clarity, and public communication — is deployed.
 
 ## How The Divisor Serves the Team
 
-**For Developers (Cobalt-Crush):** Cobalt-Crush relies on The Divisor for the final technical sign-off. The multi-faceted feedback from the eight personas provides a holistic critique covering intent, structure, security, operational readiness, test quality, and content accuracy. Clear architectural standards minimize uncertainty, allowing Cobalt-Crush to code with confidence.
+**For Developers (Cobalt-Crush):** Cobalt-Crush relies on The Divisor for the final technical sign-off. The multi-faceted feedback from the nine personas provides a holistic critique covering intent, structure, security, operational readiness, test quality, documentation governance, and content accuracy. Clear architectural standards minimize uncertainty, allowing Cobalt-Crush to code with confidence.
 
 **For the Tester (Gaze):** Gaze relies on The Divisor to establish the architectural and non-functional requirements against which testability must be measured. Gaze's green light on functional tests is the entry criterion for The Divisor's review, ensuring review time is spent on high-level risk and structure rather than defect finding.
 

--- a/specs/023-docs-v10-v11-sync/checklists/requirements.md
+++ b/specs/023-docs-v10-v11-sync/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: v0.10.0 / v0.11.0 Documentation Sync
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-11  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- This spec consolidates three GitHub issues (#33, #34, #35) into a single docs sync because they affect overlapping pages.
+- The Divisor team page is the most-touched file (affected by all three issues — Curator persona, persona count, gatekeeping audit items).
+- FR-001 identifies 7 word-level occurrences of "eight" across 6 lines (line 17 has two) — implementation should verify no additional occurrences exist beyond those inventoried in research.md.
+- Gatekeeping documentation (FR-007) must describe categories and behavior, not specific threshold values.

--- a/specs/023-docs-v10-v11-sync/plan.md
+++ b/specs/023-docs-v10-v11-sync/plan.md
@@ -1,0 +1,182 @@
+# Implementation Plan: v0.10.0 / v0.11.0 Documentation Sync
+
+**Branch**: `023-docs-v10-v11-sync` | **Date**: 2026-04-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/023-docs-v10-v11-sync/spec.md`
+
+## Summary
+
+Synchronize website documentation with three upstream changes from `unbound-force/unbound-force`: The Curator agent (PR #89), gatekeeping value protection rules (PR #85), and `.gitignore` management via `uf init` (PR #87). This is a content-only update to 6 existing Markdown pages — no new pages, no layout changes, no code. The highest-priority fix resolves a persona count contradiction between the published Curator blog post ("nine personas") and the Divisor team page ("eight personas").
+
+## Technical Context
+
+**Language/Version**: Markdown (Hugo content files) + Hugo (via @thulite), Doks theme (`@thulite/doks-core`)
+**Primary Dependencies**: N/A (static Markdown file edits only)
+**Storage**: N/A (static site, no database)
+**Testing**: Manual — `npm run build` must succeed; visual verification of 6 pages in light and dark mode
+**Target Platform**: GitHub Pages (static site)
+**Project Type**: Documentation website (Hugo SSG)
+**Performance Goals**: N/A (no runtime performance impact — static content)
+**Constraints**: All content must be sourced from upstream PRs #85, #87, #89. No fabrication.
+**Scale/Scope**: 6 existing pages, ~85 lines of Markdown changes
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+### Pre-Research Check
+
+| Principle                 | Verdict | Rationale                                                                                                                                                                                                                                                                                                   |
+| ------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **I. Content Accuracy**   | ✅ PASS | All content is sourced from merged upstream PRs (#85, #87, #89) indexed in Dewey. The Curator agent definition file (`.opencode/agents/divisor-curator.md`) is available locally. No capabilities are fabricated. The persona count update from "eight" to "nine" corrects an existing inaccuracy.          |
+| **II. Minimal Footprint** | ✅ PASS | All changes are Markdown edits to existing pages. No new pages, no custom HTML, no SCSS, no JavaScript, no new dependencies. This is the simplest possible implementation.                                                                                                                                  |
+| **III. Visitor Clarity**  | ✅ PASS | The primary fix (persona count consistency) directly improves visitor clarity — a reader following the blog post link to the team page will no longer encounter contradictory information. Gatekeeping and `.gitignore` documentation help developers understand agent behavior and `uf init` side effects. |
+
+### Post-Design Re-Check
+
+| Principle                 | Verdict | Rationale                                                                                                                                                                                                                                                                                                                                                         |
+| ------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **I. Content Accuracy**   | ✅ PASS | Research phase confirmed all source material via Dewey semantic search. Eight protected value categories verified against upstream `AGENTS.md`. Curator audit checklist verified against local agent definition file. `.gitignore` behavior verified against upstream OpenSpec design doc.                                                                        |
+| **II. Minimal Footprint** | ✅ PASS | No design artifacts (data-model, contracts) are needed — this is pure content. The quickstart.md verification steps use only existing tooling (`npm run build`, `npm run dev`, `grep`).                                                                                                                                                                           |
+| **III. Visitor Clarity**  | ✅ PASS | Each content addition serves a clear visitor purpose: (1) Curator documentation lets blog readers find consistent information, (2) gatekeeping documentation explains why agents stop mid-implementation, (3) `.gitignore` documentation explains expected `uf init` side effects. No content is added without a clear "why should a visitor care" justification. |
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-docs-v10-v11-sync/
+├── spec.md              # Feature specification (3 consolidated GitHub issues)
+├── plan.md              # This file
+├── research.md          # Phase 0 output — upstream PR research via Dewey
+└── quickstart.md        # Phase 1 output — verification steps and file change map
+```
+
+No data-model.md or contracts/ needed — this is a content-only change with no data structures, APIs, or interfaces.
+
+### Source Code (repository root)
+
+```text
+content/
+├── docs/
+│   ├── team/
+│   │   ├── the-divisor.md       # FR-001 through FR-003, FR-008 (Curator + gatekeeping audit items)
+│   │   └── _index.md            # FR-004 (persona count update)
+│   ├── contributing/
+│   │   └── _index.md            # FR-005 (persona count update)
+│   └── getting-started/
+│       ├── common-workflows.md  # FR-006 (Curator in code review table)
+│       ├── developer.md         # FR-007, FR-009, FR-010 (gatekeeping + .gitignore docs)
+│       └── quick-start.md       # FR-011 (.gitignore mention)
+```
+
+**Structure Decision**: No new files or directories. All changes are edits to existing content files in the established Hugo content structure.
+
+## Implementation Strategy
+
+### Phase 1: The Curator — Persona Count Consistency (P1)
+
+**Priority**: Highest. Resolves the blog post ↔ team page contradiction.
+
+**Scope**: 5 pages affected (the-divisor.md, team/\_index.md, contributing/\_index.md, common-workflows.md, the-divisor.md ownership table).
+
+**Approach**:
+
+1. **the-divisor.md — Count updates** (FR-001): Replace all 6 occurrences of "eight" with "nine" in persona count contexts. The word "eight" will still appear in the new gatekeeping section (referring to eight protected value categories), which is correct and distinct from persona counts.
+
+2. **the-divisor.md — Curator section** (FR-002): Add a new subsection under "Content Creation Personas" (or as a new "Triage Persona" section between review and content creation). The Curator is functionally distinct from both review and content creation — it's a triage layer. The section structure should be:
+   - Role description: Documentation & Content Pipeline Triage
+   - Five audit checklist items (numbered list)
+   - Bash access restriction: `gh` CLI only (`gh issue list`, `gh issue create`)
+   - Scope boundary: triage, not creation
+   - Temperature: 0.2
+
+   **Design decision**: Place The Curator in a new "Triage Persona" section between "Content Creation Personas" and "Exclusive Ownership Boundaries." This mirrors the three-layer model described in the blog post (Review → Triage → Creation) and avoids misclassifying The Curator as a content creation persona.
+
+3. **the-divisor.md — Ownership table** (FR-003): Add a row for The Curator with its exclusive domain: "Documentation & content pipeline triage."
+
+4. **the-divisor.md — Lens count** (implicit): The "Collective Approval" section lists eight lenses. Update to nine and add "documentation triage" to the list.
+
+5. **team/\_index.md** (FR-004): Update the Divisor summary from "eight sub-personas" to "nine sub-personas" and add "The Curator" to the parenthetical list.
+
+6. **contributing/\_index.md** (FR-005): Update the Divisor description from "eight sub-personas" to "nine sub-personas." Add "The Curator" to the persona enumeration. Update "Five review personas" to "Six review personas" to include The Curator in the review-adjacent count (since The Curator runs during code review).
+
+7. **common-workflows.md** (FR-006): Add a Curator row to the code review persona evaluation table:
+   ```
+   | **Curator** | Documentation gaps, blog/tutorial opportunities, website issue filing |
+   ```
+
+### Phase 2: Gatekeeping Value Protection (P2)
+
+**Scope**: 2 pages affected (developer.md, the-divisor.md).
+
+**Approach**:
+
+1. **developer.md — Gatekeeping section** (FR-007): Add a new section titled "Gatekeeping Value Protection" after the "Feedback Loops" section (or within the "Cobalt-Crush Persona" section, since gatekeeping is a behavioral constraint on the developer agent). Content:
+   - Brief explanation: certain values are protected from modification by AI agents
+   - The eight protected categories (numbered list, sourced from upstream AGENTS.md)
+   - The "stop and report" behavior: when an agent cannot meet a gate, it stops and reports the conflict rather than weakening the gate
+   - Note: modifying a gate without human authorization is a CRITICAL-severity constitution violation
+
+   **Design decision**: Place this section under "Cobalt-Crush Persona" as a subsection after "Feedback Loops." Gatekeeping is a behavioral constraint that directly affects how Cobalt-Crush operates — it's the reason the developer agent sometimes stops mid-implementation. This placement makes it discoverable in the context where a developer would encounter the behavior.
+
+2. **the-divisor.md — Guard and Adversary audit items** (FR-008): Add brief mentions of the new audit items:
+   - Under The Guard section: Add "Gatekeeping Integrity" — detects unauthorized modifications to quality gates
+   - Under The Adversary section: Add "Gate Tampering" — detects removal or weakening of CI security controls
+
+### Phase 3: `.gitignore` Management (P2)
+
+**Scope**: 2 pages affected (developer.md, quick-start.md).
+
+**Approach**:
+
+1. **developer.md — `uf init` `.gitignore` docs** (FR-009, FR-010): Add `.gitignore` documentation to the "Project Scaffolding with `uf init`" section:
+   - Add `.gitignore` to the "What Gets Deployed" table as a new category row
+   - Add a subsection or paragraph explaining the behavior:
+     - Append-only: never overwrites existing `.gitignore` content
+     - Idempotent: marker comment `# Unbound Force — managed by uf init` prevents duplicate blocks
+     - Creates `.gitignore` if it does not exist
+     - Two categories of ignored entries: `.uf/` runtime data and legacy tool directories
+
+   **Design decision**: Add `.gitignore` as a row in the existing "What Gets Deployed" table rather than creating a separate subsection. The table already documents what `uf init` deploys, and `.gitignore` is just another file it manages. A brief paragraph after the table explains the append-only/idempotent behavior for readers who want details.
+
+2. **quick-start.md — `.gitignore` mention** (FR-011): Add `.gitignore` management to the `uf setup` bullet list. Brief mention only — the developer guide has the details. Something like adding "`.gitignore` configuration" to the "Project scaffolding" bullet.
+
+### Cross-Cutting Concerns
+
+- **FR-012 (Content Accuracy)**: All content sourced from Dewey-indexed upstream PRs and the local agent definition file. Research.md documents every source.
+- **FR-013 (Build Success)**: `npm run build` run after each phase as a checkpoint.
+- **FR-014 (Light/Dark Mode)**: Visual verification after all changes. No custom CSS is added, so dark mode should work automatically via Doks theme.
+- **FR-015 (No Placeholders)**: No placeholder text, "Coming Soon," or TODO markers in any content.
+
+## Risk Assessment
+
+| Risk                                           | Likelihood | Impact                                  | Mitigation                                                                                                    |
+| ---------------------------------------------- | ---------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Missing an "eight" occurrence                  | Low        | Medium — creates internal inconsistency | Grep audit in research.md identified all occurrences. Post-implementation grep verification in quickstart.md. |
+| Curator section placement breaks page flow     | Low        | Low — can be repositioned               | Blog post establishes the Review → Triage → Creation model. Follow that structure.                            |
+| `.gitignore` documentation overstates behavior | Low        | Medium — violates Content Accuracy      | Source strictly from PR #87 summary and OpenSpec design doc. Do not add details not in the source.            |
+| Hugo build failure from malformed Markdown     | Low        | High — blocks deployment                | Run `npm run build` after each phase. Fix immediately.                                                        |
+
+## Dependency Graph
+
+```
+Phase 1 (Curator/counts) ──→ Phase 2 (Gatekeeping) ──→ Phase 3 (.gitignore)
+```
+
+Phases are sequential because:
+
+- Phase 1 and Phase 2 both modify `the-divisor.md` — concurrent edits risk merge conflicts
+- Phase 2 and Phase 3 both modify `developer.md` — same reason
+- Phase 1 is highest priority (P1) and should complete first
+
+Within each phase, tasks that touch different files could theoretically be parallelized, but the small scope (~85 lines total) makes sequential execution simpler and less error-prone.
+
+## Next Steps
+
+1. Run `/speckit.tasks` to generate the task breakdown from this plan
+2. Run `/speckit.analyze` for cross-artifact consistency
+3. Run `/speckit.checklist` for requirement quality validation
+4. Commit spec artifacts and push (Spec Commit Gate)
+5. Run `/speckit.implement` to execute

--- a/specs/023-docs-v10-v11-sync/quickstart.md
+++ b/specs/023-docs-v10-v11-sync/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart: v0.10.0 / v0.11.0 Documentation Sync
+
+**Branch**: `023-docs-v10-v11-sync` | **Date**: 2026-04-11
+
+## Overview
+
+This is a content-only documentation sync — no new pages, no layout changes, no SCSS, no JavaScript. All changes are Markdown edits to 6 existing pages in `content/`.
+
+## Verification Steps
+
+### 1. Build Verification
+
+```bash
+npm run build
+```
+
+Must complete with zero errors. This is the primary gate — Hugo will fail if any frontmatter is malformed or internal links are broken.
+
+### 2. Persona Count Consistency Check
+
+After all changes, verify zero occurrences of "eight" in the context of Divisor/personas remain:
+
+```bash
+grep -rn "eight" content/docs/team/the-divisor.md content/docs/team/_index.md content/docs/contributing/_index.md
+```
+
+Expected: Only the word "eight" should appear in the context of the **eight protected value categories** (gatekeeping section), NOT in the context of persona counts.
+
+### 3. Visual Verification
+
+```bash
+npm run dev
+```
+
+Check each affected page in the browser at `http://localhost:1313/`:
+
+| Page             | URL                                       | What to Check                                                                                                          |
+| ---------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| The Divisor      | `/docs/team/the-divisor/`                 | Curator section present, persona count = nine, ownership table has Curator row, Guard/Adversary audit items documented |
+| Team Index       | `/docs/team/`                             | Divisor summary says "nine sub-personas"                                                                               |
+| Contributing     | `/docs/contributing/`                     | Divisor description says "nine sub-personas"                                                                           |
+| Common Workflows | `/docs/getting-started/common-workflows/` | Code review table has 6 rows (includes Curator)                                                                        |
+| Developer Guide  | `/docs/getting-started/developer/`        | Gatekeeping section present, `.gitignore` in `uf init` docs                                                            |
+| Quick Start      | `/docs/getting-started/quick-start/`      | `.gitignore` mentioned in setup description                                                                            |
+
+### 4. Dark Mode Verification
+
+Toggle dark mode (Doks supports auto/light/dark) and verify all 6 pages render correctly. No content should be invisible or unreadable in dark mode.
+
+### 5. Cross-Reference Consistency
+
+Verify the blog post link-through is consistent:
+
+1. Navigate to `/blog/the-curator-why-documentation-triage-needed-its-own-agent/`
+2. Click the link to the Divisor team page
+3. Confirm the team page now says "nine personas" — matching the blog post
+
+## What This Spec Does NOT Change
+
+- No blog posts are modified (the Curator blog post is already published and correct)
+- No new pages are created
+- No navigation changes
+- No homepage changes
+- No SCSS/CSS changes
+- No Hugo template changes
+- No dependency changes
+
+## File Change Map
+
+```
+content/docs/team/the-divisor.md          # ~50 lines added/changed (Curator section, gatekeeping audit items, count updates)
+content/docs/team/_index.md               # ~1 line changed (eight → nine)
+content/docs/contributing/_index.md        # ~1 line changed (eight → nine)
+content/docs/getting-started/common-workflows.md  # ~1 line added (Curator table row)
+content/docs/getting-started/developer.md  # ~30 lines added (gatekeeping section, .gitignore docs)
+content/docs/getting-started/quick-start.md # ~1 line changed (.gitignore mention)
+```
+
+Total estimated changes: ~85 lines across 6 files. All Markdown, no code.

--- a/specs/023-docs-v10-v11-sync/research.md
+++ b/specs/023-docs-v10-v11-sync/research.md
@@ -1,0 +1,154 @@
+# Research: v0.10.0 / v0.11.0 Documentation Sync
+
+**Branch**: `023-docs-v10-v11-sync` | **Date**: 2026-04-11
+
+## Research Objective
+
+Understand the upstream changes from PRs #85 (gatekeeping), #87 (gitignore-init), and #89 (Curator) to determine exactly what content needs to be added or updated across 6 existing website pages. Identify all occurrences of stale persona counts and map each functional requirement to concrete content changes.
+
+## Source 1: PR #89 — The Curator Agent (Issue #35)
+
+**Source**: `unbound-force/unbound-force` PR #89 (closed/merged)
+**Dewey index**: `github-unbound-force/unbound-force/pulls/89`
+
+### Key Facts
+
+- The Curator is the **9th Divisor persona** — the first triage-layer persona, sitting between the 5 review personas and 3 content creation personas.
+- **Role**: Documentation & Content Pipeline Triage — detects documentation gaps during code review and auto-files GitHub issues in `unbound-force/website`.
+- **Functional layers**: Review (5: Guard, Architect, Adversary, SRE, Tester) → Triage (1: Curator) → Creation (3: Scribe, Herald, Envoy).
+- **Bash access**: Restricted to exactly two operations — `gh issue list` and `gh issue create` (both scoped to `unbound-force/website`). All other bash usage is a contract violation.
+- **Temperature**: 0.2 (precision — same as The Scribe).
+- **Scope boundary**: Triage, not creation. The Curator identifies _what_ needs documenting and files tracking issues. It does NOT write documentation, blog posts, or tutorials.
+
+### Five Audit Checklist Items
+
+1. **Documentation gap detection** — Were AGENTS.md or README files updated when the PR changes user-facing behavior?
+2. **Website documentation issue check** — Should an issue be filed in the website repository?
+3. **Duplicate issue check** — Search existing open issues before filing new ones.
+4. **Blog opportunity identification** — Does this change warrant a blog post?
+5. **Tutorial opportunity identification** — Does this change introduce a workflow engineers need to learn?
+
+### Exclusive Ownership Domain
+
+- **Documentation & Content Pipeline Triage**: documentation gap detection, blog opportunity identification, tutorial opportunity identification, and cross-repo issue filing in `unbound-force/website`.
+
+### Blog Post Cross-Reference
+
+The Curator blog post (`content/blog/curator-blog.md`, spec 022) references:
+
+- "nine personas" (line 47)
+- "9th Divisor persona" (line 29)
+- "all nine agents" (line 105)
+- Links to the Divisor team page (`/docs/team/the-divisor/`) which currently says "eight"
+
+**This is the highest-priority contradiction to resolve.**
+
+## Source 2: PR #85 — Gatekeeping Value Protection (Issue #33)
+
+**Source**: `unbound-force/unbound-force` PR #85 (closed/merged)
+**Dewey index**: `github-unbound-force/unbound-force/pulls/85`
+
+### Key Facts
+
+- Adds behavioral rules preventing AI agents from modifying gatekeeping values to make implementations pass.
+- Core principle: When an agent cannot meet a quality gate, it **stops and reports the conflict** rather than weakening the gate.
+- Modifying a gate without human authorization is a **CRITICAL-severity constitution violation**.
+
+### Eight Protected Value Categories
+
+1. **Coverage thresholds and CRAP scores** — minimum coverage percentages, CRAP score limits, coverage ratchets
+2. **Severity definitions and auto-fix policies** — CRITICAL/HIGH/MEDIUM/LOW boundaries, auto-fix eligibility rules
+3. **Convention pack rule classifications** — MUST/SHOULD/MAY designations (downgrading MUST to SHOULD is prohibited)
+4. **CI flags and linter configuration** — `-race`, `-count=1`, `govulncheck`, `golangci-lint` rules, pinned action SHAs
+5. **Agent temperature and tool-access settings** — frontmatter `temperature`, `tools.write`, `tools.edit`, `tools.bash` restrictions
+6. **Constitution MUST rules** — any MUST rule in `.specify/memory/constitution.md` or hero definitions
+7. **Review iteration limits and worker concurrency** — max review cycles, max parallel workers
+8. **Workflow gate markers** — spec commit gates, phase checkpoint markers, review approval requirements
+
+### Divisor Agent Changes
+
+- **Guard** (`divisor-guard.md`): New "Gatekeeping Integrity" checklist item in both Code Review and Spec Review audit sections — detects unauthorized gate modifications.
+- **Adversary** (`divisor-adversary.md`): New "Gate Tampering" checklist item in Security Checks section — detects removal or weakening of CI security controls.
+
+## Source 3: PR #87 — ensureGitignore (Issue #34)
+
+**Source**: `unbound-force/unbound-force` PR #87 (closed/merged)
+**Dewey index**: `github-unbound-force/unbound-force/pulls/87`
+
+### Key Facts
+
+- New `ensureGitignore()` function in the scaffold engine, called during `uf init`.
+- **Behavior**: Appends a standard ignore block to `.gitignore`.
+- **Idempotent**: Uses marker comment `# Unbound Force — managed by uf init` — safe to run multiple times.
+- **Creates `.gitignore`** if it does not exist (different from append-only for existing files).
+- **Append-only**: Never overwrites or removes existing `.gitignore` content.
+- Called from `Run()` after config generation, before sub-tool delegation.
+
+### Ignore Block Content
+
+The block covers two categories:
+
+1. **`.uf/` runtime data**:
+   - `.uf/workflows/` and `.uf/artifacts/`
+   - `.uf/dewey/` runtime (graph.db, cache/, locks, log)
+   - `.uf/replicator/` runtime (databases, locks)
+   - `.uf/muti-mind/artifacts/`
+   - `.uf/mx-f/data/`
+
+2. **Legacy directories**:
+   - `.dewey/`
+   - `.hive/`
+   - `.unbound-force/`
+   - `.muti-mind/`
+   - `.mx-f/`
+
+## Current State Audit: "Eight" Occurrences
+
+Grep results for "eight" in the context of Divisor/personas across `content/`:
+
+### the-divisor.md (7 word-level occurrences across 6 lines — all must change to "nine")
+
+| Line | Current Text                                                                 | Context                     |
+| ---- | ---------------------------------------------------------------------------- | --------------------------- |
+| 3    | `description: "...eight sub-personas..."`                                    | Frontmatter description     |
+| 17   | `council of eight dynamically discovered personas` + `eight canonical roles` | Council structure paragraph |
+| 126  | `All eight personas share a calibration standard`                            | Severity standard section   |
+| 139  | `All eight Divisor personas include a "Prior Learnings" step`                | Prior learnings section     |
+| 151  | `passes all eight lenses`                                                    | Collective approval section |
+| 155  | `multi-faceted feedback from the eight personas`                             | How Divisor serves the team |
+
+### team/\_index.md (1 occurrence)
+
+| Line | Current Text                    |
+| ---- | ------------------------------- |
+| 31   | `council of eight sub-personas` |
+
+### contributing/\_index.md (1 occurrence)
+
+| Line | Current Text                    |
+| ---- | ------------------------------- |
+| 33   | `council of eight sub-personas` |
+
+### common-workflows.md (0 direct "eight" occurrences)
+
+The code review table on lines 366-372 lists 5 personas (Guard, Architect, Adversary, Testing, SRE). The Curator needs to be added as a 6th row. No text says "five review personas" explicitly on this page — the table speaks for itself.
+
+### Blog posts (NOT modified — reference only)
+
+- `curator-blog.md` line 55: "All eight previous Divisor personas" — historical context, correct as-is
+- `curator-blog.md` line 73: "reviewed by the existing eight personas" — historical context, correct as-is
+
+## Affected Pages Summary
+
+| Page                                               | Issue    | Changes Required                                                                                                                                                                                    |
+| -------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content/docs/team/the-divisor.md`                 | #33, #35 | Update 6× "eight"→"nine", add Curator section, add Curator to ownership table, add Guard "Gatekeeping Integrity" + Adversary "Gate Tampering" audit items, update lens count in collective approval |
+| `content/docs/team/_index.md`                      | #35      | Update 1× "eight"→"nine" in Divisor summary                                                                                                                                                         |
+| `content/docs/contributing/_index.md`              | #35      | Update 1× "eight"→"nine" in Divisor description                                                                                                                                                     |
+| `content/docs/getting-started/common-workflows.md` | #35      | Add Curator row to code review persona table                                                                                                                                                        |
+| `content/docs/getting-started/developer.md`        | #33, #34 | Add gatekeeping section, add `.gitignore` to `uf init` docs                                                                                                                                         |
+| `content/docs/getting-started/quick-start.md`      | #34      | Mention `.gitignore` management in setup description                                                                                                                                                |
+
+## Research Gaps
+
+None identified. All three upstream PRs are merged and indexed in Dewey. The Curator agent definition file (`.opencode/agents/divisor-curator.md`) is available locally with full audit checklist details. All affected pages have been read and audited for stale content.

--- a/specs/023-docs-v10-v11-sync/spec.md
+++ b/specs/023-docs-v10-v11-sync/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: v0.10.0 / v0.11.0 Documentation Sync
+
+**Feature Branch**: `023-docs-v10-v11-sync`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "issues #33, #34, #35 — document gatekeeping value protection rules, ensureGitignore behavior in uf init, and The Curator Divisor agent across website docs pages"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 — The Curator Documented on The Divisor Team Page (Priority: P1)
+
+A visitor reading The Divisor team page learns about all nine Divisor personas, including The Curator — the documentation triage agent that detects documentation gaps during code review and auto-files GitHub issues. The persona count is updated from "eight" to "nine" across all pages that reference it. The Curator's five audit checklist items, its unique bash access (restricted to `gh` CLI), and its ownership boundaries are documented.
+
+**Why this priority**: The blog post (spec 022, now published) references "nine personas" and links to the Divisor team page. A visitor who follows that link currently sees a page that says "eight personas" — a direct contradiction. Resolving this inconsistency is the highest-priority fix because it damages credibility for any reader of the blog post.
+
+**Independent Test**: Search the entire `content/` directory for the word "eight" in the context of Divisor/personas/sub-personas. Zero matches should remain after this change. The Divisor team page lists nine personas with The Curator documented alongside the existing eight.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor on the Divisor team page, **When** they read the persona list, **Then** they find nine personas including The Curator with its documentation triage role.
+2. **Given** a visitor on the team index page (`_index.md`), **When** they read the Divisor summary, **Then** it references nine sub-personas, not eight.
+3. **Given** a visitor on the contributing page, **When** they read the Divisor description, **Then** it references nine sub-personas, not eight.
+4. **Given** a visitor on the common workflows page, **When** they read the code review persona table, **Then** The Curator appears with its documentation governance focus area.
+
+---
+
+### User Story 2 — Gatekeeping Value Protection Documented (Priority: P2)
+
+A developer reading the developer guide or the Divisor team page understands that certain values are protected from modification by AI agents. When an agent cannot meet a quality gate, it stops and reports the conflict rather than weakening the gate. The eight protected categories are listed and explained.
+
+**Why this priority**: Gatekeeping protection is a governance principle that affects how developers interpret agent behavior during reviews. Understanding this principle prevents confusion when an agent stops mid-implementation — the developer needs to know this is by design, not a failure. This is P2 rather than P1 because the blog post contradiction (P1) is more urgent and user-facing.
+
+**Independent Test**: A developer reading the developer guide can find and list the eight categories of protected values and understand what happens when an agent encounters a gate it cannot meet.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reading the developer guide, **When** they look for agent behavior constraints, **Then** they find the eight protected value categories and understand that agents stop and report rather than modifying gates.
+2. **Given** a developer reading the Divisor team page, **When** they review the Guard persona, **Then** they find the "Gatekeeping Integrity" audit item.
+3. **Given** a developer reading the Divisor team page, **When** they review the Adversary persona, **Then** they find the "Gate Tampering" audit item.
+
+---
+
+### User Story 3 — `.gitignore` Management Documented (Priority: P2)
+
+A developer reading about `uf init` understands that it automatically manages `.gitignore` entries. The developer guide explains what entries are added, the append-only behavior, and the idempotency marker. The quick-start page mentions `.gitignore` management as part of `uf setup`.
+
+**Why this priority**: This is a quality-of-life documentation gap. Developers who run `uf init` and notice `.gitignore` changes need to understand that this is expected behavior. Without documentation, they may revert the changes thinking they are unwanted. This is P2 alongside gatekeeping because both are important but neither causes a user-facing contradiction like the persona count issue.
+
+**Independent Test**: A developer reading the developer guide's `uf init` section can find `.gitignore` listed as a managed file with its behavior described (append-only, idempotent, marker comment).
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reading the developer guide, **When** they review the `uf init` "What Gets Deployed" table, **Then** `.gitignore` is listed as a managed file.
+2. **Given** a developer reading the developer guide, **When** they look for `.gitignore` details, **Then** they find the append-only behavior, idempotency marker (`# Unbound Force — managed by uf init`), and the categories of ignored files (`.uf/` runtime data, legacy tool directories).
+3. **Given** a developer reading the quick-start page, **When** they review what `uf setup` does, **Then** `.gitignore` management is mentioned alongside project scaffolding.
+
+---
+
+### Edge Cases
+
+- The Divisor team page says "eight" in six different places. All six must be updated. Missing even one creates an internal inconsistency on the same page.
+- The blog post (`curator-blog.md`) references "nine personas" — the team page update must make this link-through consistent. The blog post itself is NOT modified.
+- Pages that describe the sub-category breakdown ("five review, three content creation") must be updated to "six review, three content creation" or equivalent. The Curator participates in the review phase (it runs during code review alongside the other review personas), so it is counted as a review persona. Three pages have this sub-category breakdown: the-divisor.md, team/\_index.md, and contributing/\_index.md.
+- The contributing page's Divisor description must match the team page count.
+- The `.gitignore` documentation must explain that `uf init` creates the file if it does not exist — this is different from the append-only behavior for existing files.
+- Gatekeeping documentation must not list specific threshold values (those are implementation details that may change). It should describe the categories and the "stop and report" behavior.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+**Issue #35 — The Curator (4 unique pages, multiple changes to the-divisor.md)**:
+
+- **FR-001**: The Divisor team page (`content/docs/team/the-divisor.md`) MUST update all persona count references from "eight" to "nine" (7 word-level occurrences across 6 lines identified, including the lens count in the "Collective Approval" section).
+- **FR-002**: The Divisor team page MUST add a Curator section documenting its role (documentation & content pipeline triage), its five audit checklist items, its restricted bash access (`gh` CLI only), and its triage-not-creation scope.
+- **FR-003**: The Divisor team page MUST add The Curator to the Ownership Boundaries table with its exclusive domain.
+- **FR-004**: The team index page (`content/docs/team/_index.md`) MUST update the Divisor summary from "eight sub-personas" to "nine sub-personas."
+- **FR-005**: The contributing page (`content/docs/contributing/_index.md`) MUST update its Divisor reference from "eight sub-personas" to "nine sub-personas."
+- **FR-006**: The common workflows page (`content/docs/getting-started/common-workflows.md`) MUST add The Curator to the code review persona evaluation table.
+- **FR-016**: All pages that describe the sub-category breakdown ("five review" / "five for code review" and "three content creation") MUST be updated to "six review" and "three content creation" (or equivalent phrasing reflecting that The Curator is a review-phase persona). Affected pages: the-divisor.md, team/\_index.md, contributing/\_index.md.
+
+**Issue #33 — Gatekeeping Protection (2 affected pages)**:
+
+- **FR-007**: The developer guide (`content/docs/getting-started/developer.md`) MUST add a section documenting the eight categories of gatekeeping-protected values and the "stop and report" agent behavior.
+- **FR-008**: The Divisor team page MUST document the Guard's "Gatekeeping Integrity" audit item and the Adversary's "Gate Tampering" audit item.
+
+**Issue #34 — `.gitignore` Management (2 affected pages)**:
+
+- **FR-009**: The developer guide MUST add `.gitignore` to the `uf init` "What Gets Deployed" table or equivalent section.
+- **FR-010**: The developer guide MUST document `.gitignore` management behavior: append-only, idempotency via marker comment, file creation if absent, categories of ignored entries (`.uf/` runtime data, legacy tool directories).
+- **FR-011**: The quick-start page (`content/docs/getting-started/quick-start.md`) MUST mention `.gitignore` management as part of what `uf setup`/`uf init` handles.
+
+**Cross-cutting**:
+
+- **FR-012**: All content MUST be sourced from upstream PRs (#85 for gatekeeping, #87 for gitignore-init, #89 for Curator) and their associated OpenSpec change artifacts. No capabilities may be fabricated or overstated.
+- **FR-013**: The site MUST build successfully (`npm run build`) with no errors after all changes.
+- **FR-014**: All updated pages MUST render correctly in both light and dark mode.
+- **FR-015**: No page may contain placeholder text, "Coming Soon," or TODO markers after changes.
+
+## Scope & Constraints
+
+### In Scope
+
+- Updating persona count from "eight" to "nine" across all affected pages (4 unique pages identified for Issue #35).
+- Adding The Curator persona section to the Divisor team page.
+- Adding gatekeeping value protection documentation to the developer guide and Divisor team page.
+- Adding `.gitignore` management documentation to the developer guide and quick-start page.
+- Updating the code review persona table in common workflows.
+
+### Out of Scope
+
+- Blog posts — the Curator blog post (spec 022) is already published and NOT modified.
+- The Curator's agent definition file — that lives in the upstream `unbound-force/unbound-force` repo.
+- Changes to the homepage, navigation, or site structure.
+- New pages — all changes are updates to existing pages.
+- Upstream code changes to `uf init` or the Divisor framework.
+
+## Dependencies & Assumptions
+
+### Dependencies
+
+- **Spec 022 (curator-blog)**: Published a blog post that references "nine personas." This spec resolves the resulting inconsistency on the team page.
+- **Spec 020 (dewey-v3-docs-sync)**: Established the pattern of documentation sync specs that update multiple existing pages. This spec follows the same pattern.
+- **Upstream PR #85**: Source of truth for gatekeeping value protection rules.
+- **Upstream PR #87**: Source of truth for `ensureGitignore` behavior.
+- **Upstream PR #89**: Source of truth for The Curator agent and spec 026-documentation-curation.
+
+### Assumptions
+
+- The upstream PRs (#85, #87, #89) are all merged and their changes are final.
+- The Divisor team page structure (sections for each persona, ownership boundaries table, lenses list) is stable and does not need restructuring — only content additions and count updates.
+- The developer guide's `uf init` section structure is stable and only needs content additions (new table row, new subsection).
+- The quick-start page only needs a brief mention of `.gitignore` management, not a detailed section.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Zero occurrences of "eight" in the context of Divisor/personas/sub-personas remain across the entire `content/` directory after changes.
+- **SC-002**: A visitor navigating from the Curator blog post to the Divisor team page finds consistent persona counts (nine) and The Curator documented.
+- **SC-003**: A developer can find and list the eight gatekeeping-protected value categories from the developer guide.
+- **SC-004**: A developer can find `.gitignore` management documented in the `uf init` section of the developer guide.
+- **SC-005**: The site builds successfully (`npm run build`) with zero errors and all updated pages render correctly in both light and dark mode.

--- a/specs/023-docs-v10-v11-sync/tasks.md
+++ b/specs/023-docs-v10-v11-sync/tasks.md
@@ -1,0 +1,123 @@
+# Tasks: v0.10.0 / v0.11.0 Documentation Sync
+
+**Input**: Design documents from `/specs/023-docs-v10-v11-sync/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, quickstart.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Build Verification & Audit)
+
+**Purpose**: Confirm clean baseline before making content changes
+
+- [x] T001 Run `npm run build` and verify zero errors on current branch baseline
+- [x] T002 Audit all "eight" occurrences in `content/docs/team/the-divisor.md`, `content/docs/team/_index.md`, and `content/docs/contributing/_index.md` — confirm 6 occurrences in the-divisor.md, 1 in team/\_index.md, 1 in contributing/\_index.md match research.md line/context inventory
+
+**Checkpoint**: Clean build confirmed, stale content locations verified against research.md
+
+---
+
+## Phase 2: User Story 1 — The Curator (Priority: P1)
+
+**Goal**: Update persona count from "eight" to "nine" across 5 pages and add full Curator documentation to the Divisor team page. Resolves blog post ↔ team page contradiction.
+
+**Independent Test**: `grep -rn "eight" content/docs/team/the-divisor.md content/docs/team/_index.md content/docs/contributing/_index.md` returns zero matches in persona-count contexts. The Divisor team page lists nine personas with The Curator documented.
+
+### the-divisor.md (sequential — shared file)
+
+- [x] T003 [US1] Update all 7 persona-count word occurrences of "eight" to "nine" across 6 lines in `content/docs/team/the-divisor.md` (frontmatter description, council structure paragraph ×2 on same line, severity standard, prior learnings, collective approval, how Divisor serves the team) — FR-001
+- [x] T004 [US1] Add Curator "Triage Persona" section to `content/docs/team/the-divisor.md` between "Content Creation Personas" and "Exclusive Ownership Boundaries" — include role description (Documentation & Content Pipeline Triage), five audit checklist items, bash access restriction (`gh` CLI only: `gh issue list`, `gh issue create`), scope boundary (triage, not creation), temperature (0.2) — FR-002
+- [x] T005 [US1] Add Curator row to the Exclusive Ownership Boundaries table in `content/docs/team/the-divisor.md` with domain "Documentation & content pipeline triage" — FR-003
+- [x] T006 [US1] Update the "Collective Approval" section lens count in `content/docs/team/the-divisor.md` from eight lenses to nine and add "documentation triage" to the lens list between "test quality" and "documentation accuracy" (matching Review → Triage → Creation order). Also update any sub-category breakdown text ("five review" → "six review") in the introduction and body text — FR-001, FR-016
+
+### Other pages (parallel — different files)
+
+- [x] T007 [P] [US1] Update Divisor summary in `content/docs/team/_index.md` from "eight sub-personas" to "nine sub-personas", update sub-category breakdown from "five for code review" to "six for code review" (adding The Curator), and add "The Curator" to the parenthetical persona list — FR-004, FR-016
+- [x] T008 [P] [US1] Update Divisor description in `content/docs/contributing/_index.md` from "eight sub-personas" to "nine sub-personas", update "Five review personas" to "Six review personas" and add The Curator to the persona enumeration — FR-005, FR-016
+- [x] T009 [P] [US1] Add Curator row to the code review persona evaluation table in `content/docs/getting-started/common-workflows.md`: `| **Curator** | Documentation gaps, blog/tutorial opportunities, website issue filing |` — FR-006
+
+**Checkpoint**: Run `npm run build`. Verify zero errors. Grep confirms no stale "eight" in persona-count contexts. Blog post link-through to team page shows consistent "nine personas."
+
+---
+
+## Phase 3: User Story 2 — Gatekeeping Value Protection (Priority: P2)
+
+**Goal**: Document the eight categories of gatekeeping-protected values and the "stop and report" agent behavior. Add Guard and Adversary audit items.
+
+**Independent Test**: A developer reading the developer guide can find and list the eight protected value categories and understand the "stop and report" behavior.
+
+- [x] T010 [P] [US2] Add "Gatekeeping Value Protection" section to `content/docs/getting-started/developer.md` under the Cobalt-Crush persona section after "Feedback Loops" — include brief explanation, eight protected categories (numbered list from research.md), "stop and report" behavior description, note that modifying a gate without human authorization is a CRITICAL-severity constitution violation — FR-007
+- [x] T011 [US2] Add "Gatekeeping Integrity" audit item to The Guard section and "Gate Tampering" audit item to The Adversary section in `content/docs/team/the-divisor.md` — FR-008
+
+**Checkpoint**: Run `npm run build`. Verify zero errors. Developer guide gatekeeping section is complete and sourced from upstream PR #85.
+
+---
+
+## Phase 4: User Story 3 — `.gitignore` Management (Priority: P2)
+
+**Goal**: Document `.gitignore` management behavior in `uf init` and mention it in the quick-start.
+
+**Independent Test**: A developer reading the developer guide's `uf init` section finds `.gitignore` listed as a managed file with append-only, idempotent behavior described.
+
+- [x] T012 [P] [US3] Add `.gitignore` row to the "What Gets Deployed" table in `content/docs/getting-started/developer.md` and add a paragraph explaining behavior: append-only (never overwrites existing content), idempotent via marker comment (`# Unbound Force — managed by uf init`), creates `.gitignore` if absent, two categories of ignored entries (`.uf/` runtime data, legacy tool directories) — FR-009, FR-010
+- [x] T013 [P] [US3] Add `.gitignore` management mention to the `uf setup`/`uf init` bullet list in `content/docs/getting-started/quick-start.md` — brief mention only, developer guide has details — FR-011
+
+**Checkpoint**: Run `npm run build`. Verify zero errors. Developer guide `uf init` section documents `.gitignore`. Quick-start mentions it.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification across all 6 pages, content accuracy, and build validation
+
+- [x] T014 Run full stale-mention audit: `grep -rn "eight" content/` and verify "eight" only appears in (a) the gatekeeping section (eight protected value categories) and (b) blog post historical references — SC-001, FR-012
+- [x] T015 Run `npm run build` — final build verification with all changes applied — FR-013, SC-005
+- [x] T016 Cross-reference consistency: verify blog post (`/blog/the-curator-why-documentation-triage-needed-its-own-agent/`) link-through to Divisor team page shows consistent "nine personas" — SC-002
+- [x] T017 Verify no placeholder text, "Coming Soon," or TODO markers exist in any of the 6 modified pages — FR-015
+- [x] T018 Run quickstart.md verification steps (Sections 2-5): persona count consistency check, visual verification of all 6 pages, dark mode verification, cross-reference consistency — FR-014, SC-005
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (US1 — Curator)**: Depends on Phase 1 completion
+- **Phase 3 (US2 — Gatekeeping)**: Depends on Phase 2 completion (shares `the-divisor.md`)
+- **Phase 4 (US3 — Gitignore)**: Depends on Phase 3 completion (shares `developer.md`)
+- **Phase 5 (Polish)**: Depends on all previous phases
+
+### Parallel Opportunities
+
+- **Phase 2**: T007, T008, T009 are [P] — they touch different files (`_index.md`, `contributing/_index.md`, `common-workflows.md`) and can run in parallel. T003→T004→T005→T006 are sequential (all modify `the-divisor.md`).
+- **Phase 3**: T010 and T011 are on different files (`developer.md` vs `the-divisor.md`) — T010 is [P].
+- **Phase 4**: T012 and T013 are on different files (`developer.md` vs `quick-start.md`) — both are [P].
+
+### File Contention Map
+
+| File                     | Tasks (in order)             |
+| ------------------------ | ---------------------------- |
+| `the-divisor.md`         | T003, T004, T005, T006, T011 |
+| `team/_index.md`         | T007                         |
+| `contributing/_index.md` | T008                         |
+| `common-workflows.md`    | T009                         |
+| `developer.md`           | T010, T012                   |
+| `quick-start.md`         | T013                         |
+
+---
+
+## Notes
+
+- Total: 18 tasks across 5 phases, 6 files, ~85 lines of Markdown changes
+- No new files created — all edits to existing pages
+- No tests to write — validation is `npm run build` + visual verification
+- Content must be sourced from upstream PRs #85, #87, #89 (FR-012) — no fabrication
+- The word "eight" will correctly remain in the gatekeeping section (eight protected value categories) — only persona-count "eight" references are updated
+
+<!-- spec-review: passed -->


### PR DESCRIPTION
## Summary

Syncs the website documentation to reflect three upstream changes from `unbound-force/unbound-force` v0.10.0 and v0.11.0:

**The Curator (Issue #35)**:
- Add The Curator as the 9th Divisor persona with full section on the team page (five audit checklist items, bash restriction, triage scope)
- Update persona count "eight" → "nine" across 5 pages, resolving inconsistency with the published Curator blog post
- Update sub-category breakdown "five review" → "six review" on 3 pages
- Add Curator to code review persona table in common workflows
- Fix 3 additional stale persona counts on tester, product-owner, and developer pages

**Gatekeeping Protection (Issue #33)**:
- Add "Gatekeeping Value Protection" section to developer guide with 8 protected categories and "stop and report" behavior
- Add Guard "Gatekeeping Integrity" and Adversary "Gate Tampering" audit items to Divisor team page

**`.gitignore` Management (Issue #34)**:
- Add `.gitignore` to `uf init` deployment table in developer guide with append-only, idempotent behavior
- Add `.gitignore` mention to quick-start page

## Review Results

- **Spec review**: REQUEST CHANGES → APPROVE (after fixing sub-category count gap)
- **Code review**: APPROVE (unanimous, zero findings)
- **Build**: passes with zero errors

Closes #33
Closes #34
Closes #35
