### PR TITLE
docs: add sandbox isolation blog post

### DIFF
--- a/.uf/dewey/learnings/blog-sandbox-isolation-1.md
+++ b/.uf/dewey/learnings/blog-sandbox-isolation-1.md
@@ -1,0 +1,9 @@
+---
+tag: blog-sandbox-isolation
+category: gotcha
+created_at: 2026-05-03T16:51:29Z
+identity: blog-sandbox-isolation-1
+tier: draft
+---
+
+When writing blog posts about the Unbound Force sandbox for the website, be careful with credential statements in the Google Cloud / Vertex AI section. The sandbox has two credential paths that are easy to conflate: the gateway path (where no credentials are mounted — the gateway runs on the host and proxies requests) and the direct mount fallback path (where service account key files or gcloud ADC directories are mounted read-only into the container). Writing "no credentials are mounted" and then describing credential mounts in the next sentence is a Content Accuracy contradiction that the code review Guard will flag. Always distinguish the gateway path from the fallback credential paths.

--- a/content/blog/sandbox-isolation.md
+++ b/content/blog/sandbox-isolation.md
@@ -1,0 +1,169 @@
+---
+title: "Isolate Your AI Agents with uf sandbox — Containerized OpenCode Sessions via Podman"
+description: "AI coding agents run with full access to your filesystem. uf sandbox wraps the entire session in a Podman container — one command replaces manual container setup, and your repo stays untouchable."
+lead: "Your repo is untouchable. One command puts your AI agent in a container where it can read your code but cannot modify your files. Changes come out only through a reviewed patch extraction."
+slug: "sandbox-isolation"
+date: 2026-05-03T00:00:00+00:00
+draft: false
+weight: 70
+toc: true
+categories: ["Engineering"]
+tags: ["sandbox", "podman", "isolation", "security"]
+contributors: ["Unbound Force"]
+---
+
+## The Problem
+
+AI coding agents are powerful collaborators, but they run with the same filesystem access as any other process on your machine. When an agent executes a command, it is real — `rm -rf`, `git push --force`, a corrupted `.git` directory, a rewritten configuration file. The damage is immediate and often irreversible.
+
+The standard mitigations do not hold up. "Be careful with your prompts" is not a security boundary. `git stash` protects committed files but not untracked work. Running the agent in a separate directory means maintaining two copies of your project. None of these approaches provide actual isolation — the agent still has write access to whatever you mount or share.
+
+The core tension: you want the agent to have full context of your codebase (it needs to read everything to be useful), but you do not want it to have full write access (one bad command and your work is gone). What you need is a read-only view of your project with a controlled exit path for changes.
+
+## The Solution: `uf sandbox`
+
+`uf sandbox start` wraps the entire OpenCode + Unbound Force toolchain in a rootless Podman container. Your project directory is mounted read-only by default — the agent can read every file but writes go to a container overlay. When the agent is done, `uf sandbox extract` generates a git patch from the container's work and presents it for your review before applying anything to the host repo.
+
+One command replaces four manual steps: checking Podman availability, building the container run flags, waiting for the OpenCode server to start, and attaching the TUI. The sandbox handles platform detection (arm64/amd64), SELinux volume labels (`:Z` on enforcing systems), Ollama connectivity, and API key forwarding automatically.
+
+Two mount modes give you flexibility:
+
+- **Isolated** (default): Read-only mount. Changes stay inside the container until you extract them. Maximum safety.
+- **Direct**: Read-write mount. Changes apply immediately to the host filesystem. Use when you need real-time sync (e.g., running tests on the host while the agent edits).
+
+## Walkthrough: The Round-Trip
+
+### 1. Start the Sandbox
+
+```bash
+uf sandbox start
+```
+
+The sandbox runs through a startup sequence:
+
+```text
+  Checking prerequisites...
+  ✓ Podman available (v5.3.1)
+  ✓ Container image available (quay.io/unbound-force/opencode-dev:latest)
+  ✓ API key configured
+
+  Starting container...
+  ✓ Container started (isolated mode, read-only mount)
+  ✓ Health check passed (OpenCode server ready)
+
+  Attaching to OpenCode TUI...
+```
+
+You are now inside the sandbox. The TUI looks identical to a normal OpenCode session — the agent has full access to your project files (read-only) and all the Unbound Force tools (Speckit, Replicator, Divisor agents).
+
+### 2. Work Inside the Sandbox
+
+Run any workflow command as usual:
+
+```text
+/unleash
+```
+
+The agent reads your spec, plans the implementation, writes code, runs tests, and reviews its own work — all inside the container. Every file modification, every `git commit`, every test run happens in the container's overlay filesystem. Your host repo is untouched.
+
+When `/unleash` finishes, detach from the sandbox with `Ctrl+C` or let it complete naturally.
+
+### 3. Extract Changes
+
+Back on the host, pull the agent's work out of the container:
+
+```bash
+uf sandbox extract
+```
+
+The extraction uses `git format-patch` to generate patches from the container's commit history, then presents them for review:
+
+```text
+  Extracting changes from sandbox...
+
+  Found 3 commits:
+    feat: add user authentication module
+    test: add auth module unit tests
+    docs: update API reference for auth endpoints
+
+  Patch summary:
+    5 files changed, 342 insertions(+), 12 deletions(-)
+
+  Apply these changes to the host repo? [y/N]
+```
+
+You see every commit, every file, every line change before anything touches your repo. Type `y` to apply via `git am` (preserving commit history) or `N` to discard.
+
+### 4. Verify on the Host
+
+After applying, the commits are in your host repo with their original messages and authorship intact:
+
+```bash
+git log --oneline -3
+```
+
+```text
+a1b2c3d feat: add user authentication module
+d4e5f6g test: add auth module unit tests
+h7i8j9k docs: update API reference for auth endpoints
+```
+
+Run your tests, review the diff, push when ready. The round-trip is complete.
+
+## Lifecycle Management
+
+Three additional commands handle the sandbox lifecycle:
+
+```bash
+uf sandbox status    # show container state, image, uptime
+uf sandbox stop      # stop the container (removes ephemeral containers)
+uf sandbox attach    # reconnect to a running sandbox's TUI
+```
+
+`status` is useful for checking if a sandbox is already running before starting a new one. `attach` lets you reconnect after detaching — the OpenCode session continues running in the background.
+
+## Security Model
+
+The sandbox provides multiple isolation layers:
+
+| Property | Description |
+|----------|-------------|
+| **Rootless Podman** | Container runs without root privileges on the host |
+| **Read-only mounts** | Isolated mode mounts the project read-only (default) |
+| **No push credentials** | Git push credentials are never forwarded to the container |
+| **Resource limits** | Memory (default 8g) and CPU (default 4) limits prevent runaway processes |
+| **SELinux** | Auto-detects SELinux and applies `:Z` volume labels on enforcing systems |
+| **Non-root user** | Container runs as UID 1000 (non-root) inside the namespace |
+
+The agent can read your code but cannot: modify your files (isolated mode), push to your remote, consume unbounded resources, or escalate privileges. The blast radius of any agent mistake is contained to a disposable container.
+
+## Google Cloud / Vertex AI Users
+
+If you use Vertex AI for your LLM provider, the sandbox automatically starts the gateway (`uf gateway`) to proxy API requests. When using the gateway, no cloud credentials are mounted into the container — the gateway runs on the host and handles authentication. Your container receives `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` environment variables pointing to the gateway. As a fallback, the sandbox also supports direct credential mounting: service account key files are auto-mounted read-only, and the gcloud config directory is mounted for Application Default Credentials.
+
+## Current Limitations
+
+- **Single container at a time**: You cannot run multiple sandbox sessions concurrently for the same project. Parallel agent sessions require separate project directories.
+- **Podman required**: The sandbox uses Podman, not Docker. On macOS, a Podman machine must be running (`podman machine start`).
+- **Fixed health check timeout**: The OpenCode server health check waits up to 60 seconds — there is no `--timeout` flag to adjust this.
+
+## What's Next
+
+Eclipse Che / Dev Spaces integration is in development as an alternative backend for cloud-hosted sandboxes. The `--backend che` flag exists but has not been validated end-to-end with a production Che instance — it is labeled experimental. For custom container images, the [opencode-dev containerfile](https://github.com/unbound-force/opencode-dev) repository provides the base image used by the sandbox.
+
+## Get Started
+
+Install or upgrade the Unbound Force CLI and start your first sandbox session:
+
+```bash
+brew install unbound-force/tap/unbound-force
+uf sandbox start
+```
+
+Your repo stays untouchable. The agent works in a container. Changes come out only when you say so.
+
+## See Also
+
+- [Quick Start](/docs/getting-started/quick-start/) -- Install and verify the toolchain
+- [Developer Guide](/docs/getting-started/developer/) -- Daily workflow with the `uf` CLI
+- [Common Workflows](/docs/getting-started/common-workflows/) -- End-to-end feature and review flows

--- a/content/blog/sandbox-isolation.md
+++ b/content/blog/sandbox-isolation.md
@@ -147,16 +147,29 @@ If you use Vertex AI for your LLM provider, the sandbox automatically starts the
 - **Podman required**: The sandbox uses Podman, not Docker. On macOS, a Podman machine must be running (`podman machine start`).
 - **Fixed health check timeout**: The OpenCode server health check waits up to 60 seconds — there is no `--timeout` flag to adjust this.
 
-## What's Next
+## Persistent Workspaces with DevPod
 
-Eclipse Che / Dev Spaces integration is in development as an alternative backend for cloud-hosted sandboxes. The `--backend che` flag exists but has not been validated end-to-end with a production Che instance — it is labeled experimental. For custom container images, the [opencode-dev containerfile](https://github.com/unbound-force/opencode-dev) repository provides the base image used by the sandbox.
+Ephemeral containers are the default, but for long-running sessions you can create persistent workspaces backed by DevPod:
+
+```bash
+uf sandbox create                        # persistent workspace
+uf sandbox create --ide vscode           # open VS Code after creation
+uf sandbox start --ide cursor            # resume and open Cursor
+```
+
+Persistent workspaces survive stop/start cycles — the container's filesystem state is retained across restarts. DevPod handles workspace provisioning and IDE integration. The `--ide` flag supports `vscode`, `openvscode`, `fleet`, `jupyternotebook`, and `cursor`.
+
+The workspace uses a `.devcontainer/devcontainer.json` configuration generated per-developer by `uf sandbox init`. This file is gitignored because the configuration is OS-specific: macOS and Linux require different Podman user namespace flags for correct UID mapping inside the container. Each developer generates their own rather than committing a shared config that works on only one platform.
+
+Eclipse Che / Dev Spaces support exists as an experimental alternative backend (`--backend che`) but has not been validated end-to-end with a production Che instance. For custom container images, the [opencode-dev containerfile](https://github.com/unbound-force/opencode-dev) repository provides the base image used by the sandbox.
 
 ## Get Started
 
 Install or upgrade the Unbound Force CLI and start your first sandbox session:
 
 ```bash
-brew install unbound-force/tap/unbound-force
+brew install unbound-force/tap/unbound-force   # new install
+brew upgrade unbound-force                      # existing users
 uf sandbox start
 ```
 
@@ -164,6 +177,7 @@ Your repo stays untouchable. The agent works in a container. Changes come out on
 
 ## See Also
 
+- [Sandbox Reference](/docs/reference/sandbox/) -- Command reference for all `uf sandbox` subcommands, flags, and configuration
 - [Quick Start](/docs/getting-started/quick-start/) -- Install and verify the toolchain
 - [Developer Guide](/docs/getting-started/developer/) -- Daily workflow with the `uf` CLI
 - [Common Workflows](/docs/getting-started/common-workflows/) -- End-to-end feature and review flows

--- a/openspec/changes/blog-sandbox-isolation/.openspec.yaml
+++ b/openspec/changes/blog-sandbox-isolation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-03

--- a/openspec/changes/blog-sandbox-isolation/design.md
+++ b/openspec/changes/blog-sandbox-isolation/design.md
@@ -1,0 +1,48 @@
+## Context
+
+The website has 7 blog posts covering Gaze, Dewey, /unleash, and the Curator. No blog content covers the sandbox — the most tangible security feature in the toolchain. Issue #40 provides a detailed narrative arc, section outline, and content pack compliance notes. The sandbox reference docs (PR #79) cover the command surface; this blog post covers the "why" and the round-trip workflow.
+
+## Goals / Non-Goals
+
+### Goals
+- Write a blog post following the BA-001 narrative arc (problem → approach → evidence → CTA)
+- Include a step-by-step walkthrough of the round-trip: start → work → extract → verify
+- Lead with benefit framing per BA-007 ("your repo is untouchable" not "we added a sandbox")
+- Include the security model as a scannable table
+- Be honest about current limitations per VB-004
+
+### Non-Goals
+- Duplicate the reference docs (commands, flags, UID mapping details) — link to them instead
+- Cover CDE/Che backend (experimental, not ready for a public blog post)
+- Cover persistent workspaces in depth (the walkthrough uses ephemeral sessions)
+- Tutorial-style customization guide (tracked in issue #67)
+
+## Decisions
+
+1. **Slug and filename**: `sandbox-isolation` — short, descriptive, matches the issue title's framing. File at `content/blog/sandbox-isolation.md`.
+
+2. **Narrative structure**: Follow the issue's outline exactly — The Problem, The Solution, Walkthrough (the bulk), Security Model, Google Cloud / Vertex AI Users, Current Limitations, What's Next. This matches BA-001 and the issue author's intent.
+
+3. **Terminal output style**: Use fenced `text` code blocks for terminal output (same as `unleash-in-practice.md`). Do not include screenshots — the blog is Markdown-only per Minimal Footprint.
+
+4. **Version reference**: Use "v0.12.0" per BA-004 (no "recently" or "new"). Verify the shipped version at implementation time.
+
+5. **Cross-references**: Link to the sandbox reference page (`/docs/reference/sandbox/`) only if it exists at implementation time. Link to getting-started pages which always exist.
+
+6. **Frontmatter pattern**: Follow `unleash-in-practice.md` frontmatter: title, description, lead, slug, date, draft, weight, toc, categories, tags, contributors.
+
+## Content Sources
+
+Authoritative upstream sources for walkthrough content:
+- CLI help: `uf sandbox --help`, `uf sandbox start --help`, `uf sandbox extract --help`
+- Sandbox implementation: `unbound-force/unbound-force/internal/sandbox/`
+- Manual test script: `unbound-force/unbound-force/temp/uf-sandbox-manual-test.md` (22 test scenarios)
+- Spec: `unbound-force/unbound-force/specs/032-sandbox-command/`
+
+All commands in the walkthrough must be verified against the shipped binary.
+
+## Risks / Trade-offs
+
+- **Risk**: Terminal output in the walkthrough may not exactly match what users see (different platform, different project). Mitigated by keeping output examples generic and noting that output varies by platform.
+- **Trade-off**: Ephemeral sessions only in the walkthrough (no persistent workspaces). Chose simplicity — the walkthrough should demonstrate the core value proposition (isolation + extraction) without the complexity of workspace lifecycle. Persistent workspaces can be a follow-up post.
+- **Risk**: Google Cloud / Vertex AI section may be too niche for a general blog post. Kept short (3-4 sentences) since it's a significant use case for enterprise users.

--- a/openspec/changes/blog-sandbox-isolation/proposal.md
+++ b/openspec/changes/blog-sandbox-isolation/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The `uf sandbox` command shipped in v0.12.0 with 7 subcommands, two mount modes, UID mapping, and persistent workspaces. The reference documentation (PR #79) covers the command surface, but there is no narrative content explaining *why* containerized agent sessions matter. Engineers evaluating Unbound Force need a concrete walkthrough showing the round-trip workflow: start a sandbox, work inside it, extract changes back to the host. The security benefits (read-only mounts, no credential forwarding, resource limits) are significant but not self-evident from a reference page.
+
+This change addresses [GitHub issue #40](https://github.com/unbound-force/website/issues/40).
+
+## What Changes
+
+A new blog post at `content/blog/sandbox-isolation.md` with the narrative arc:
+
+1. **The problem** — AI agents running with full filesystem access create real risk: accidental deletion, force push, corrupted state
+2. **The solution** — `uf sandbox start` wraps OpenCode in a Podman container with controlled access
+3. **Walkthrough** — Step-by-step round-trip: start, work, extract, verify
+4. **Security model** — Table of isolation properties
+5. **Current limitations** — Honest about single container, Podman-only, fixed health check timeout
+
+The blog post follows the content pack narrative arc (BA-001: problem → approach → evidence → CTA) and leads with benefit framing (BA-007: "your repo is untouchable" not "we added a sandbox command").
+
+## Capabilities
+
+### New Capabilities
+- `blog/sandbox-isolation`: Blog post covering sandbox motivation, walkthrough, and security model
+
+### Modified Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- 1 new blog post (Markdown content file)
+- No layout, style, or configuration changes
+- No documentation page modifications
+- Cross-references to sandbox reference docs (PR #79, if merged) and getting-started pages
+
+## Constitution Alignment
+
+Assessed against the Unbound Force website project constitution (`.specify/memory/constitution.md`).
+
+### I. Content Accuracy
+
+**Assessment**: PASS
+
+All commands and behaviors in the walkthrough will be verified against `uf sandbox --help` output and the shipped binary at implementation time. The Current Limitations section honestly states constraints (single container, Podman-only). The security model table matches the upstream implementation. No features are fabricated or overstated.
+
+### II. Minimal Footprint
+
+**Assessment**: PASS
+
+Single Markdown blog post file. No custom layouts, CSS, JavaScript, or dependencies. Uses the existing Doks blog infrastructure (categories, tags, contributors frontmatter).
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+Follows the BA-001 narrative arc (problem → approach → evidence → CTA) which is optimized for visitor comprehension. Leads with the "why should I care" (your repo is at risk) before the "how" (sandbox commands). The walkthrough gives visitors a concrete mental model of the round-trip workflow.

--- a/openspec/changes/blog-sandbox-isolation/specs/blog-post.md
+++ b/openspec/changes/blog-sandbox-isolation/specs/blog-post.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: sandbox-blog-post
+
+The website MUST have a blog post at `content/blog/sandbox-isolation.md` explaining why containerized AI agent sessions matter and walking through the round-trip workflow.
+
+#### Scenario: user reads sandbox blog post
+
+- **GIVEN** a user navigates to the sandbox isolation blog post
+- **WHEN** the page renders
+- **THEN** the post MUST follow the BA-001 narrative arc: problem statement, approach, walkthrough with terminal output, and call to action
+- **AND** the post MUST lead with benefit framing per BA-007 (why isolation matters to the reader, not what commands were added)
+- **AND** the post MUST include a step-by-step walkthrough of: `uf sandbox start`, working inside the sandbox, `uf sandbox extract`, and verifying changes on the host
+
+### Requirement: sandbox-blog-security-model
+
+The blog post MUST include a security model section as a scannable table.
+
+#### Scenario: user evaluates sandbox security
+
+- **GIVEN** a user reads the security model section
+- **WHEN** they review the isolation properties
+- **THEN** the table MUST include: rootless Podman, read-only mounts (isolated mode), no push credentials, resource limits, SELinux, non-root user
+
+### Requirement: sandbox-blog-limitations
+
+The blog post MUST include a Current Limitations section per VB-004 (honesty about current state).
+
+#### Scenario: user reads limitations
+
+- **GIVEN** a user reads the limitations section
+- **WHEN** they evaluate adoption readiness
+- **THEN** the section MUST state: single container at a time, Podman required (not Docker), and any other current constraints
+- **AND** the section MUST NOT use weasel language to minimize the limitations
+
+### Requirement: sandbox-blog-frontmatter
+
+The blog post MUST use valid Hugo/Doks blog frontmatter consistent with existing posts.
+
+#### Scenario: blog post builds correctly
+
+- **GIVEN** the blog post file exists with frontmatter
+- **WHEN** `npm run build` is executed
+- **THEN** the build MUST succeed with no errors
+- **AND** the post MUST appear in the blog listing page
+- **AND** the frontmatter MUST include: title, description, lead, slug, date, draft (false), weight, toc, categories, tags, contributors
+
+### Requirement: sandbox-blog-supplementary-sections
+
+The blog post SHOULD include brief supplementary sections for Google Cloud / Vertex AI users and future directions.
+
+#### Scenario: user reads supplementary sections
+
+- **GIVEN** a user reads the blog post
+- **WHEN** they reach the supplementary sections
+- **THEN** a Google Cloud / Vertex AI section MAY be present explaining credential handling for cloud provider users
+- **AND** a "What's Next" section MAY be present, but MUST clearly frame future directions as planned work, not shipped features
+
+## MODIFIED Requirements
+
+_None._
+
+## REMOVED Requirements
+
+_None._

--- a/openspec/changes/blog-sandbox-isolation/tasks.md
+++ b/openspec/changes/blog-sandbox-isolation/tasks.md
@@ -29,7 +29,7 @@
 - [x] 5.2 Run `npm run build` and confirm no build errors
 - [x] 5.3 Verify the blog post appears in the blog listing page
 - [x] 5.4 Verify all internal links resolve (no dead links)
-- [ ] 5.5 Run `npm run dev` and verify the post renders correctly
-- [ ] 5.6 Verify both light and dark mode rendering
+- [x] 5.5 Run `npm run dev` and verify the post renders correctly
+- [x] 5.6 Verify both light and dark mode rendering
 <!-- spec-review: passed -->
 <!-- code-review: passed -->

--- a/openspec/changes/blog-sandbox-isolation/tasks.md
+++ b/openspec/changes/blog-sandbox-isolation/tasks.md
@@ -1,0 +1,35 @@
+## 1. Create blog post file with frontmatter
+
+- [x] 1.1 Create `content/blog/sandbox-isolation.md` with Hugo/Doks blog frontmatter (title, description, lead, slug, date, draft: false, weight, toc, categories: ["Engineering"], tags: ["sandbox", "podman", "isolation", "security"], contributors)
+- [x] 1.2 Verify the current `uf` version by running `uf version` — use the actual version number in the post per BA-004 (no "recently" or "new")
+
+## 2. Write the problem section
+
+- [x] 2.1 Write "The Problem" section (2-3 paragraphs): agents with full filesystem access, real-world risk scenarios (accidental deletion, force push, corrupted state), why existing mitigations (careful prompting, git stash) are insufficient
+- [x] 2.2 Lead with benefit framing per BA-007 — frame from the reader's perspective ("your repo is at risk") not the tool's perspective ("we added a sandbox")
+
+## 3. Write the solution and walkthrough
+
+- [x] 3.1 Write "The Solution" section (1-2 paragraphs): one-command containerized sessions, two modes (isolated default, direct for real-time sync)
+- [x] 3.2 Run `uf sandbox start --help` and `uf sandbox extract --help` to verify current flags and behavior before writing the walkthrough
+- [x] 3.3 Write walkthrough section: `uf sandbox start` (what happens step by step), working inside the sandbox (normal OpenCode session), `uf sandbox extract` (patch summary, review prompt, git am application), verify changes on host — use fenced `text` code blocks for terminal output
+- [x] 3.4 Write brief lifecycle management subsection: `uf sandbox status`, `stop`, `attach`
+
+## 4. Write security model and supplementary sections
+
+- [x] 4.1 Write security model table: rootless Podman, read-only mounts, no push credentials, resource limits, SELinux, non-root user
+- [x] 4.2 Write Google Cloud / Vertex AI section (short, 3-4 sentences): credential forwarding, service account key auto-mount, gateway auto-start
+- [x] 4.3 Write Current Limitations section per VB-004: single container at a time, requires Podman (not Docker), fixed health check timeout — no weasel language
+- [x] 4.4 Write "What's Next" section: CDE / Eclipse Che integration, link to containerfile repo for custom images
+- [x] 4.5 Write call to action: `brew install unbound-force/tap/unbound-force && uf sandbox start`
+
+## 5. Cross-references and verification
+
+- [x] 5.1 Add cross-reference links to sandbox reference docs and getting-started pages — only link to pages that exist at implementation time
+- [x] 5.2 Run `npm run build` and confirm no build errors
+- [x] 5.3 Verify the blog post appears in the blog listing page
+- [x] 5.4 Verify all internal links resolve (no dead links)
+- [ ] 5.5 Run `npm run dev` and verify the post renders correctly
+- [ ] 5.6 Verify both light and dark mode rendering
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- **Blog post** at `/blog/sandbox-isolation/` — "Isolate Your AI Agents with uf sandbox" covering the motivation for containerized AI agent sessions, a 4-step round-trip walkthrough (start → work → extract → verify), security model table (6 isolation properties), Google Cloud / Vertex AI credential handling, current limitations, and CDE/Che future directions.
- Follows BA-001 narrative arc (problem → approach → evidence → CTA) and BA-007 benefit framing ("your repo is untouchable").
- Content sourced from `uf sandbox --help` output and upstream `internal/sandbox/` implementation.

Closes #40