### PR TITLE
docs: add code review tutorial

### DIFF
--- a/.uf/dewey/learnings/tutorial-code-review-1.md
+++ b/.uf/dewey/learnings/tutorial-code-review-1.md
@@ -1,0 +1,9 @@
+---
+tag: tutorial-code-review
+category: pattern
+created_at: 2026-05-03T19:39:37Z
+identity: tutorial-code-review-1
+tier: draft
+---
+
+When creating tutorial pages for the Unbound Force website, the weight value in Hugo frontmatter determines sidebar ordering. The getting-started section uses weights from 10 (_index) to 85 (constitution). Tutorials that are follow-ups to reference pages should use a weight value just above the reference page they extend — for example, the code review tutorial at weight 72 appears right after common-workflows at weight 70. This co-locates the reference and tutorial in the sidebar navigation, matching how readers naturally progress from command reference to hands-on walkthrough.

--- a/content/docs/getting-started/code-review-tutorial.md
+++ b/content/docs/getting-started/code-review-tutorial.md
@@ -1,0 +1,207 @@
+---
+title: "Code Review Tutorial"
+description: "Step-by-step walkthrough of the complete code review lifecycle — /review-council before pushing, /review-pr after creating a PR."
+lead: "Two commands, one review lifecycle. Use /review-council to validate locally before pushing, then /review-pr to review the PR with CI results."
+date: 2026-05-03T00:00:00+00:00
+draft: false
+weight: 72
+toc: true
+---
+
+## Prerequisites
+
+Before starting this tutorial, ensure:
+
+1. **`uf init` completed** — your project has Divisor review agents deployed (`.opencode/agents/divisor-*.md`)
+2. **`gh` CLI installed and authenticated** — `/review-pr` uses `gh` to fetch PR metadata and CI results
+
+```bash
+which gh && gh auth status
+```
+
+If `gh` is not installed, get it from [cli.github.com](https://cli.github.com/). If not authenticated, run `gh auth login`.
+
+## Step 1: Pre-PR Review with `/review-council`
+
+Before you push your changes and create a PR, run `/review-council` to catch issues locally:
+
+```text
+/review-council
+```
+
+### What Happens
+
+The review council runs in two phases:
+
+**Phase 1: CI Gate** — runs your project's build, test, and lint commands (derived from `.github/workflows/`). If the build fails, the review stops immediately. This is a hard gate — no point reviewing code that does not compile.
+
+**Phase 2: Divisor Review** — launches 5+ review personas in parallel, each with a different focus:
+
+| Persona | Focus |
+|---------|-------|
+| **Adversary** | Security, resilience, edge cases |
+| **Architect** | Structure, conventions, patterns |
+| **Guard** | Intent drift, scope discipline |
+| **Testing** | Test coverage, isolation, assertions |
+| **SRE** | Deployment, operational readiness |
+| **Curator** | Documentation gaps |
+
+### Expected Output
+
+```text
+Phase 1: CI Gate
+  ✓ npm run build — passed (536ms)
+
+Phase 2: Divisor Review
+  Adversary:  APPROVE (0 findings)
+  Architect:  APPROVE (1 LOW — weight inconsistency)
+  Guard:      APPROVE (0 findings)
+  Testing:    APPROVE (0 findings)
+  SRE:        APPROVE (0 findings)
+  Curator:    APPROVE (0 findings)
+
+Council Verdict: APPROVE
+```
+
+If any persona returns **REQUEST CHANGES**, the council verdict is REQUEST CHANGES. Fix the findings and re-run. The review council iterates up to 3 times, auto-fixing LOW and MEDIUM findings where possible.
+
+**Gaze integration** (optional): If [Gaze](/docs/projects/gaze/) is installed, the review council runs quality analysis (CRAP scores, test coverage) as Phase 1b. This is informational — it does not block the verdict.
+
+## Step 2: Push and Create a PR
+
+Once the review council approves, push your changes and create a PR:
+
+```bash
+/finale
+```
+
+Or manually:
+
+```bash
+git push -u origin my-branch
+gh pr create --title "feat: add user auth" --body "..."
+```
+
+## Step 3: Post-PR Review with `/review-pr`
+
+After the PR is created and CI has run, review the PR:
+
+```text
+/review-pr
+```
+
+This auto-detects the open PR for your current branch. To review a specific PR (including someone else's):
+
+```text
+/review-pr 42
+```
+
+### What Happens
+
+`/review-pr` runs a structured review informed by CI results:
+
+1. **Resolve PR** — auto-detect or use the provided PR number
+2. **Fetch metadata** — title, description, changed files, branch info
+3. **CI check results** — fetch pass/fail status for every check
+4. **Causality classification** — for each failing check, determine if it is PR-caused or pre-existing
+5. **Local tool pre-flight** — run tools only for checks CI did not already cover
+6. **Scoped diff** — fetch the PR diff (skipping lock files, generated code, binaries)
+7. **Spec alignment** — locate the associated spec for intent checking
+8. **AI review** — judgment on alignment, security, and architecture
+9. **Structured report** — severity-classified findings
+
+### Expected Output
+
+```text
+PR #42: feat: add user auth
+Branch: feature/user-auth → main
+Files changed: 8 (+342, -12)
+
+CI Checks:
+  ✓ Build & Test — passed
+  ✓ Lint — passed
+  ✗ yamllint — FAILED (pre-existing)
+
+Causality Analysis:
+  yamllint: base branch FAIL, PR FAIL → Pre-existing
+  (This failure exists independently of your PR)
+
+Local Pre-flight:
+  Skipped: build (CI passed), lint (CI passed)
+
+Review Findings:
+  [HIGH] Missing error handling in auth.go:42
+  [MEDIUM] Consider extracting helper function at auth.go:87
+
+Verdict: 2 findings (1 HIGH, 1 MEDIUM)
+```
+
+## Step 4: Understanding CI Causality
+
+When CI checks fail on your PR, the key question is: *did my changes cause this?*
+
+`/review-pr` answers this by checking whether the same check also fails on the base branch:
+
+| Base Branch | PR Check | Classification |
+|-------------|----------|----------------|
+| Pass | Fail | **PR-caused** — your changes introduced this |
+| Fail | Fail | **Pre-existing** — failure exists independently |
+| No data | Fail | **Unknown** — treated as PR-caused (conservative) |
+
+**PR-caused failures** are reported as HIGH or CRITICAL findings. These are your regressions.
+
+**Pre-existing failures** are reported separately and do not block the PR verdict. They are not your problem — but `/review-pr` can help fix them.
+
+## Step 5: Fix Branches for Pre-existing Failures
+
+When pre-existing failures are found, `/review-pr` offers to create a fix branch:
+
+```text
+I identified 1 pre-existing CI failure:
+  - yamllint: trailing whitespace in config/database.yml
+
+Would you like me to create a fix branch?
+```
+
+If you agree, it creates `fix/pr-42-yamllint` from the base branch with a minimal fix. The branch stays local — you review and push when ready.
+
+**Safety guards**:
+- Will not create a fix branch if you have uncommitted changes (dirty-tree guard)
+- Will not overwrite an existing branch with the same name (collision check)
+- Will not attempt non-trivial fixes spanning more than 3 files
+
+## The Complete Loop
+
+The two review commands fit into the standard development workflow:
+
+```text
+/speckit.specify          # define the work
+       ↓
+/unleash                  # implement autonomously
+       ↓
+/review-council           # validate locally (pre-PR)
+       ↓
+/finale                   # commit, push, create PR
+       ↓
+/review-pr                # review with CI data (post-PR)
+       ↓
+Merge                     # after reviewer approval
+```
+
+You can use either command independently — they do not depend on each other. But together they catch issues at two different points: before the code leaves your machine and after it runs through CI.
+
+## Decision Table
+
+| Situation | Command | Why |
+|-----------|---------|-----|
+| Before pushing | `/review-council` | Catch issues locally with 5+ parallel reviewers |
+| After creating a PR | `/review-pr` | Review with CI results and causality analysis |
+| Reviewing someone else's PR | `/review-pr 42` | Works on any PR by number |
+| CI failed, unsure if my fault | `/review-pr` | Causality classification separates your regressions from noise |
+| Want maximum coverage | Both in sequence | `/review-council` pre-push, `/review-pr` post-PR |
+
+## See Also
+
+- [Common Workflows](/docs/getting-started/common-workflows/) -- `/review-council` vs `/review-pr` comparison table and full command reference
+- [Quick Start](/docs/getting-started/quick-start/) -- Install and verify the toolchain
+- [Developer Guide](/docs/getting-started/developer/) -- Daily workflow with the `uf` CLI

--- a/openspec/changes/tutorial-code-review/.openspec.yaml
+++ b/openspec/changes/tutorial-code-review/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-03

--- a/openspec/changes/tutorial-code-review/design.md
+++ b/openspec/changes/tutorial-code-review/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The website has reference documentation for both review commands in `common-workflows.md` (PR #74) and a blog post on `/review-pr` CI causality (PR #82). Issue #66 requests a tutorial that walks through the complete lifecycle. Tutorials differ from reference docs (command surface) and blog posts (narrative arc) — they are step-by-step guides with expected output at each stage.
+
+## Goals / Non-Goals
+
+### Goals
+- Create a step-by-step tutorial covering both review commands in sequence
+- Show expected output at each step (fenced `text` code blocks)
+- Include the decision table for quick command selection
+- Show the commands in the context of the full development loop
+- Cover CI causality analysis with a concrete example
+
+### Non-Goals
+- Duplicate the full command reference (flags, phases) — link to common-workflows docs
+- Duplicate the blog post's narrative on CI causality — link to the blog post
+- Cover Gaze integration in depth (optional feature, not required for the tutorial)
+- Cover review council configuration or Divisor agent customization
+
+## Decisions
+
+1. **Page location**: `content/docs/getting-started/code-review-tutorial.md` — tutorials belong in Getting Started, not Reference. Weight after `common-workflows.md` to position it as a follow-up.
+
+2. **Structure**: Linear walkthrough — prerequisites → review-council → push & PR → review-pr → causality → fix branch → complete loop → decision table. Each section has a "Run" step and an "Expected output" block.
+
+3. **Expected output style**: Use fenced `text` code blocks showing representative (not exact) output. Note that actual output varies by project.
+
+4. **Decision table at the end**: The issue's decision table is the quick-reference payoff. Place it at the end as a summary the reader can bookmark.
+
+5. **Frontmatter**: Standard docs page frontmatter (title, description, lead, date, weight, toc). Not a blog post — no categories/tags/contributors.
+
+6. **Cross-references**: Link to common-workflows (comparison table), blog post (narrative depth), and getting-started pages.
+
+## Content Sources
+
+Authoritative upstream sources:
+- `/review-council`: `unbound-force/unbound-force/.opencode/command/review-council.md`
+- `/review-pr`: `unbound-force/unbound-force/.opencode/command/review-pr.md`
+- Comparison table: `content/docs/getting-started/common-workflows.md` (if PR #74 merged)
+
+All commands and output examples must be verified against the upstream command files at implementation time.
+
+## Risks / Trade-offs
+
+- **Risk**: The tutorial may go stale as review commands evolve. Mitigated by keeping output examples generic and linking to reference docs for exact behavior.
+- **Trade-off**: Depth vs. length. Chose moderate depth — enough to follow along, not enough to be a reference manual. The decision table provides the quick-hit value for readers who do not want the full walkthrough.

--- a/openspec/changes/tutorial-code-review/proposal.md
+++ b/openspec/changes/tutorial-code-review/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+The website documents `/review-council` and `/review-pr` as reference material in `common-workflows.md` (PR #74) and covers `/review-pr` in a blog post (PR #82). But there is no tutorial that walks an engineer through the complete code review lifecycle — from pre-PR local review to post-PR GitHub review to CI failure triage. Engineers need a step-by-step guide showing when to use each command, what output to expect, and how the two commands complement each other.
+
+This change addresses [GitHub issue #66](https://github.com/unbound-force/website/issues/66).
+
+## What Changes
+
+A new tutorial page at `content/docs/getting-started/code-review-tutorial.md` covering:
+
+1. **Prerequisites**: `uf init` completed, `gh` CLI installed
+2. **Pre-PR review with `/review-council`**: Run before pushing — multi-agent Divisor council with Gaze integration
+3. **Post-PR review with `/review-pr`**: Run after creating a PR — single-agent review with CI causality analysis
+4. **CI causality analysis walkthrough**: Understanding PR-caused vs pre-existing failure classification
+5. **Fix branches**: How `/review-pr` offers fix branches for pre-existing failures
+6. **The complete loop**: specify → unleash → /review-council → /finale → /review-pr
+7. **Decision table**: When to use each command
+
+## Capabilities
+
+### New Capabilities
+- `docs/getting-started/code-review-tutorial`: Tutorial page for the complete code review lifecycle
+
+### Modified Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- 1 new tutorial page (Markdown content)
+- No layout, style, or configuration changes
+- Cross-references to common-workflows docs (comparison table) and blog posts
+
+## Constitution Alignment
+
+Assessed against the Unbound Force website project constitution (`.specify/memory/constitution.md`).
+
+### I. Content Accuracy
+
+**Assessment**: PASS
+
+All commands, flags, and output examples will be verified against the upstream implementation at `unbound-force/unbound-force/.opencode/command/review-council.md` and `review-pr.md` at implementation time. The decision table maps directly to the commands' actual behavior.
+
+### II. Minimal Footprint
+
+**Assessment**: PASS
+
+Single Markdown tutorial page under the existing Getting Started section. No custom layouts, CSS, JavaScript, or dependencies. Uses Doks built-in sidebar navigation.
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+Step-by-step tutorial structure with expected output examples. The decision table at the end provides a quick-reference for returning visitors. The "complete loop" section shows how review commands fit into the overall development workflow.

--- a/openspec/changes/tutorial-code-review/specs/tutorial.md
+++ b/openspec/changes/tutorial-code-review/specs/tutorial.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: code-review-tutorial-page
+
+The website MUST have a tutorial page at `content/docs/getting-started/code-review-tutorial.md` walking through the complete code review lifecycle.
+
+#### Scenario: user follows code review tutorial
+
+- **GIVEN** a user navigates to the code review tutorial
+- **WHEN** the page renders
+- **THEN** the tutorial MUST cover both `/review-council` (pre-PR) and `/review-pr` (post-PR) in sequence
+- **AND** each step MUST include a command to run and expected output
+- **AND** the tutorial MUST include prerequisites (uf init, gh CLI)
+
+### Requirement: code-review-tutorial-decision-table
+
+The tutorial MUST include a decision table showing when to use each review command.
+
+#### Scenario: user decides which command to use
+
+- **GIVEN** a user reads the decision table
+- **WHEN** they evaluate their situation
+- **THEN** the table MUST cover at least: before pushing, after creating PR, reviewing someone else's PR, and CI failure triage
+
+### Requirement: code-review-tutorial-causality
+
+The tutorial MUST include a CI causality analysis walkthrough.
+
+#### Scenario: user understands causality classification
+
+- **GIVEN** a user reads the causality section
+- **WHEN** they see a CI failure on their PR
+- **THEN** the tutorial MUST explain how `/review-pr` classifies failures as PR-caused vs pre-existing
+- **AND** the tutorial MUST show the fix branch offering for pre-existing failures
+
+### Requirement: code-review-tutorial-complete-loop
+
+The tutorial MUST show how review commands fit into the complete development loop.
+
+#### Scenario: user sees the full workflow
+
+- **GIVEN** a user reads the complete loop section
+- **WHEN** they understand the end-to-end flow
+- **THEN** the tutorial MUST show: specify → unleash → /review-council → /finale → /review-pr
+
+### Requirement: code-review-tutorial-frontmatter
+
+The tutorial MUST use valid Hugo/Doks docs frontmatter consistent with existing pages.
+
+#### Scenario: tutorial builds correctly
+
+- **GIVEN** the tutorial file exists with frontmatter
+- **WHEN** `npm run build` is executed
+- **THEN** the build MUST succeed with no errors
+- **AND** the page MUST appear in the Getting Started sidebar
+
+## MODIFIED Requirements
+
+_None._
+
+## REMOVED Requirements
+
+_None._

--- a/openspec/changes/tutorial-code-review/tasks.md
+++ b/openspec/changes/tutorial-code-review/tasks.md
@@ -1,0 +1,31 @@
+## 1. Create tutorial page with frontmatter
+
+- [x] 1.1 Create `content/docs/getting-started/code-review-tutorial.md` with Hugo/Doks docs frontmatter (title: "Code Review Tutorial", description, lead, date, weight after common-workflows, toc: true, draft: false)
+
+## 2. Write prerequisites and /review-council section
+
+- [x] 2.1 Write prerequisites section: `uf init` completed, `gh` CLI installed and authenticated
+- [x] 2.2 Read upstream source files (`unbound-force/unbound-force/.opencode/command/review-council.md` and `review-pr.md`) to verify current behavior before writing
+- [x] 2.3 Write `/review-council` walkthrough: run the command, explain what happens (CI gate, Gaze optional, 5+ Divisor personas), show representative output with verdict
+
+## 3. Write /review-pr and causality sections
+
+- [x] 3.1 Write `/review-pr` walkthrough: push and create PR first, then run `/review-pr`, show representative output
+- [x] 3.2 Write CI causality analysis walkthrough: show the classification table (PR-caused, pre-existing, unknown) with a concrete example
+- [x] 3.3 Write fix branch section: show the fix branch offering for pre-existing failures, dirty-tree guard, collision check
+
+## 4. Write complete loop and decision table
+
+- [x] 4.1 Write "The Complete Loop" section: specify → unleash → /review-council → /finale → /review-pr
+- [x] 4.2 Write decision table: Before pushing → /review-council, After creating PR → /review-pr, Reviewing someone else's PR → /review-pr N, CI failed unsure if my fault → /review-pr (causality)
+
+## 5. Cross-references and verification
+
+- [x] 5.1 Add cross-reference links to common-workflows docs, blog posts, and getting-started pages — only link to pages that exist at implementation time
+- [x] 5.2 Run `npm run build` and confirm no build errors
+- [x] 5.3 Verify the tutorial page appears in the Getting Started sidebar
+- [x] 5.4 Verify all internal links resolve (no dead links)
+- [ ] 5.5 Run `npm run dev` and verify the tutorial renders correctly
+- [ ] 5.6 Verify both light and dark mode rendering
+<!-- spec-review: passed -->
+<!-- code-review: passed -->


### PR DESCRIPTION
## Summary

- **Tutorial page** at `/docs/getting-started/code-review-tutorial/` — step-by-step walkthrough of the complete code review lifecycle: `/review-council` (pre-PR, 5+ Divisor personas in parallel) and `/review-pr` (post-PR, CI causality analysis, fix branch offering). Includes prerequisites, representative output examples, the complete development loop (specify → unleash → review-council → finale → review-pr), and a 5-row decision table for choosing the right command.
- Positioned at weight 72 in the Getting Started sidebar, right after Common Workflows (weight 70).

Closes #66