### PR TITLE
docs: add CLI reference page, changelog, and stack positioning

### DIFF
--- a/.uf/dewey/learnings/cli-reference-and-positioning-1.md
+++ b/.uf/dewey/learnings/cli-reference-and-positioning-1.md
@@ -1,0 +1,9 @@
+---
+tag: cli-reference-and-positioning
+category: gotcha
+created_at: 2026-05-02T19:39:18Z
+identity: cli-reference-and-positioning-1
+tier: draft
+---
+
+When creating OpenSpec proposals for the Unbound Force website, the Constitution Alignment section must assess against the website project constitution at `.specify/memory/constitution.md` (Content Accuracy, Minimal Footprint, Visitor Clarity) — not the org-level constitution from `unbound-force/unbound-force` (Autonomous Collaboration, Composability First, Observable Quality, Testability). This was a CRITICAL finding in the spec review for cli-reference-and-positioning: all 6 Divisor reviewers flagged the wrong constitution. The OpenSpec config.yaml context block itself referenced the org constitution, which may have caused the initial artifact generator to use the wrong one. Future proposals should always check which constitution governs the specific project.

--- a/.uf/dewey/learnings/cli-reference-and-positioning-2.md
+++ b/.uf/dewey/learnings/cli-reference-and-positioning-2.md
@@ -1,0 +1,9 @@
+---
+tag: cli-reference-and-positioning
+category: gotcha
+created_at: 2026-05-02T19:39:23Z
+identity: cli-reference-and-positioning-2
+tier: draft
+---
+
+The Unbound Force website homepage (`content/_index.md`) contains only YAML frontmatter with no body content — the homepage is rendered entirely by `layouts/home.html`. The homepage template has no stack/tools table. The stack table actually lives on `content/docs/getting-started/_index.md` (the "What is Unbound Force?" page) and `content/docs/getting-started/quick-start.md`. This was a HIGH finding in the cli-reference-and-positioning spec review: tasks targeted `content/_index.md` for a stack table update, but that file has no stack table. When writing specs that modify the homepage or stack table, always verify the actual file locations by reading the files rather than assuming from page URLs.

--- a/.uf/dewey/learnings/cli-reference-and-positioning-3.md
+++ b/.uf/dewey/learnings/cli-reference-and-positioning-3.md
@@ -1,0 +1,9 @@
+---
+tag: cli-reference-and-positioning
+category: pattern
+created_at: 2026-05-02T19:39:27Z
+identity: cli-reference-and-positioning-3
+tier: draft
+---
+
+For the Unbound Force website's Hugo/Doks theme, section index pages (`_index.md`) should use `weight: 10` in their frontmatter for consistency with all existing section indexes. The top-level sidebar ordering is controlled by `config/_default/menus/menus.en.toml` menu entries, not by the frontmatter weight. Setting the section index weight to match the menu weight (e.g., weight: 35) is harmless but inconsistent with the established pattern. The code review Architect flagged this as a LOW finding.

--- a/.uf/replicator/replicator.log
+++ b/.uf/replicator/replicator.log
@@ -1,0 +1,1 @@
+2026/05/02 15:12:16 INFO tool call tool=forge_worktree_list duration=20.419708ms success=true

--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -17,6 +17,18 @@
   url = "/docs/team/"
 
 [[docs]]
+  name = "Reference"
+  weight = 35
+  identifier = "reference"
+  url = "/docs/reference/"
+
+[[docs]]
+  name = "Changelog"
+  weight = 38
+  identifier = "changelog"
+  url = "/docs/changelog/"
+
+[[docs]]
   name = "Contributing"
   weight = 40
   identifier = "contributing"

--- a/content/docs/changelog/_index.md
+++ b/content/docs/changelog/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Changelog"
+description: "Release history for the Unbound Force toolchain — user-facing changes per release, sourced from actual release artifacts."
+lead: "User-facing changes per release."
+date: 2026-05-02T00:00:00+00:00
+draft: false
+weight: 10
+toc: true
+---
+
+## v0.12.0 — 2026-04-14
+
+### Added
+
+- **Containerized development sessions** -- New `uf sandbox` command group for launching, managing, and extracting changes from containerized OpenCode sessions. Supports Podman (local) and Eclipse Che / Dev Spaces (CDE) backends.
+- **Linux cross-platform install** -- RPM packages and Homebrew Formula for Linux installations.
+- **Externalized Speckit commands** -- Speckit, OpenSpec, and Gaze init assets are now externalized from embedded assets, enabling independent updates.
+- **Workflow phase boundaries** -- Speckit commands now enforce phase boundaries (spec vs. implementation), preventing out-of-phase changes.
+
+### Fixed
+
+- Guardrails added to `/opsx-propose` to prevent phase boundary violations.
+- Anthropic Vertex environment variables now forwarded to sandbox containers.
+- Google Cloud config directory mounted for Vertex AI auth in sandbox.

--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -14,17 +14,18 @@ Unbound Force is a set of purpose-built agent personas designed to work as a coo
 
 But these are not just instruction files. Each hero can include LSP servers, MCP servers, tooling, tasks, commands, plugins, and other technologies that enable them to do their job. They are designed to be the pinnacle archetype of their role.
 
-## Three Tools, One Workflow
+## The Stack
 
-Unbound Force is built on three complementary tools that form a layered stack:
+Unbound Force is built on four complementary tools that form a layered stack:
 
 | Layer            | Tool                                                      | What It Does                                                                                                               |
 | ---------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **CLI**          | [`uf`](/docs/reference/cli/)                               | Project scaffolding, environment setup, health checks, configuration, sandboxed execution, LLM gateway.                   |
 | **Agent**        | [OpenCode](https://opencode.ai)                           | The AI coding environment where you interact, write code, and run commands. The personas run inside OpenCode.              |
 | **Planning**     | [Speckit](https://github.com/github/spec-kit) (spec-kit)  | A specification pipeline that turns ideas into structured specs, plans, and tasks before implementation begins.            |
 | **Coordination** | [Replicator](https://github.com/unbound-force/replicator) | Multi-agent coordination: parallel workers, git-backed tracking, file reservations, and semantic memory. Single Go binary. |
 
-Each tool is independently useful, but they compose into the full Unbound Force workflow: plan with Speckit, execute with OpenCode, coordinate with Replicator.
+Each tool is independently useful, but they compose into the full Unbound Force workflow: scaffold with `uf`, plan with Speckit, execute with OpenCode, coordinate with Replicator.
 
 ## The Heroes
 

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -372,6 +372,8 @@ The council discovers available Divisor persona agents in `.opencode/agents/divi
 | **SRE**       | Release pipeline, dependency health, configuration, runtime observability                |
 | **Curator**   | Documentation gaps, blog/tutorial opportunities, website issue filing                    |
 
+> **Note**: The table above lists the 6 review personas that participate in code review. Three additional content personas — Scribe (technical documentation), Herald (blog/announcements), and Envoy (public communications) — are invoked separately for content creation tasks and do not participate in the code review council.
+
 ### CI Gate (Phase 1a and 1b)
 
 Before delegating to Divisor agents, the review council runs a two-phase CI gate:

--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -65,15 +65,16 @@ For bug fixes and tactical changes:
 
 ## The Stack
 
-Unbound Force runs on three tools that form a layered stack. `uf setup` installs all of them, but each is independently useful:
+Unbound Force runs on four tools that form a layered stack. `uf setup` installs all of them, but each is independently useful:
 
 | Layer            | Tool                                                      | What It Does                                                                                                               |
 | ---------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **CLI**          | [`uf`](/docs/reference/cli/)                               | Project scaffolding, environment setup, health checks, configuration, sandboxed execution, LLM gateway.                   |
 | **Agent**        | [OpenCode](https://opencode.ai)                           | The AI coding environment where you interact, write code, and run commands. The personas run inside OpenCode.              |
 | **Planning**     | [Speckit](https://github.com/github/spec-kit) (spec-kit)  | A specification pipeline that turns ideas into structured specs, plans, and tasks before implementation begins.            |
 | **Coordination** | [Replicator](https://github.com/unbound-force/replicator) | Multi-agent coordination: parallel workers, git-backed tracking, file reservations, and semantic memory. Single Go binary. |
 
-Each tool is independently useful, but they compose into the full Unbound Force workflow: plan with Speckit, execute with OpenCode, coordinate with Replicator.
+Each tool is independently useful, but they compose into the full Unbound Force workflow: scaffold with `uf`, plan with Speckit, execute with OpenCode, coordinate with Replicator.
 
 ## Next Steps
 

--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Reference"
+description: "Command reference and configuration documentation for the Unbound Force toolchain — CLI commands, flags, and subcommands."
+lead: "Detailed reference documentation for the uf CLI and related tools."
+date: 2026-05-02T00:00:00+00:00
+draft: false
+weight: 10
+toc: true
+---
+
+## CLI Reference
+
+- **[uf CLI Reference](/docs/reference/cli/)** -- Complete command reference for the `uf` CLI, including all command groups, subcommands, and flags.

--- a/content/docs/reference/cli.md
+++ b/content/docs/reference/cli.md
@@ -1,0 +1,174 @@
+---
+title: "uf CLI Reference"
+description: "Complete command reference for the uf CLI — all command groups, subcommands, and flags for the Unbound Force toolchain."
+lead: "The uf CLI is the entry point for the Unbound Force toolchain. It scaffolds projects, installs tools, runs health checks, manages configuration, launches sandboxed sessions, and provides an LLM gateway."
+date: 2026-05-02T00:00:00+00:00
+draft: false
+weight: 10
+toc: true
+---
+
+> This page reflects `uf` v0.12.0. Run `uf --help` for the latest.
+
+## Overview
+
+```text
+uf [command] [flags]
+```
+
+The `uf` CLI (alias for `unbound-force`) manages the full Unbound Force toolchain. Each command group handles a distinct concern — from project scaffolding to containerized development sessions.
+
+**Global flags:**
+
+| Flag | Description |
+|------|-------------|
+| `-h`, `--help` | Help for any command |
+| `-v`, `--version` | Print the uf version |
+
+## init
+
+Scaffold the Unbound Force specification framework into the current directory. Creates Speckit templates, scripts, OpenCode commands and agents, Divisor review personas, convention packs, and OpenSpec schema files.
+
+User-owned files (templates, scripts, agents, config) are skipped if they already exist. Tool-owned files (Speckit commands, OpenSpec schema, convention packs) are updated if their content has changed.
+
+```bash
+uf init [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--divisor` | Deploy only Divisor review agents and convention packs |
+| `--force` | Overwrite all existing files |
+| `--lang <string>` | Project language for convention pack selection (auto-detected from `go.mod`, `package.json`, etc. if omitted) |
+
+## setup
+
+Install and configure the Unbound Force development toolchain. Detects existing version and package managers, installs missing tools through the appropriate manager, configures the Swarm plugin in `opencode.json`, and scaffolds project files. Idempotent — safe to run multiple times.
+
+```bash
+uf setup [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dir <string>` | Target directory for setup (default `.`) |
+| `--dry-run` | Print actions without executing |
+| `--yes` | Skip confirmation prompts for curl\|bash installs |
+
+See the [Quick Start](/docs/getting-started/quick-start/) for a walkthrough of `uf setup`.
+
+## doctor
+
+Check for required tools, version managers, scaffolded files, hero availability, Swarm plugin status, MCP server configuration, and agent/skill integrity. Produces a colored terminal report by default, or structured JSON for CI pipelines.
+
+Exit code 0 when all checks pass or only warnings exist. Exit code 1 when any check fails.
+
+```bash
+uf doctor [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dir <string>` | Target directory to check (default `.`) |
+| `--format <string>` | Output format: `text` or `json` (default `text`) |
+
+## config
+
+Manage the unified `.uf/config.yaml` configuration file.
+
+```bash
+uf config [command] [flags]
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `init` | Create or update `.uf/config.yaml` |
+| `show` | Display effective configuration after all layers merge |
+| `validate` | Validate config file against known field values |
+
+### config init
+
+```bash
+uf config init [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dir <string>` | Target directory (default `.`) |
+
+### config show
+
+```bash
+uf config show [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dir <string>` | Target directory (default `.`) |
+| `--format <string>` | Output format: `text` or `json` (default `text`) |
+
+### config validate
+
+```bash
+uf config validate [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dir <string>` | Target directory (default `.`) |
+| `--format <string>` | Output format: `text` or `json` (default `text`) |
+
+## sandbox
+
+Launch, manage, and extract changes from containerized OpenCode development sessions. Supports Podman (local) and Eclipse Che / Dev Spaces (CDE) backends.
+
+```bash
+uf sandbox [command] [flags]
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `create` | Provision a persistent sandbox workspace |
+| `start` | Launch or resume a sandbox |
+| `stop` | Stop a sandbox (preserves persistent state) |
+| `attach` | Connect to a running sandbox's TUI |
+| `extract` | Extract changes from the sandbox as git patches |
+| `status` | Show sandbox workspace status |
+| `destroy` | Permanently delete a sandbox workspace |
+
+## gateway
+
+Start a local reverse proxy that serves the Anthropic Messages API. The gateway auto-detects the cloud provider from environment variables and injects host-side credentials into upstream requests.
+
+**Supported providers:**
+
+- Anthropic (`ANTHROPIC_API_KEY`)
+- Vertex AI (`CLAUDE_CODE_USE_VERTEX=1` + `ANTHROPIC_VERTEX_PROJECT_ID`)
+- AWS Bedrock (`CLAUDE_CODE_USE_BEDROCK=1`)
+
+```bash
+uf gateway [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--detach` | Run gateway in the background |
+| `--port <int>` | Port to listen on (default `53147`) |
+| `--provider <string>` | Provider override: `anthropic`, `vertex`, or `bedrock` (auto-detected if omitted) |
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `status` | Show gateway status |
+| `stop` | Stop a running gateway |
+
+## See Also
+
+- [Quick Start](/docs/getting-started/quick-start/) -- Install and verify the toolchain
+- [Developer Guide](/docs/getting-started/developer/) -- Daily workflow with the `uf` CLI
+- [Common Workflows](/docs/getting-started/common-workflows/) -- End-to-end feature, bug fix, and review flows

--- a/openspec/changes/cli-reference-and-positioning/.openspec.yaml
+++ b/openspec/changes/cli-reference-and-positioning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-02

--- a/openspec/changes/cli-reference-and-positioning/design.md
+++ b/openspec/changes/cli-reference-and-positioning/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The `uf` CLI is the primary user interface for Unbound Force — it installs, configures, and manages OpenCode, Speckit, and Replicator. Despite having 6 command groups and 15+ subcommands, the website only documents `init`, `setup`, and `doctor` scattered across getting-started pages. There is no single reference page and no changelog.
+
+## Goals / Non-Goals
+
+### Goals
+- Create a comprehensive CLI reference page listing all commands, subcommands, and flags
+- Add `uf` as a layer in the stack positioning table
+- Create a changelog page for tracking release-level changes
+- Establish a reference section in the docs navigation
+
+### Non-Goals
+- Detailed tutorials for each command (covered by separate tutorial specs)
+- Exhaustive flag documentation for `sandbox` and `gateway` (covered by their own doc specs)
+- Backfilling changelog entries for all historical releases (start from the current release)
+
+## Decisions
+
+1. **CLI reference as a table-driven page**: Use tables for command/flag reference rather than prose. Tables are scannable and maintainable. Each command group gets a section with a subcommand table.
+
+2. **Stack table adds CLI as the top layer**: The `uf` CLI sits above the existing three tools because it's the entry point that bootstraps and manages them. Position: CLI > Agent > Planning > Coordination.
+
+3. **Changelog in docs section, not blog**: The changelog is a reference page, not a narrative. Place it under `docs/changelog/` with weight ordering so newest entries appear first.
+
+4. **Reference section in navigation**: Create a new "Reference" section in the docs sidebar to house the CLI reference and future reference pages (e.g., configuration reference).
+
+5. **Source command data from upstream**: Pull command details from `cmd/unbound-force/*.go` files and `--help` output in the `unbound-force` repo. Cross-reference with Dewey for any curated content.
+
+## Risks / Trade-offs
+
+- **Risk**: CLI surface may change between spec creation and implementation. Mitigated by sourcing from the shipped binary at implementation time.
+- **Risk**: Changelog page requires ongoing maintenance with each release. Accepted — this is the nature of changelogs. Keep entries concise.
+- **Trade-off**: Brief descriptions in the CLI reference vs. detailed docs. Chose brief — the reference links to detailed pages where they exist.

--- a/openspec/changes/cli-reference-and-positioning/design.md
+++ b/openspec/changes/cli-reference-and-positioning/design.md
@@ -13,7 +13,7 @@ The `uf` CLI is the primary user interface for Unbound Force — it installs, co
 ### Non-Goals
 - Detailed tutorials for each command (covered by separate tutorial specs)
 - Exhaustive flag documentation for `sandbox` and `gateway` (covered by their own doc specs)
-- Backfilling changelog entries for all historical releases (start from the current release)
+- Backfilling changelog entries for historical releases (include the current release only)
 
 ## Decisions
 
@@ -25,10 +25,10 @@ The `uf` CLI is the primary user interface for Unbound Force — it installs, co
 
 4. **Reference section in navigation**: Create a new "Reference" section in the docs sidebar to house the CLI reference and future reference pages (e.g., configuration reference).
 
-5. **Source command data from upstream**: Pull command details from `cmd/unbound-force/*.go` files and `--help` output in the `unbound-force` repo. Cross-reference with Dewey for any curated content.
+5. **Source command data from upstream**: Pull command details from `uf --help` and `uf <command> --help` output, cross-referencing with the `unbound-force/unbound-force` repo's CLI source code. `--help` output is the authoritative source. Cross-reference with Dewey for any curated content. Include a version marker (e.g., "This page reflects `uf` vX.Y.Z") so staleness is detectable.
 
 ## Risks / Trade-offs
 
 - **Risk**: CLI surface may change between spec creation and implementation. Mitigated by sourcing from the shipped binary at implementation time.
-- **Risk**: Changelog page requires ongoing maintenance with each release. Accepted — this is the nature of changelogs. Keep entries concise.
+- **Risk**: Changelog page requires ongoing maintenance with each release. Mitigated: changelog updates are part of the release process; the Website Documentation Gate in AGENTS.md already requires issues for user-facing changes. If the changelog falls more than 2 releases behind, remove it rather than show stale content (per Constitution I: Content Accuracy).
 - **Trade-off**: Brief descriptions in the CLI reference vs. detailed docs. Chose brief — the reference links to detailed pages where they exist.

--- a/openspec/changes/cli-reference-and-positioning/proposal.md
+++ b/openspec/changes/cli-reference-and-positioning/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The `uf` CLI has grown to 6 command groups with 15+ subcommands, but the website has no single CLI reference page. Users looking for "what can `uf` do?" have no landing page. Additionally, the website's "Three Tools" stack table (OpenCode + Speckit + Replicator) omits the CLI layer entirely, and there is no changelog or "what's new" page despite 84+ commits shipping since v0.12.0.
+
+This change addresses GitHub issues #62 (CLI reference page) and #68 (changelog page + stack positioning).
+
+## What Changes
+
+1. **CLI reference page**: New page at `content/docs/reference/cli.md` listing all 6 command groups (`init`, `setup`, `doctor`, `config`, `sandbox`, `gateway`) with subcommands, flags, and brief descriptions.
+
+2. **Stack table update**: Add `uf` CLI as a fourth layer in the stack table on `_index.md` and `quick-start.md` — positioned above the existing three tools as the glue layer.
+
+3. **Changelog page**: New page at `content/docs/changelog/` tracking major releases with user-facing changes per version.
+
+## Capabilities
+
+### New Capabilities
+- `docs/reference/cli`: Complete CLI reference page with all command groups and subcommands
+- `docs/changelog/`: Release changelog page tracking user-facing changes per version
+
+### Modified Capabilities
+- `_index.md` (homepage): Stack table updated to include `uf` CLI layer
+- `docs/getting-started/quick-start`: Stack table updated to include `uf` CLI layer
+- `config/_default/menus/menus.en.toml`: Navigation updated for new reference section
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- 2 new content pages created
+- 2-3 existing pages modified (stack table updates)
+- Navigation menu updated
+- This change is a foundation for subsequent command-specific docs (#57-#61)
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+Documentation pages do not affect artifact-based communication between heroes.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The CLI reference documents standalone functionality of each command group. The changelog page is independent of other sections. No mandatory dependencies introduced.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+A CLI reference page improves discoverability and makes the tool surface observable to users. The changelog provides provenance for version-level changes.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No code changes. Validation is `npm run build` + visual review.

--- a/openspec/changes/cli-reference-and-positioning/proposal.md
+++ b/openspec/changes/cli-reference-and-positioning/proposal.md
@@ -6,11 +6,13 @@ This change addresses GitHub issues #62 (CLI reference page) and #68 (changelog 
 
 ## What Changes
 
-1. **CLI reference page**: New page at `content/docs/reference/cli.md` listing all 6 command groups (`init`, `setup`, `doctor`, `config`, `sandbox`, `gateway`) with subcommands, flags, and brief descriptions.
+1. **CLI reference page**: New page at `content/docs/reference/cli.md` listing all current command groups with subcommands, flags, and brief descriptions — sourced from `uf --help` output at implementation time.
 
-2. **Stack table update**: Add `uf` CLI as a fourth layer in the stack table on `_index.md` and `quick-start.md` — positioned above the existing three tools as the glue layer.
+2. **Stack table update**: Add `uf` CLI as a fourth layer in the stack table on `content/docs/getting-started/_index.md` and `content/docs/getting-started/quick-start.md` — positioned above the existing three tools as the glue layer. Update "Three Tools" heading/prose to reflect the 4-layer model.
 
-3. **Changelog page**: New page at `content/docs/changelog/` tracking major releases with user-facing changes per version.
+3. **Changelog page**: New page at `content/docs/changelog/` tracking the current release with user-facing changes.
+
+4. **Code review persona clarification**: Add a note to the Code Review persona table in `content/docs/getting-started/common-workflows.md` clarifying that content personas (Scribe, Herald, Envoy) are invoked separately and do not participate in code review.
 
 ## Capabilities
 
@@ -19,44 +21,40 @@ This change addresses GitHub issues #62 (CLI reference page) and #68 (changelog 
 - `docs/changelog/`: Release changelog page tracking user-facing changes per version
 
 ### Modified Capabilities
-- `_index.md` (homepage): Stack table updated to include `uf` CLI layer
-- `docs/getting-started/quick-start`: Stack table updated to include `uf` CLI layer
-- `config/_default/menus/menus.en.toml`: Navigation updated for new reference section
+- `docs/getting-started/_index.md`: Stack table and heading updated to include `uf` CLI layer (4 layers)
+- `docs/getting-started/quick-start`: Stack table and prose updated to include `uf` CLI layer
+- `docs/getting-started/common-workflows.md`: Clarifying note added to Code Review persona table
+- `config/_default/menus/menus.en.toml`: Navigation updated for new reference and changelog sections
 
 ### Removed Capabilities
 - None
 
 ## Impact
 
-- 2 new content pages created
-- 2-3 existing pages modified (stack table updates)
-- Navigation menu updated
+- 2 new content pages created (CLI reference, changelog)
+- 3 existing pages modified (getting-started index, quick-start, common-workflows)
+- Navigation menu updated for Reference and Changelog sections
 - This change is a foundation for subsequent command-specific docs (#57-#61)
+- GitHub issues: [#62](https://github.com/unbound-force/website/issues/62), [#68](https://github.com/unbound-force/website/issues/68)
 
 ## Constitution Alignment
 
-Assessed against the Unbound Force org constitution.
+Assessed against the Unbound Force website project constitution (`.specify/memory/constitution.md`).
 
-### I. Autonomous Collaboration
-
-**Assessment**: N/A
-
-Documentation pages do not affect artifact-based communication between heroes.
-
-### II. Composability First
+### I. Content Accuracy
 
 **Assessment**: PASS
 
-The CLI reference documents standalone functionality of each command group. The changelog page is independent of other sections. No mandatory dependencies introduced.
+CLI reference content will be sourced from actual `uf --help` output and upstream repository source code at implementation time. Changelog entries will reflect actual shipped releases only, derived from git tags and release notes. A version marker on the CLI reference page will make staleness detectable.
 
-### III. Observable Quality
+### II. Minimal Footprint
 
 **Assessment**: PASS
 
-A CLI reference page improves discoverability and makes the tool surface observable to users. The changelog provides provenance for version-level changes.
+New pages use standard Markdown content with Doks built-in sidebar navigation. No custom layouts, CSS, or JavaScript required. The changelog introduces an ongoing maintenance commitment — this is justified by GitHub issue #68 and serves Visitor Clarity by answering "what's new?" Changelog updates will be part of the release process; if the changelog falls more than 2 releases behind, it should be removed rather than left stale.
 
-### IV. Testability
+### III. Visitor Clarity
 
-**Assessment**: N/A
+**Assessment**: PASS
 
-No code changes. Validation is `npm run build` + visual review.
+The CLI reference provides a single discoverable landing page for "what can `uf` do?" — currently this information is scattered across getting-started pages. The changelog answers "what's new?" for returning visitors. The 4-layer stack table clarifies the tool hierarchy by making the CLI's role as the entry point explicit. The new Reference navigation section improves discoverability for command-level documentation.

--- a/openspec/changes/cli-reference-and-positioning/specs/cli-reference.md
+++ b/openspec/changes/cli-reference-and-positioning/specs/cli-reference.md
@@ -2,27 +2,32 @@
 
 ### Requirement: cli-reference-page
 
-The website MUST have a CLI reference page at `content/docs/reference/cli.md` that lists all `uf` command groups and subcommands.
+The website MUST have a CLI reference page at `content/docs/reference/cli.md` that lists all current `uf` command groups and subcommands, sourced from `uf --help` output at implementation time.
 
 Each command group MUST include:
 - Command name and brief description
 - Table of subcommands (if applicable) with flags and descriptions
 - Link to detailed documentation page (if one exists)
 
+The page MUST include a version marker indicating which `uf` version the reference was generated from (e.g., "This page reflects `uf` vX.Y.Z. Run `uf --help` for the latest."). Changelog entries MUST be derived from actual release artifacts (git tags, release notes, merged PRs).
+
 #### Scenario: user visits CLI reference
 
 - **GIVEN** a user navigates to the CLI reference page
 - **WHEN** the page renders
-- **THEN** all 6 command groups MUST be listed: `init`, `setup`, `doctor`, `config`, `sandbox`, `gateway`
+- **THEN** all current command groups MUST be listed (expected at time of writing: `init`, `setup`, `doctor`, `config`, `sandbox`, `gateway`)
 - **AND** each group MUST show its subcommands and primary flags
+- **AND** the page MUST display a version marker indicating the `uf` version it was generated from
 
 ### Requirement: changelog-page
 
-The website MUST have a changelog page at `content/docs/changelog/_index.md` tracking user-facing changes per release.
+The website MUST have a changelog page at `content/docs/changelog/_index.md` tracking user-facing changes for the current release.
 
 Each release entry MUST include:
 - Version number and date
 - Summary of user-facing changes grouped by type (Added, Changed, Fixed)
+
+Changelog entries MUST be derived from actual release artifacts (git tags, release notes, merged PRs). Do not fabricate or estimate release contents.
 
 #### Scenario: user checks what's new
 
@@ -46,9 +51,9 @@ The website navigation MUST include a "Reference" section in the docs sidebar co
 
 ### Requirement: stack-table-includes-cli
 
-The stack positioning table on the homepage (`_index.md`) and quick-start page MUST include the `uf` CLI as a layer.
+The stack positioning table on the getting-started index page (`content/docs/getting-started/_index.md`) and quick-start page (`content/docs/getting-started/quick-start.md`) MUST include the `uf` CLI as a layer.
 
-Previously: The stack table listed 3 layers (Agent: OpenCode, Planning: Speckit, Coordination: Replicator).
+Previously: The stack table listed 3 layers (Agent: OpenCode, Planning: Speckit, Coordination: Replicator). The heading "Three Tools, One Workflow" and surrounding prose MUST be updated to reflect the 4-layer model.
 
 The updated table MUST show 4 layers:
 
@@ -59,12 +64,13 @@ The updated table MUST show 4 layers:
 | Planning | Speckit | Specification pipeline |
 | Coordination | Replicator | Multi-agent coordination |
 
-#### Scenario: user reads stack table on homepage
+#### Scenario: user reads stack table on getting-started pages
 
-- **GIVEN** a user visits the homepage or quick-start page
+- **GIVEN** a user visits the getting-started index or quick-start page
 - **WHEN** they read the stack/tools table
 - **THEN** the table MUST show 4 layers including the `uf` CLI layer
 - **AND** the CLI layer MUST be positioned first (top of table)
+- **AND** the section heading and prose MUST reflect the 4-layer model (not "Three Tools")
 
 ### Requirement: code-review-persona-scope
 

--- a/openspec/changes/cli-reference-and-positioning/specs/cli-reference.md
+++ b/openspec/changes/cli-reference-and-positioning/specs/cli-reference.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: cli-reference-page
+
+The website MUST have a CLI reference page at `content/docs/reference/cli.md` that lists all `uf` command groups and subcommands.
+
+Each command group MUST include:
+- Command name and brief description
+- Table of subcommands (if applicable) with flags and descriptions
+- Link to detailed documentation page (if one exists)
+
+#### Scenario: user visits CLI reference
+
+- **GIVEN** a user navigates to the CLI reference page
+- **WHEN** the page renders
+- **THEN** all 6 command groups MUST be listed: `init`, `setup`, `doctor`, `config`, `sandbox`, `gateway`
+- **AND** each group MUST show its subcommands and primary flags
+
+### Requirement: changelog-page
+
+The website MUST have a changelog page at `content/docs/changelog/_index.md` tracking user-facing changes per release.
+
+Each release entry MUST include:
+- Version number and date
+- Summary of user-facing changes grouped by type (Added, Changed, Fixed)
+
+#### Scenario: user checks what's new
+
+- **GIVEN** a user navigates to the changelog page
+- **WHEN** the page renders
+- **THEN** releases MUST be listed in reverse chronological order (newest first)
+- **AND** each release MUST summarize user-facing changes
+
+### Requirement: reference-nav-section
+
+The website navigation MUST include a "Reference" section in the docs sidebar containing the CLI reference page.
+
+#### Scenario: user finds reference section
+
+- **GIVEN** a user is browsing the documentation sidebar
+- **WHEN** they look for command reference information
+- **THEN** a "Reference" section MUST be visible in the navigation
+- **AND** it MUST contain a link to the CLI reference page
+
+## MODIFIED Requirements
+
+### Requirement: stack-table-includes-cli
+
+The stack positioning table on the homepage (`_index.md`) and quick-start page MUST include the `uf` CLI as a layer.
+
+Previously: The stack table listed 3 layers (Agent: OpenCode, Planning: Speckit, Coordination: Replicator).
+
+The updated table MUST show 4 layers:
+
+| Layer | Tool | What It Does |
+|-------|------|-------------|
+| CLI | `uf` | Project scaffolding, environment setup, health checks, configuration, sandboxed execution, LLM gateway |
+| Agent | OpenCode | AI coding environment |
+| Planning | Speckit | Specification pipeline |
+| Coordination | Replicator | Multi-agent coordination |
+
+#### Scenario: user reads stack table on homepage
+
+- **GIVEN** a user visits the homepage or quick-start page
+- **WHEN** they read the stack/tools table
+- **THEN** the table MUST show 4 layers including the `uf` CLI layer
+- **AND** the CLI layer MUST be positioned first (top of table)
+
+### Requirement: code-review-persona-scope
+
+The Code Review section in `common-workflows.md` persona table MUST clarify that it covers review personas only, not content personas.
+
+Previously: The table listed 6 personas without scoping the header.
+
+#### Scenario: user reads persona table
+
+- **GIVEN** a user reads the Code Review persona table
+- **WHEN** they see the 6-persona list
+- **THEN** a note MUST clarify that the 3 content personas (Scribe, Herald, Envoy) are invoked separately for content creation tasks and do not participate in code review
+
+## REMOVED Requirements
+
+_None._

--- a/openspec/changes/cli-reference-and-positioning/tasks.md
+++ b/openspec/changes/cli-reference-and-positioning/tasks.md
@@ -1,26 +1,29 @@
 ## 1. Create Reference section and CLI reference page
 
-- [ ] 1.1 Create `content/docs/reference/_index.md` section index with frontmatter (title: "Reference", weight appropriate for sidebar placement)
-- [ ] 1.2 Create `content/docs/reference/cli.md` with full CLI reference: all 6 command groups (`init`, `setup`, `doctor`, `config`, `sandbox`, `gateway`), subcommands, primary flags, and brief descriptions — sourced from upstream `unbound-force` repo
-- [ ] 1.3 Update `config/_default/menus/menus.en.toml` to add Reference section to top-level navigation if needed
+- [x] 1.1 Create `content/docs/reference/_index.md` section index with frontmatter (title: "Reference", weight appropriate for sidebar placement)
+- [x] 1.2 Create `content/docs/reference/cli.md` with full CLI reference: all current command groups, subcommands, primary flags, and brief descriptions — sourced from `uf --help` and `uf <command> --help` output. Include a version marker indicating which `uf` version the reference was generated from.
+- [x] 1.3 Update `config/_default/menus/menus.en.toml` to add Reference section to top-level navigation
 
 ## 2. Create Changelog page
 
-- [ ] 2.1 Create `content/docs/changelog/_index.md` with frontmatter and initial release entries (current release + key milestones)
-- [ ] 2.2 Add changelog to navigation menu if not auto-discovered by Hugo
+- [x] 2.1 Create `content/docs/changelog/_index.md` with frontmatter and the current release entry only — sourced from actual release artifacts (git tags, release notes, merged PRs)
+- [x] 2.2 Add a `[[docs]]` entry for Changelog in `config/_default/menus/menus.en.toml` with appropriate weight
 
 ## 3. Update stack positioning table
 
-- [ ] 3.1 Update `content/_index.md` stack table to add `uf` CLI as the first/top layer (4 layers total)
-- [ ] 3.2 Update `content/docs/getting-started/quick-start.md` stack table to add `uf` CLI layer
-- [ ] 3.3 Update `layouts/home.html` if the homepage template renders the stack table from HTML rather than Markdown
+- [x] 3.1 Update `content/docs/getting-started/_index.md` stack table and "Three Tools, One Workflow" heading/prose to reflect the 4-layer model with `uf` CLI as the first/top layer
+- [x] 3.2 Update `content/docs/getting-started/quick-start.md` stack table and surrounding prose to add `uf` CLI layer (4 layers total)
 
 ## 4. Update code review persona table scope
 
-- [ ] 4.1 Add clarifying note to the Code Review persona table in `content/docs/getting-started/common-workflows.md` stating that the 3 content personas (Scribe, Herald, Envoy) are invoked separately and do not participate in code review
+- [x] 4.1 Add clarifying note to the Code Review persona table in `content/docs/getting-started/common-workflows.md` stating that the 3 content personas (Scribe, Herald, Envoy) are invoked separately and do not participate in code review
 
 ## 5. Verification
 
-- [ ] 5.1 Run `npm run build` and confirm no build errors
-- [ ] 5.2 Run `npm run dev` and verify: CLI reference page renders with all command groups, changelog page renders, stack table shows 4 layers on homepage and quick-start, Reference section appears in navigation
-- [ ] 5.3 Verify both light and dark mode rendering for new pages
+- [x] 5.1 Run `npm run build` and confirm no build errors
+- [x] 5.2 Run `uf --help` and `uf <command> --help` for all command groups; verify the CLI reference page matches the actual command names, subcommands, and primary flags
+- [ ] 5.3 Run `npm run dev` and verify: CLI reference page renders with all command groups and version marker, changelog page renders with current release, stack table shows 4 layers on getting-started index and quick-start, Reference and Changelog sections appear in navigation
+- [x] 5.4 Verify all internal links in new pages resolve to existing pages (no dead links)
+- [ ] 5.5 Verify both light and dark mode rendering for new pages
+<!-- spec-review: passed -->
+<!-- code-review: passed -->

--- a/openspec/changes/cli-reference-and-positioning/tasks.md
+++ b/openspec/changes/cli-reference-and-positioning/tasks.md
@@ -1,0 +1,26 @@
+## 1. Create Reference section and CLI reference page
+
+- [ ] 1.1 Create `content/docs/reference/_index.md` section index with frontmatter (title: "Reference", weight appropriate for sidebar placement)
+- [ ] 1.2 Create `content/docs/reference/cli.md` with full CLI reference: all 6 command groups (`init`, `setup`, `doctor`, `config`, `sandbox`, `gateway`), subcommands, primary flags, and brief descriptions — sourced from upstream `unbound-force` repo
+- [ ] 1.3 Update `config/_default/menus/menus.en.toml` to add Reference section to top-level navigation if needed
+
+## 2. Create Changelog page
+
+- [ ] 2.1 Create `content/docs/changelog/_index.md` with frontmatter and initial release entries (current release + key milestones)
+- [ ] 2.2 Add changelog to navigation menu if not auto-discovered by Hugo
+
+## 3. Update stack positioning table
+
+- [ ] 3.1 Update `content/_index.md` stack table to add `uf` CLI as the first/top layer (4 layers total)
+- [ ] 3.2 Update `content/docs/getting-started/quick-start.md` stack table to add `uf` CLI layer
+- [ ] 3.3 Update `layouts/home.html` if the homepage template renders the stack table from HTML rather than Markdown
+
+## 4. Update code review persona table scope
+
+- [ ] 4.1 Add clarifying note to the Code Review persona table in `content/docs/getting-started/common-workflows.md` stating that the 3 content personas (Scribe, Herald, Envoy) are invoked separately and do not participate in code review
+
+## 5. Verification
+
+- [ ] 5.1 Run `npm run build` and confirm no build errors
+- [ ] 5.2 Run `npm run dev` and verify: CLI reference page renders with all command groups, changelog page renders, stack table shows 4 layers on homepage and quick-start, Reference section appears in navigation
+- [ ] 5.3 Verify both light and dark mode rendering for new pages


### PR DESCRIPTION
## Summary

- **CLI Reference Page** — New page at `/docs/reference/cli/` with complete command reference for all `uf` command groups (`init`, `setup`, `doctor`, `config`, `sandbox`, `gateway`), including subcommands, flags, and descriptions. Version marker (v0.12.0) for staleness detection.
- **Changelog Page** — New page at `/docs/changelog/` with v0.12.0 release entry sourced from actual GitHub release artifacts.
- **Stack Table Update** — Updated from 3 to 4 layers on both getting-started index and quick-start pages, adding `uf` CLI as the top layer.
- **Navigation** — Added Reference and Changelog sections to the docs sidebar menu.
- **Persona Table Clarification** — Added note to code review section clarifying that Scribe, Herald, and Envoy are content personas invoked separately.

Closes #62, closes #68

## Spec Artifacts

All artifacts in `openspec/changes/cli-reference-and-positioning/` — proposal, design, specs, and tasks updated per review council findings (constitution alignment corrected, file targets fixed, changelog scope aligned).

## Verification

```bash
npm run build   # passes — 108 pages, no errors
npm run dev     # then visit /docs/reference/cli/, /docs/changelog/
```