### PR TITLE
docs: add gateway credential isolation blog post

### DIFF
--- a/.uf/dewey/learnings/blog-gateway-credentials-1.md
+++ b/.uf/dewey/learnings/blog-gateway-credentials-1.md
@@ -1,0 +1,9 @@
+---
+tag: blog-gateway-credentials
+category: gotcha
+created_at: 2026-05-03T17:29:17Z
+identity: blog-gateway-credentials-1
+tier: draft
+---
+
+When writing blog posts about the Unbound Force gateway for the website, the environment variable injected into sandbox containers is ANTHROPIC_API_KEY (not ANTHROPIC_AUTH_TOKEN), and the placeholder value is "gateway" (not "gateway-proxy"). This was caught as a HIGH finding during code review for the blog-gateway-credentials change. The actual source is internal/sandbox/config.go line 79 which sets ANTHROPIC_API_KEY=gateway. The ANTHROPIC_AUTH_TOKEN name does not exist in the codebase. Always verify environment variable names against the actual source code, even when they seem obvious from the naming convention — the Anthropic SDK uses ANTHROPIC_API_KEY while the concept of an "auth token" is a gateway abstraction that doesn't appear in the implementation.

--- a/content/blog/gateway-credentials.md
+++ b/content/blog/gateway-credentials.md
@@ -1,0 +1,121 @@
+---
+title: "Stop Leaking Cloud Credentials to Your AI Containers — uf gateway Credential Isolation"
+description: "Running AI agents in containers means forwarding cloud credentials into the container. uf gateway eliminates this — your container sees localhost and a dummy API key while the gateway handles authentication on the host."
+lead: "Your container sees localhost, not Google Cloud. One local proxy handles Vertex AI, Bedrock, and Anthropic authentication — zero cloud credentials inside the container."
+slug: "gateway-credentials"
+date: 2026-05-03T00:00:00+00:00
+draft: false
+weight: 65
+toc: true
+categories: ["Engineering"]
+tags: ["gateway", "security", "credentials", "vertex-ai", "bedrock"]
+contributors: ["Unbound Force"]
+---
+
+## The Problem
+
+Running AI agents in containers requires LLM API access. The agent needs to call Claude, but the cloud credentials — Google Cloud OAuth tokens, AWS session credentials, Anthropic API keys — live on the host machine. Getting those credentials into the container is where things go wrong.
+
+The standard approach is environment variable forwarding. Mount `ANTHROPIC_API_KEY` into the container, or bind-mount the gcloud config directory, or inject `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Each provider has its own credential format, its own SDK expectations, and its own expiry behavior. What works on your macOS laptop breaks on the CI server. What works with Anthropic direct requires a completely different setup for Vertex AI.
+
+The result is a matrix of provider-specific container configurations:
+
+- **Vertex AI**: OAuth tokens expire every 60 minutes. Bind-mount the gcloud directory, handle token refresh inside the container, hope the container's `gcloud` binary is compatible with the host's config format.
+- **Bedrock**: AWS session credentials require SigV4 request signing. Forward 3+ environment variables, install the AWS SDK inside the container, deal with region and credential chain resolution.
+- **Anthropic direct**: Simpler (one API key), but now you have a long-lived secret mounted inside a container where an AI agent has shell access.
+
+Every credential you forward into the container is attack surface. Every provider-specific workaround is maintenance burden. And when tokens expire mid-session, the agent fails with cryptic auth errors that have nothing to do with the code it was writing.
+
+## The Solution: One Proxy, Three Clouds
+
+`uf gateway` runs a local reverse proxy on the host. It accepts standard Anthropic Messages API requests on `localhost:53147` and translates + authenticates upstream to whichever cloud provider you use. The container never touches a real credential — it sends requests to localhost with a placeholder API key, and the gateway swaps in the real credentials on the host side.
+
+```bash
+uf gateway --detach    # start the proxy in the background
+```
+
+The gateway auto-detects your provider from environment variables:
+
+| Priority | Provider | Detection |
+|----------|----------|-----------|
+| 1 | **Vertex AI** | `CLAUDE_CODE_USE_VERTEX=1` + `ANTHROPIC_VERTEX_PROJECT_ID` |
+| 2 | **Bedrock** | `CLAUDE_CODE_USE_BEDROCK=1` |
+| 3 | **Anthropic** | `ANTHROPIC_API_KEY` |
+
+Once running, any container on the host can call `http://localhost:53147` with a dummy token. The gateway intercepts the request, injects real credentials, translates the request format for the upstream provider, and forwards it. The container's code never changes regardless of which provider you use.
+
+## How It Works
+
+The request flow is straightforward:
+
+```text
+Container                    Host                        Cloud
+─────────                    ────                        ─────
+Anthropic API request  ───►  uf gateway (localhost:53147)
+                             ├─ Inject credentials
+                             ├─ Translate request format
+                             └─ Forward upstream    ───►  Vertex AI / Bedrock / Anthropic
+                                                    ◄───  Response
+                       ◄───  Strip provider headers
+                             Return standard response
+```
+
+For **Vertex AI**, the gateway handles the heaviest translation: rewriting URLs to the Vertex AI endpoint format, moving the model name from the JSON body to the URL path, injecting the `anthropic_version` header, and filtering out Vertex-specific SSE events (`vertex_event`, `ping`) that would confuse the Anthropic SDK client.
+
+For **Bedrock**, the gateway implements SigV4 request signing directly — no AWS SDK dependency. The entire signing implementation is about 200 lines of Go, eliminating a large transitive dependency from the container image.
+
+For **Anthropic direct**, the gateway simply injects the API key as the `x-api-key` header. Even this simple case benefits from credential isolation — the container never sees the actual key.
+
+## Tokens Refresh Themselves
+
+OAuth tokens and session credentials expire. If your agent runs for 2 hours, the credentials it started with will be stale long before it finishes. The gateway handles this transparently.
+
+**Vertex AI tokens** are assumed to last 55 minutes (5-minute safety margin before the typical 60-minute expiry). A background goroutine refreshes the token by calling `gcloud auth application-default print-access-token` on the host — where gcloud is authenticated and working.
+
+**Bedrock credentials** refresh every 50 minutes using the AWS CLI on the host.
+
+**Proactive refresh**: When a request arrives and the current token will expire within 5 minutes, the gateway starts a non-blocking refresh before forwarding the request. The request uses the existing (still-valid) token while the refresh runs in the background. By the next request, the fresh token is ready.
+
+**Deduplication**: If multiple requests arrive simultaneously during the refresh window, the gateway uses `sync.Mutex.TryLock()` to ensure only one refresh runs at a time. Concurrent requests get the existing token — no thundering herd of `gcloud` invocations.
+
+## Before and After
+
+| Aspect | Before Gateway | With Gateway |
+|--------|---------------|--------------|
+| **Env vars forwarded** | 4-6 (provider-specific) | 2 (`ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`) |
+| **Credential mounts** | gcloud dir, service account keys, AWS config | None |
+| **SDK dependencies** | AWS SDK, gcloud CLI inside container | None |
+| **Token management** | Container-side refresh logic | Host-side, automatic |
+| **Provider switching** | Rebuild container config | Change host env vars, restart gateway |
+| **Container image** | Provider-specific variants | Single universal image |
+
+The container sees the same two environment variables regardless of whether you use Vertex AI, Bedrock, or Anthropic direct. Switching providers is a host-side configuration change — the container image and agent code remain identical.
+
+## Sandbox Integration
+
+If you use `uf sandbox` for containerized development sessions, the gateway integration is automatic. When `uf sandbox start` detects a cloud provider in your environment (Vertex AI or Bedrock env vars), it starts the gateway before launching the container. The container receives `ANTHROPIC_BASE_URL=http://host.containers.internal:53147` and `ANTHROPIC_API_KEY=gateway` — no manual gateway setup required.
+
+```bash
+uf sandbox start    # gateway auto-starts if Vertex/Bedrock detected
+```
+
+## Scope
+
+The gateway proxies Anthropic Messages API requests only. It is not a general-purpose HTTP proxy — it does not forward arbitrary traffic, non-Anthropic API calls, or direct model downloads. For API access beyond the Anthropic Messages API, forward the relevant credentials directly.
+
+## Get Started
+
+Install the Unbound Force CLI and start the gateway:
+
+```bash
+brew install unbound-force/tap/unbound-force
+uf gateway --detach
+```
+
+Your container sees localhost. Your credentials stay on the host. Tokens refresh themselves.
+
+## See Also
+
+- [Quick Start](/docs/getting-started/quick-start/) -- Install and verify the toolchain
+- [Developer Guide](/docs/getting-started/developer/) -- Daily workflow with the `uf` CLI
+- [Common Workflows](/docs/getting-started/common-workflows/) -- End-to-end feature and review flows

--- a/openspec/changes/blog-gateway-credentials/.openspec.yaml
+++ b/openspec/changes/blog-gateway-credentials/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-03

--- a/openspec/changes/blog-gateway-credentials/design.md
+++ b/openspec/changes/blog-gateway-credentials/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The website has a gateway reference page (PR #77) covering the command surface. Issue #63 provides a narrative angle, key messages, and source references for a blog post that explains the "why" behind credential isolation. The sandbox isolation blog post (PR #80) covers sandbox containerization; this post covers the complementary gateway credential proxy.
+
+## Goals / Non-Goals
+
+### Goals
+- Write a blog post following the BA-001 narrative arc (problem → approach → evidence → CTA)
+- Lead with "your container sees localhost, not Google Cloud" per BA-007
+- Include a concrete before/after comparison (6 env vars → 2)
+- Explain the three-provider support (Vertex AI, Bedrock, Anthropic) without drowning in implementation details
+- Cover token refresh as a key reliability feature
+
+### Non-Goals
+- Duplicate the reference docs (command flags, full Vertex translation details) — link to them instead
+- Deep SigV4 signing implementation details (internal concern)
+- Performance benchmarks or latency analysis
+- Troubleshooting provider-specific errors
+
+## Decisions
+
+1. **Slug and filename**: `gateway-credentials` — short, matches the issue's credential isolation framing. File at `content/blog/gateway-credentials.md`.
+
+2. **Narrative structure**: Problem (credential forwarding headaches) → Solution (local reverse proxy) → How It Works (request flow, auto-detection) → Token Refresh → Before/After → Sandbox Integration → CTA.
+
+3. **Before/after as a table**: Use a comparison table showing the concrete reduction in complexity. This is the "evidence" section of the narrative arc — scannable and precise.
+
+4. **Light on Vertex internals**: Mention SSE filtering and model catalog briefly but don't explain the full translation pipeline. The reference docs cover that. The blog audience cares about "it works with Vertex" not "here's how SSE event filtering drops vertex_event frames."
+
+5. **Frontmatter pattern**: Follow existing blog post frontmatter (title, description, lead, slug, date, draft, weight, toc, categories, tags, contributors).
+
+6. **Cross-references**: Link to gateway reference page (`/docs/reference/gateway/`) only if it exists at implementation time. Link to getting-started pages which always exist.
+
+## Content Sources
+
+Authoritative upstream sources:
+- Gateway implementation: `unbound-force/unbound-force/internal/gateway/` (provider.go, refresh.go, gateway.go, sse.go)
+- CLI help: `uf gateway --help`
+- Specs: `unbound-force/unbound-force/specs/033-gateway-command/`, `unbound-force/unbound-force/specs/034-gateway-vertex-translation/`
+
+All technical claims must be verified against these upstream files at implementation time.
+
+## Risks / Trade-offs
+
+- **Risk**: The before/after metrics (6 env vars → 2) are derived from the current implementation. If the gateway's env var handling changes, the metrics go stale. Mitigated by using "Before gateway" / "With gateway" framing rather than version-specific claims.
+- **Trade-off**: Light Vertex details may frustrate power users who want to understand the translation. Mitigated by linking to the reference docs for depth.

--- a/openspec/changes/blog-gateway-credentials/proposal.md
+++ b/openspec/changes/blog-gateway-credentials/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+AI agents running in containers need to call LLM APIs, which means cloud credentials (GCP OAuth tokens, AWS session credentials, Anthropic API keys) must somehow reach the container. The standard approach — forwarding environment variables or mounting credential files — creates security surface, platform friction, and token expiry headaches. `uf gateway` solves this by running a local reverse proxy on the host that accepts standard Anthropic API requests and translates + authenticates upstream. The container sees `localhost:53147` and a dummy token. Zero cloud credentials inside the container.
+
+This is a compelling engineering story with concrete before/after metrics (6 env vars forwarded → 2, zero AWS SDK dependency for Bedrock, proactive token refresh). The gateway reference docs (PR #77) cover the command surface, but there is no narrative content explaining the credential isolation design and why it matters.
+
+This change addresses [GitHub issue #63](https://github.com/unbound-force/website/issues/63).
+
+## What Changes
+
+A new blog post at `content/blog/gateway-credentials.md` with the narrative arc:
+
+1. **The problem** — credential forwarding to containers: leaked env vars, stale tokens, provider-specific SDK quirks
+2. **The solution** — `uf gateway` as a local reverse proxy: one proxy, three clouds (Vertex AI, Bedrock, Anthropic)
+3. **How it works** — request flow diagram (container → gateway → cloud), provider auto-detection, translation mechanics
+4. **Token refresh** — proactive refresh with 55-minute safety margins, thundering-herd deduplication
+5. **Before/after** — concrete comparison: 6 env vars → 2, credential mounts → none, SDK dependencies → none
+6. **Sandbox integration** — auto-start when cloud provider detected
+
+## Capabilities
+
+### New Capabilities
+- `blog/gateway-credentials`: Blog post covering gateway credential isolation design
+
+### Modified Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- 1 new blog post (Markdown content file)
+- No layout, style, or configuration changes
+- Cross-references to gateway reference docs (PR #77, if merged) and getting-started pages
+
+## Constitution Alignment
+
+Assessed against the Unbound Force website project constitution (`.specify/memory/constitution.md`).
+
+### I. Content Accuracy
+
+**Assessment**: PASS
+
+All technical claims (provider detection priority, token refresh timing, SigV4 signing, SSE event filtering) will be verified against the upstream implementation at `unbound-force/unbound-force/internal/gateway/` and `uf gateway --help` output at implementation time. The before/after metrics (6 env vars → 2) are derived from the actual implementation.
+
+### II. Minimal Footprint
+
+**Assessment**: PASS
+
+Single Markdown blog post file. No custom layouts, CSS, JavaScript, or dependencies. Uses the existing Doks blog infrastructure.
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+Follows the BA-001 narrative arc (problem → approach → evidence → CTA). Leads with "your container sees localhost, not Google Cloud" per BA-007 benefit framing. The before/after comparison gives visitors a concrete mental model of what the gateway eliminates.

--- a/openspec/changes/blog-gateway-credentials/specs/blog-post.md
+++ b/openspec/changes/blog-gateway-credentials/specs/blog-post.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: gateway-blog-post
+
+The website MUST have a blog post at `content/blog/gateway-credentials.md` explaining why credential isolation matters and how `uf gateway` eliminates credential forwarding to containers.
+
+#### Scenario: user reads gateway blog post
+
+- **GIVEN** a user navigates to the gateway credentials blog post
+- **WHEN** the page renders
+- **THEN** the post MUST follow the BA-001 narrative arc: problem statement (credential forwarding risks), approach (local reverse proxy), evidence (before/after comparison), and call to action
+- **AND** the post MUST lead with benefit framing per BA-007 (why credential isolation matters to the reader, not what commands were added)
+- **AND** the post MUST explain how the gateway eliminates credential forwarding: container sees localhost + dummy token, gateway handles authentication upstream
+
+### Requirement: gateway-blog-before-after
+
+The blog post MUST include a before/after comparison showing the concrete reduction in complexity when using the gateway.
+
+#### Scenario: user evaluates gateway value
+
+- **GIVEN** a user reads the before/after section
+- **WHEN** they compare the two approaches
+- **THEN** the comparison MUST show the reduction in environment variables forwarded to the container
+- **AND** the comparison MUST show the elimination of credential file mounts
+
+### Requirement: gateway-blog-token-refresh
+
+The blog post MUST cover token refresh as a reliability feature.
+
+#### Scenario: user reads token refresh section
+
+- **GIVEN** a user reads the token refresh section
+- **WHEN** they review the refresh mechanism
+- **THEN** the section MUST explain proactive refresh before token expiry
+- **AND** the section MUST mention deduplication to prevent thundering-herd refreshes
+
+### Requirement: gateway-blog-frontmatter
+
+The blog post MUST use valid Hugo/Doks blog frontmatter consistent with existing posts.
+
+#### Scenario: blog post builds correctly
+
+- **GIVEN** the blog post file exists with frontmatter
+- **WHEN** `npm run build` is executed
+- **THEN** the build MUST succeed with no errors
+- **AND** the post MUST appear in the blog listing page
+- **AND** the frontmatter MUST include: title, description, lead, slug, date, draft (false), weight, toc, categories, tags, contributors
+
+### Requirement: gateway-blog-limitations
+
+The blog post SHOULD include honest caveats about what the gateway does not solve, per VB-004.
+
+#### Scenario: user reads limitations
+
+- **GIVEN** a user reads the post
+- **WHEN** they evaluate the gateway's scope
+- **THEN** the post SHOULD note that the gateway proxies LLM API requests only — it does not proxy arbitrary HTTP traffic or non-Anthropic APIs
+
+## MODIFIED Requirements
+
+_None._
+
+## REMOVED Requirements
+
+_None._

--- a/openspec/changes/blog-gateway-credentials/tasks.md
+++ b/openspec/changes/blog-gateway-credentials/tasks.md
@@ -1,0 +1,32 @@
+## 1. Create blog post file with frontmatter
+
+- [x] 1.1 Create `content/blog/gateway-credentials.md` with Hugo/Doks blog frontmatter (title, description, lead, slug, date, draft: false, weight, toc, categories: ["Engineering"], tags: ["gateway", "security", "credentials", "vertex-ai", "bedrock"], contributors)
+
+## 2. Write the problem and solution sections
+
+- [x] 2.1 Write "The Problem" section: credential forwarding to containers (leaked env vars, stale tokens, provider-specific SDK quirks, platform friction)
+- [x] 2.2 Write "The Solution" section: `uf gateway` as a local reverse proxy — one proxy, three clouds. Lead with benefit framing per BA-007 ("your container sees localhost, not Google Cloud")
+- [x] 2.3 Write "How It Works" section: request flow (container → gateway → cloud provider), provider auto-detection priority order, brief mention of Vertex translation and SSE filtering without deep implementation details
+
+## 3. Write token refresh and before/after sections
+
+- [x] 3.1 Read upstream source files (`unbound-force/unbound-force/internal/gateway/refresh.go`, `provider.go`) to verify token refresh timing and deduplication mechanism before writing
+- [x] 3.2 Write token refresh section: proactive refresh with 55-minute safety margin (5 minutes before typical 60-minute expiry), thundering-herd deduplication via `sync.Mutex.TryLock()`
+- [x] 3.3 Write before/after comparison table: environment variables forwarded, credential file mounts, SDK dependencies, token management — showing concrete reduction in complexity
+
+## 4. Write supplementary sections
+
+- [x] 4.1 Write sandbox integration section: gateway auto-starts when `uf sandbox start` detects a cloud provider
+- [x] 4.2 Write scope/limitations note per VB-004: gateway proxies Anthropic Messages API only, not arbitrary HTTP or non-Anthropic APIs
+- [x] 4.3 Write call to action: install command verified at implementation time
+
+## 5. Cross-references and verification
+
+- [x] 5.1 Add cross-reference links to gateway reference docs and getting-started pages — only link to pages that exist at implementation time
+- [x] 5.2 Run `npm run build` and confirm no build errors
+- [x] 5.3 Verify the blog post appears in the blog listing page
+- [x] 5.4 Verify all internal links resolve (no dead links)
+- [ ] 5.5 Run `npm run dev` and verify the post renders correctly
+- [ ] 5.6 Verify both light and dark mode rendering
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- **Blog post** at `/blog/gateway-credentials/` — "Stop Leaking Cloud Credentials to Your AI Containers" covering the credential forwarding problem, `uf gateway` as a local reverse proxy for Vertex AI/Bedrock/Anthropic, request flow diagram, before/after comparison table (6 env vars → 2), token refresh with proactive 55-min safety margin and TryLock deduplication, sandbox auto-start integration, and scope caveat (Anthropic Messages API only).
- Content sourced from `internal/gateway/provider.go` (token lifetimes, TryLock) and `internal/sandbox/config.go` (ANTHROPIC_API_KEY=gateway).
- Code review caught and fixed incorrect env var name (ANTHROPIC_AUTH_TOKEN → ANTHROPIC_API_KEY).

Closes #63