### PR TITLE
fix: correct critical doc errors — /finale, /unleash, uf init, mxf

### DIFF
--- a/.uf/dewey/learnings/critical-doc-fixes-1.md
+++ b/.uf/dewey/learnings/critical-doc-fixes-1.md
@@ -1,0 +1,9 @@
+---
+tag: critical-doc-fixes
+category: gotcha
+created_at: 2026-05-02T22:08:02Z
+identity: critical-doc-fixes-1
+tier: draft
+---
+
+When fixing factual errors in the Unbound Force website documentation, always grep all files under content/ for every stale pattern being corrected before writing the spec. The critical-doc-fixes change initially scoped /finale merge corrections to 3 docs pages but the Adversary spec reviewer found a 4th instance in blog/unleash-in-practice.md and 3 additional instances in developer.md (Session Lifecycle table, Session Ritual prose, Session Ritual code block) beyond the single reference originally targeted. The blog post was entirely missed from the original scope. Always run a site-wide search for stale patterns before writing the spec, not just as a verification task after implementation.

--- a/content/blog/unleash-in-practice.md
+++ b/content/blog/unleash-in-practice.md
@@ -132,11 +132,11 @@ Every exit message tells you what happened, what to do next, and how to resume. 
 
 `/unleash` builds. [`/finale`](/docs/getting-started/common-workflows/#end-of-branch-workflow-finale) ships.
 
-After `/unleash` presents demo instructions, run `/finale` to automate the end-of-branch workflow: stage all changes, generate a conventional commit message, push, create a PR, watch CI checks, rebase-merge, and return to `main`. The full developer loop is two commands:
+After `/unleash` presents demo instructions, run `/finale` to automate the end-of-branch workflow: stage all changes, generate a conventional commit message, push, create a PR, watch CI checks, and return to `main`. The PR stays open for human review. The full developer loop is two commands:
 
 ```text
 /unleash       # spec → demo-ready code
-/finale        # commit → push → PR → merge → main
+/finale        # commit → push → PR → main
 ```
 
 ## Every Tool Is Optional

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -35,17 +35,17 @@ toc: true
 
 ### Branch Safety
 
-`/unleash` requires a Speckit feature branch (`NNN-*`). It never runs on `main` and rejects `opsx/*` branches (use `/opsx-apply` instead). It validates that `spec.md` exists before proceeding.
+`/unleash` works with both Speckit (`NNN-*`) and OpenSpec (`opsx/*`) feature branches. It never runs on `main`. For Speckit branches, it validates that `spec.md` exists. For OpenSpec branches, it detects the change name from the branch (`opsx/<name>`) and reads tasks from `openspec/changes/<name>/tasks.md`.
 
-After `/unleash` completes, the demo step suggests running `/finale` to commit, push, create a PR, and merge.
+After `/unleash` completes, the demo step suggests running `/finale` to commit, push, and create a PR.
 
 See also: [From Spec to Demo in One Command](/blog/unleash-in-practice/) — a narrative walkthrough of the pipeline.
 
 ## End-of-Branch Workflow (`/finale`)
 
-`/finale` automates the end-of-branch workflow — one command to stage, commit, push, create a PR, watch CI, merge, and return to main.
+`/finale` automates the end-of-branch workflow — one command to stage, commit, push, create a PR, watch CI, and return to main. The PR stays open for human review.
 
-### The 9-Step Workflow
+### The 8-Step Workflow
 
 | Step | Name                        | Description                                                                         |
 | ---- | --------------------------- | ----------------------------------------------------------------------------------- |
@@ -55,20 +55,18 @@ See also: [From Spec to Demo in One Command](/blog/unleash-in-practice/) — a n
 | 4    | **Push to Remote**          | Sets upstream if needed (`git push -u origin <branch>`).                            |
 | 5    | **Create or Find PR**       | Creates PR via `gh pr create` or finds existing one.                                |
 | 6    | **Watch CI Checks**         | `gh pr checks --watch`. Stops on failure with options.                              |
-| 7    | **Merge PR**                | `gh pr merge --rebase --delete-branch`. Always uses rebase merge strategy.          |
-| 8    | **Return to Main**          | `git checkout main && git pull`.                                                    |
-| 9    | **Summary**                 | Displays completion report: branch, commit, PR, checks, status.                     |
+| 7    | **Return to Main**          | `git checkout main && git pull`.                                                    |
+| 8    | **Summary**                 | Displays completion report: branch, commit, PR, checks, status.                     |
 
 ### Guardrails
 
 - Never runs on `main`
-- Never merges with failing CI checks
+- Never merges the PR — creates PRs for review, not for immediate merge
 - Never stages secret files (`.env`, `credentials.json`, `*.key`, `*.pem`) without warning
 - Never commits without user approval of the commit message
-- Always uses rebase merge strategy (no squash or merge commits)
 - If any step fails, stops immediately with context and options
 
-`/finale` works with both Speckit (`NNN-*`) and OpenSpec (`opsx/*`) branches. It is the natural complement to `/unleash` — `/unleash` builds, `/finale` ships.
+`/finale` works with both Speckit (`NNN-*`) and OpenSpec (`opsx/*`) branches. It is the natural complement to `/unleash` — `/unleash` builds, `/finale` wraps up the branch and creates a PR for review.
 
 ## New Feature (End-to-End) {#new-feature-end-to-end}
 

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -65,7 +65,7 @@ For features that need architectural planning:
 
    If `/unleash` pauses (unanswerable question, spec finding, build failure), fix the issue and re-run. If the spec needs refinement, run `/speckit.clarify` then `/unleash` again.
 
-4. **Finale** (build mode): Ship it -- commit, push, PR, merge, return to main
+4. **Finale** (build mode): Wrap up -- commit, push, and create a PR for review
 
    ```text
    /finale
@@ -179,7 +179,7 @@ Every session follows this ritual:
 | --------- | ------------------------------------- | --------------------------------------- |
 | **Start** | `/speckit.specify` or `/opsx-propose` | Define the work                         |
 | **Work**  | `/unleash` or `/cobalt-crush`         | Execute the work                        |
-| **End**   | `/finale`                             | Commit, push, PR, merge, return to main |
+| **End**   | `/finale`                             | Commit, push, create PR for review      |
 
 ## Cobalt-Crush Persona
 
@@ -291,17 +291,16 @@ uf init [--divisor] [--lang go|typescript] [--force]
 
 ### What Gets Deployed
 
-`uf init` deploys approximately 50 files across these categories:
+`uf init` deploys approximately 35 user-owned files plus tool-owned files (Speckit commands, OpenSpec schemas, etc.) across these categories:
 
-| Category         | Files   | Examples                                                                                   |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------ |
-| Agents           | ~12     | 6 Divisor personas, Cobalt-Crush, Constitution Check, Mx F Coach                           |
-| Commands         | ~15     | 9 Speckit commands, review-council, constitution-check, cobalt-crush                       |
-| Convention Packs | 9       | default, go, typescript, content (each with tool-owned and user-owned variants) + severity |
-| Templates        | ~6      | spec, plan, tasks, checklist, constitution, agent-file templates                           |
-| Scripts          | ~5      | check-prerequisites, setup-plan, create-new-feature, update-agent-context                  |
-| OpenSpec         | ~6      | config, schema, 4 templates (design, proposal, spec, tasks)                                |
-| `.gitignore`     | Managed | UF runtime and legacy tool ignore patterns                                                 |
+| Category         | Files   | Examples                                                                                                     |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| Agents           | ~12     | 9 Divisor personas (6 review + 3 content), Cobalt-Crush, Constitution Check, Mx F Coach                     |
+| Commands         | ~8      | review-council, review-pr, constitution-check, cobalt-crush, unleash, uf-init, agent-brief, finale           |
+| Convention Packs | 9       | default, go, typescript, content (each with tool-owned and user-owned variants) + severity                   |
+| OpenSpec         | ~5      | config, schema, templates (design, proposal, spec, tasks)                                                    |
+| Skills           | 1       | speckit-workflow                                                                                             |
+| `.gitignore`     | Managed | UF runtime and legacy tool ignore patterns                                                                   |
 
 `uf init` also manages `.gitignore` entries. It appends a standard Unbound Force ignore block (marked with `# Unbound Force — managed by uf init`) that covers `.uf/` runtime data (databases, caches, locks, logs) and legacy tool directories (`.dewey/`, `.hive/`, `.unbound-force/`, `.muti-mind/`, `.mx-f/`). The behavior is append-only — existing `.gitignore` content is never modified or removed. If `.gitignore` does not exist, it is created. The operation is idempotent: running `uf init` multiple times does not duplicate the ignore block.
 
@@ -332,13 +331,13 @@ After completion, `uf init` shows a summary with file dispositions (`+` created,
 
 ## Session Ritual
 
-The most important habit: **always end your session properly**. The daily workflow follows a specify → unleash → finale loop. When you are done working, run `/finale` to commit, push, create a PR, and merge:
+The most important habit: **always end your session properly**. The daily workflow follows a specify → unleash → finale loop. When you are done working, run `/finale` to commit, push, and create a PR for review:
 
 ```text
-/finale        # commit → push → PR → merge → main
+/finale        # commit → push → PR → main
 ```
 
-`/finale` handles the full end-of-branch workflow: staging changes, generating a conventional commit message, pushing to remote, creating a PR, watching CI checks, rebase-merging, and returning to `main`. The session is not complete until `git push` succeeds — this ensures your work items, semantic memory learnings, and file reservation state are available for your next session and for other team members who may pick up where you left off.
+`/finale` handles the full end-of-branch workflow: staging changes, generating a conventional commit message, pushing to remote, creating a PR, watching CI checks, and returning to `main`. The PR stays open for human review — `/finale` never merges. The session is not complete until `git push` succeeds — this ensures your work items, semantic memory learnings, and file reservation state are available for your next session and for other team members who may pick up where you left off.
 
 ## Next Steps
 

--- a/content/docs/getting-started/product-manager.md
+++ b/content/docs/getting-started/product-manager.md
@@ -28,11 +28,13 @@ The `mxf` command-line tool provides 7 subcommands for sprint management:
 | `mxf standup`    | Facilitate daily standups            |
 | `mxf retro`      | Facilitate retrospectives            |
 
-Install via Homebrew (included with the `unbound-force` package, the `uf` CLI):
+Install via Homebrew (separate formula from the `uf` CLI):
 
 ```bash
-brew install unbound-force/tap/unbound-force
+brew install unbound-force/tap/mxf
 ```
+
+Alternatively, `uf setup` installs the full toolchain including `mxf`.
 
 ## Reading the Dashboard
 

--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -48,7 +48,7 @@ Start in plan mode to explore your idea, then switch to build mode:
 ```text
 /speckit.specify    # describe what you want to build
 /unleash            # the swarm takes it from here
-/finale             # ship it
+/finale             # commit, push, create PR
 ```
 
 `/unleash` runs the entire pipeline autonomously: clarify, plan, implement, test, and review. It pauses when it needs you and resumes where it left off. See the [blog post](/blog/unleash-in-practice/) for a walkthrough.
@@ -60,7 +60,7 @@ For bug fixes and tactical changes:
 ```text
 /opsx-propose fix-the-bug    # create proposal + design + tasks
 /cobalt-crush                # implement with convention pack adherence
-/finale                      # ship it
+/finale                      # commit, push, create PR
 ```
 
 ## The Stack

--- a/openspec/changes/critical-doc-fixes/.openspec.yaml
+++ b/openspec/changes/critical-doc-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-02

--- a/openspec/changes/critical-doc-fixes/design.md
+++ b/openspec/changes/critical-doc-fixes/design.md
@@ -1,0 +1,29 @@
+## Context
+
+The website has four factual errors or stale data points in its getting-started documentation. These were identified through cross-referencing shipped command behavior (in `unbound-force/unbound-force`) against the website's descriptions. All four are text-only corrections — no layout, template, or configuration changes.
+
+## Goals / Non-Goals
+
+### Goals
+- Correct all four factual errors in a single change
+- Ensure corrected text matches the shipped command behavior (source of truth: `.opencode/command/*.md` in the `unbound-force` repo)
+- Preserve page structure, frontmatter, and surrounding content
+
+### Non-Goals
+- Restructuring the getting-started section
+- Adding new documentation pages
+- Updating command reference tables (covered by separate CLI reference change)
+- Addressing other stale content not identified in issues #53-#56
+
+## Decisions
+
+1. **Bundle four fixes into one change**: All four are small, non-overlapping text corrections. Separate branches per fix would add overhead without benefit.
+
+2. **Source of truth is shipped commands, not specs**: Issue #53 is notable — the `/finale` spec (opsx/finale-command) includes a `finale-merge` requirement, but the shipped command at `.opencode/command/finale.md` explicitly says "NEVER merge the PR." The shipped behavior is the source of truth for documentation.
+
+3. **Exact replacement text from issues**: Each issue provides explicit before/after text. Use the issue-provided corrections verbatim rather than rephrasing.
+
+## Risks / Trade-offs
+
+- **Risk**: The `/finale` spec and shipped command disagree on merge behavior. If the spec is later re-implemented, the docs would need updating again. Accepted — we document shipped behavior, not planned behavior.
+- **Risk**: File count (#55) may drift again as commands are added/removed. Accepted — use "approximately" language and update the breakdown table to match current state.

--- a/openspec/changes/critical-doc-fixes/proposal.md
+++ b/openspec/changes/critical-doc-fixes/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+The website contains factual errors and stale data that actively mislead users. Two are CRITICAL severity (users following the instructions will get wrong results), and two are HIGH severity (users get incorrect expectations about tooling).
+
+These corrections address GitHub issues #53, #54, #55, and #56 — all tagged `release-ready`.
+
+## What Changes
+
+Four surgical text corrections across four documentation pages:
+
+1. **`/finale` merge behavior** (#53): Three pages describe `/finale` as merging PRs. The shipped command explicitly states "NEVER merge the PR" — it creates PRs for review only. Fix across `common-workflows.md`, `quick-start.md`, and `developer.md`.
+
+2. **`/unleash` branch support** (#54): `common-workflows.md` states `/unleash` rejects `opsx/*` branches. Since Spec 031, `/unleash` supports both `NNN-*` and `opsx/*` branches. Fix in `common-workflows.md`.
+
+3. **`uf init` file count and breakdown** (#55): `developer.md` states "approximately 50 files" and lists stale command/agent counts. Correct to ~35 files, update the breakdown table to reflect externalized Speckit commands and added content personas.
+
+4. **`mxf` install instruction** (#56): `product-manager.md` implies `mxf` is bundled with the `unbound-force` Homebrew package. It's a separate formula. Correct the install instruction.
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `docs/getting-started/common-workflows`: Corrected `/finale` and `/unleash` descriptions
+- `docs/getting-started/quick-start`: Corrected `/finale` description
+- `docs/getting-started/developer`: Corrected `/finale` description, file count, and command breakdown
+- `docs/getting-started/product-manager`: Corrected `mxf` install instruction
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- 4 Markdown content pages modified
+- No layout, style, or configuration changes
+- No new pages created
+- All changes are text corrections within existing content
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: N/A
+
+Documentation text corrections do not affect artifact-based communication between heroes.
+
+### II. Composability First
+
+**Assessment**: N/A
+
+No tool behavior or dependency changes — text-only corrections.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Corrections improve the accuracy of published documentation, which is a form of observable output quality. Users reading the docs will get correct information about command behavior.
+
+### IV. Testability
+
+**Assessment**: N/A
+
+No code changes. Validation is manual: `npm run build` succeeds and corrected text renders properly.

--- a/openspec/changes/critical-doc-fixes/proposal.md
+++ b/openspec/changes/critical-doc-fixes/proposal.md
@@ -8,7 +8,7 @@ These corrections address GitHub issues #53, #54, #55, and #56 — all tagged `r
 
 Four surgical text corrections across four documentation pages:
 
-1. **`/finale` merge behavior** (#53): Three pages describe `/finale` as merging PRs. The shipped command explicitly states "NEVER merge the PR" — it creates PRs for review only. Fix across `common-workflows.md`, `quick-start.md`, and `developer.md`.
+1. **`/finale` merge behavior** (#53): Four pages describe `/finale` as merging PRs. The shipped command explicitly states "NEVER merge the PR" — it creates PRs for review only. Fix across `common-workflows.md`, `quick-start.md`, `developer.md`, and `blog/unleash-in-practice.md`.
 
 2. **`/unleash` branch support** (#54): `common-workflows.md` states `/unleash` rejects `opsx/*` branches. Since Spec 031, `/unleash` supports both `NNN-*` and `opsx/*` branches. Fix in `common-workflows.md`.
 
@@ -23,44 +23,39 @@ Four surgical text corrections across four documentation pages:
 
 ### Modified Capabilities
 - `docs/getting-started/common-workflows`: Corrected `/finale` and `/unleash` descriptions
-- `docs/getting-started/quick-start`: Corrected `/finale` description
-- `docs/getting-started/developer`: Corrected `/finale` description, file count, and command breakdown
+- `docs/getting-started/quick-start`: Corrected `/finale` description (both code blocks)
+- `docs/getting-started/developer`: Corrected `/finale` description (4 locations), file count, and command breakdown
 - `docs/getting-started/product-manager`: Corrected `mxf` install instruction
+- `blog/unleash-in-practice`: Corrected `/finale` description in "The Complete Loop" section
 
 ### Removed Capabilities
 - None
 
 ## Impact
 
-- 4 Markdown content pages modified
+- 5 Markdown content pages modified (4 docs + 1 blog)
 - No layout, style, or configuration changes
 - No new pages created
 - All changes are text corrections within existing content
 
 ## Constitution Alignment
 
-Assessed against the Unbound Force org constitution.
+Assessed against the Unbound Force website project constitution (`.specify/memory/constitution.md`).
 
-### I. Autonomous Collaboration
-
-**Assessment**: N/A
-
-Documentation text corrections do not affect artifact-based communication between heroes.
-
-### II. Composability First
-
-**Assessment**: N/A
-
-No tool behavior or dependency changes — text-only corrections.
-
-### III. Observable Quality
+### I. Content Accuracy
 
 **Assessment**: PASS
 
-Corrections improve the accuracy of published documentation, which is a form of observable output quality. Users reading the docs will get correct information about command behavior.
+This change exists specifically to fix Content Accuracy violations. All four corrections align documentation with the shipped command behavior (source of truth: `.opencode/command/*.md` in the `unbound-force/unbound-force` repo). The `uf init` file count (~35 files) and breakdown were verified against the current scaffold assets.
 
-### IV. Testability
+### II. Minimal Footprint
 
-**Assessment**: N/A
+**Assessment**: PASS
 
-No code changes. Validation is manual: `npm run build` succeeds and corrected text renders properly.
+Text-only corrections within existing Markdown content. No new pages, layouts, CSS, JavaScript, or dependencies.
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+Correcting factual errors directly improves visitor clarity. Users reading corrected docs will get accurate expectations about `/finale` (creates PRs, does not merge), `/unleash` (supports both branch types), `uf init` (correct file count), and `mxf` (separate install).

--- a/openspec/changes/critical-doc-fixes/specs/corrections.md
+++ b/openspec/changes/critical-doc-fixes/specs/corrections.md
@@ -21,15 +21,22 @@ Previously: `/finale` was described as merging PRs with rebase strategy, includi
 #### Scenario: user reads finale in quick-start
 
 - **GIVEN** a user visits the Quick Start page
-- **WHEN** they read the workflow code block
-- **THEN** the `/finale` comment MUST say "commit, push, create PR" not "ship it"
+- **WHEN** they read the workflow code blocks (Large Tasks and Small Tasks)
+- **THEN** all `/finale` comments MUST say "commit, push, create PR" not "ship it"
 
 #### Scenario: user reads finale in developer guide
 
 - **GIVEN** a user visits the Developer Guide page
-- **WHEN** they read the daily workflow section
-- **THEN** the text MUST say "run `/finale` to commit, push, and create a PR"
-- **AND** MUST NOT say "and merge"
+- **WHEN** they read the daily workflow section, Session Lifecycle table, and Session Ritual section
+- **THEN** all references to `/finale` MUST say "commit, push, and create a PR"
+- **AND** MUST NOT say "and merge" or "rebase-merge"
+
+#### Scenario: user reads finale in blog post
+
+- **GIVEN** a user reads the "Unleash in Practice" blog post
+- **WHEN** they read "The Complete Loop" section
+- **THEN** the `/finale` description MUST NOT mention "rebase-merge"
+- **AND** the code block comment MUST NOT include "merge"
 
 ### Requirement: unleash-branch-support-accuracy
 

--- a/openspec/changes/critical-doc-fixes/specs/corrections.md
+++ b/openspec/changes/critical-doc-fixes/specs/corrections.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+_None._
+
+## MODIFIED Requirements
+
+### Requirement: finale-description-accuracy
+
+The website MUST describe `/finale` as creating a PR for review. The website MUST NOT state that `/finale` merges PRs.
+
+Previously: `/finale` was described as merging PRs with rebase strategy, including a "Merge PR" step in the workflow table.
+
+#### Scenario: user reads finale description in common-workflows
+
+- **GIVEN** a user visits the Common Workflows page
+- **WHEN** they read the `/finale` workflow steps
+- **THEN** the steps MUST NOT include a "Merge PR" step
+- **AND** the guardrails MUST state "Never merges the PR — creates PRs for review, not for immediate merge"
+- **AND** the description MUST say "/unleash builds, /finale wraps up the branch and creates a PR for review"
+
+#### Scenario: user reads finale in quick-start
+
+- **GIVEN** a user visits the Quick Start page
+- **WHEN** they read the workflow code block
+- **THEN** the `/finale` comment MUST say "commit, push, create PR" not "ship it"
+
+#### Scenario: user reads finale in developer guide
+
+- **GIVEN** a user visits the Developer Guide page
+- **WHEN** they read the daily workflow section
+- **THEN** the text MUST say "run `/finale` to commit, push, and create a PR"
+- **AND** MUST NOT say "and merge"
+
+### Requirement: unleash-branch-support-accuracy
+
+The website MUST describe `/unleash` as supporting both `NNN-*` and `opsx/*` branches. The website MUST NOT state that `/unleash` rejects `opsx/*` branches.
+
+Previously: `/unleash` was described as rejecting `opsx/*` branches.
+
+#### Scenario: user reads unleash description
+
+- **GIVEN** a user visits the Common Workflows page
+- **WHEN** they read the `/unleash` section
+- **THEN** the text MUST state that `/unleash` works with both Speckit (`NNN-*`) and OpenSpec (`opsx/*`) branches
+- **AND** MUST explain that for OpenSpec branches, it detects the change name and reads tasks from `openspec/changes/<name>/tasks.md`
+
+### Requirement: uf-init-file-count-accuracy
+
+The website MUST state the correct approximate file count for `uf init` scaffolding and MUST list accurate command and agent counts.
+
+Previously: File count stated as "approximately 50 files" with stale breakdown (Commands ~15, Agents ~12 with incomplete persona list).
+
+#### Scenario: user reads uf init scaffolding details
+
+- **GIVEN** a user visits the Developer Guide page
+- **WHEN** they read the `uf init` section
+- **THEN** the file count MUST state "approximately 35 files"
+- **AND** the Commands count MUST be 8 with the correct list (review-council, review-pr, constitution-check, cobalt-crush, unleash, uf-init, agent-brief, finale)
+- **AND** the Agents count MUST list 9 Divisor personas (6 review + 3 content), Cobalt-Crush, Constitution Check, Mx F Coach
+
+### Requirement: mxf-install-accuracy
+
+The website MUST NOT imply that `mxf` is bundled with the `unbound-force` Homebrew package. The install instruction MUST show the separate formula or the `uf setup` path.
+
+Previously: Install instruction stated `brew install unbound-force/tap/unbound-force` includes `mxf`.
+
+#### Scenario: user reads mxf install instruction
+
+- **GIVEN** a user visits the Product Manager guide
+- **WHEN** they read the Mx F installation section
+- **THEN** the instruction MUST show `brew install unbound-force/tap/mxf` as the direct install
+- **AND** MAY show `uf setup` as an alternative that installs the full toolchain
+
+## REMOVED Requirements
+
+_None._

--- a/openspec/changes/critical-doc-fixes/tasks.md
+++ b/openspec/changes/critical-doc-fixes/tasks.md
@@ -1,24 +1,27 @@
 ## 1. Fix `/finale` merge description (#53)
 
-- [ ] 1.1 Update `content/docs/getting-started/common-workflows.md`: Remove "Merge PR" step from the `/finale` workflow table, renumber remaining steps, update guardrails to say "Never merges the PR", update description to say "/finale wraps up the branch and creates a PR for review"
-- [ ] 1.2 Update `content/docs/getting-started/quick-start.md`: Change `/finale # ship it` comment to `/finale # commit, push, create PR`
-- [ ] 1.3 Update `content/docs/getting-started/developer.md`: Change "run `/finale` to commit, push, create a PR, and merge" to "run `/finale` to commit, push, and create a PR"
+- [x] 1.1 Update `content/docs/getting-started/common-workflows.md`: Remove "Merge PR" step from the `/finale` workflow table, renumber remaining steps, update guardrails to say "Never merges the PR", update description to say "/finale wraps up the branch and creates a PR for review"
+- [x] 1.2 Update `content/docs/getting-started/quick-start.md`: Change **both** `/finale # ship it` comments (Large Tasks and Small Tasks code blocks) to `/finale # commit, push, create PR`
+- [x] 1.3 Update `content/docs/getting-started/developer.md`: Fix **all four** `/finale` merge references: (a) daily workflow description, (b) Session Lifecycle table "End" row, (c) Session Ritual prose, (d) Session Ritual code block comment — remove "merge" and "rebase-merge" language, replace with "create a PR"
+- [x] 1.4 Update `content/blog/unleash-in-practice.md`: Fix The Complete Loop section — remove "rebase-merge" from prose (line 135) and change code block comment from "merge → main" to "PR → main" (line 139)
 
 ## 2. Fix `/unleash` branch support (#54)
 
-- [ ] 2.1 Update `content/docs/getting-started/common-workflows.md`: Replace text stating `/unleash` rejects `opsx/*` branches with text stating it supports both `NNN-*` and `opsx/*` branches, including OpenSpec task detection behavior
+- [x] 2.1 Update `content/docs/getting-started/common-workflows.md`: Replace text stating `/unleash` rejects `opsx/*` branches with text stating it supports both `NNN-*` and `opsx/*` branches, including OpenSpec task detection behavior
 
 ## 3. Fix `uf init` file count and breakdown (#55)
 
-- [ ] 3.1 Update `content/docs/getting-started/developer.md`: Change "approximately 50 files" to "approximately 35 files"
-- [ ] 3.2 Update the breakdown table in `developer.md`: Set Commands to 8 (review-council, review-pr, constitution-check, cobalt-crush, unleash, uf-init, agent-brief, finale), set Agents to 12 (9 Divisor personas including 3 content, Cobalt-Crush, Constitution Check, Mx F Coach)
+- [x] 3.1 Verify current file counts against upstream `unbound-force/unbound-force/.opencode/command/` and `.opencode/agents/` directories before writing
+- [x] 3.2 Update `content/docs/getting-started/developer.md`: Change "approximately 50 files" to the verified count (~35), update the breakdown table to reflect current command and agent counts (verify against upstream at implementation time)
 
 ## 4. Fix `mxf` install instruction (#56)
 
-- [ ] 4.1 Update `content/docs/getting-started/product-manager.md`: Replace the stale `brew install unbound-force/tap/unbound-force` instruction with `brew install unbound-force/tap/mxf` and add `uf setup` as an alternative
+- [x] 4.1 Update `content/docs/getting-started/product-manager.md`: Replace the stale `brew install unbound-force/tap/unbound-force` instruction with `brew install unbound-force/tap/mxf` and add `uf setup` as an alternative
 
 ## 5. Verification
 
-- [ ] 5.1 Run `npm run build` and confirm no build errors
-- [ ] 5.2 Run `npm run dev` and visually verify all four corrected pages render correctly
-- [ ] 5.3 Verify no other pages reference the stale `/finale` merge behavior or `/unleash` opsx rejection
+- [x] 5.1 Run `npm run build` and confirm no build errors
+- [ ] 5.2 Run `npm run dev` and visually verify all corrected pages render correctly
+- [x] 5.3 Search all files under `content/` for remaining references to `/finale` merging PRs or `/unleash` rejecting `opsx/*` branches (colloquial uses of "ship" that don't imply PR merging are acceptable)
+<!-- spec-review: passed -->
+<!-- code-review: passed -->

--- a/openspec/changes/critical-doc-fixes/tasks.md
+++ b/openspec/changes/critical-doc-fixes/tasks.md
@@ -1,0 +1,24 @@
+## 1. Fix `/finale` merge description (#53)
+
+- [ ] 1.1 Update `content/docs/getting-started/common-workflows.md`: Remove "Merge PR" step from the `/finale` workflow table, renumber remaining steps, update guardrails to say "Never merges the PR", update description to say "/finale wraps up the branch and creates a PR for review"
+- [ ] 1.2 Update `content/docs/getting-started/quick-start.md`: Change `/finale # ship it` comment to `/finale # commit, push, create PR`
+- [ ] 1.3 Update `content/docs/getting-started/developer.md`: Change "run `/finale` to commit, push, create a PR, and merge" to "run `/finale` to commit, push, and create a PR"
+
+## 2. Fix `/unleash` branch support (#54)
+
+- [ ] 2.1 Update `content/docs/getting-started/common-workflows.md`: Replace text stating `/unleash` rejects `opsx/*` branches with text stating it supports both `NNN-*` and `opsx/*` branches, including OpenSpec task detection behavior
+
+## 3. Fix `uf init` file count and breakdown (#55)
+
+- [ ] 3.1 Update `content/docs/getting-started/developer.md`: Change "approximately 50 files" to "approximately 35 files"
+- [ ] 3.2 Update the breakdown table in `developer.md`: Set Commands to 8 (review-council, review-pr, constitution-check, cobalt-crush, unleash, uf-init, agent-brief, finale), set Agents to 12 (9 Divisor personas including 3 content, Cobalt-Crush, Constitution Check, Mx F Coach)
+
+## 4. Fix `mxf` install instruction (#56)
+
+- [ ] 4.1 Update `content/docs/getting-started/product-manager.md`: Replace the stale `brew install unbound-force/tap/unbound-force` instruction with `brew install unbound-force/tap/mxf` and add `uf setup` as an alternative
+
+## 5. Verification
+
+- [ ] 5.1 Run `npm run build` and confirm no build errors
+- [ ] 5.2 Run `npm run dev` and visually verify all four corrected pages render correctly
+- [ ] 5.3 Verify no other pages reference the stale `/finale` merge behavior or `/unleash` opsx rejection


### PR DESCRIPTION
## Summary

Four surgical text corrections for factual errors across five content pages:

- **`/finale` merge behavior** (#53) — Removed "Merge PR" step from workflow table, updated guardrails and descriptions across `common-workflows.md`, `quick-start.md`, `developer.md` (4 locations), and `blog/unleash-in-practice.md`. `/finale` creates PRs for review, never merges.
- **`/unleash` branch support** (#54) — Changed from "rejects `opsx/*` branches" to "works with both `NNN-*` and `opsx/*`" with OpenSpec task detection behavior.
- **`uf init` file count** (#55) — Changed from ~50 to ~35 files. Updated breakdown table: Commands 15→8, Agents now lists 9 Divisor personas (6 review + 3 content).
- **`mxf` install instruction** (#56) — Changed from `brew install unbound-force/tap/unbound-force` to `brew install unbound-force/tap/mxf` with `uf setup` alternative.

Closes #53, closes #54, closes #55, closes #56