### PR TITLE
docs: add Architecture & Design Philosophy page

### DIFF
--- a/content/docs/getting-started/architecture.md
+++ b/content/docs/getting-started/architecture.md
@@ -1,0 +1,109 @@
+---
+title: "Architecture & Design Philosophy"
+description: "The unified system architecture behind Unbound Force — three-tier context, layered governance, control matrix, and composability."
+lead: "How six architectural principles connect the tools, agents, and workflows into a coherent system."
+date: 2026-05-03T00:00:00+00:00
+draft: false
+weight: 82
+toc: true
+---
+
+## Why Architecture Matters
+
+Each page in this documentation describes a piece of Unbound Force: [Dewey](/docs/getting-started/knowledge/) provides semantic search, [convention packs](/docs/getting-started/developer/#convention-packs) encode coding standards, [the Divisor](/docs/team/the-divisor/) runs multi-agent code review, and the [Speckit pipeline](/docs/getting-started/common-workflows/#autonomous-pipeline-unleash) enforces plan-before-execute discipline. But none of those pages explains why the system is structured the way it is — why these specific components exist, how they interact, and what design principles hold them together.
+
+This page presents the six architectural principles that shape how Unbound Force works. Understanding them helps you predict how the system will behave, diagnose problems when something goes wrong, and make informed decisions about which components to adopt.
+
+## Three-Tier Context System
+
+AI agents perform better when given concrete context — real file paths, real code patterns, real project decisions — rather than abstract instructions. Research across multiple AI engineering teams has converged on this finding: showing the agent a map of the territory consistently outperforms giving it a manual of procedures (Yanli Liu, "Harness Engineering," *AI Advances*, Apr 2026).
+
+Unbound Force implements context delivery through three tiers, each serving a different purpose:
+
+**Tier 1 — Static documentation.** The `AGENTS.md` file in every repository provides project structure, build commands, coding conventions, and behavioral constraints. Agents read this at session start. It is the equivalent of onboarding documentation for a new team member — comprehensive, stable, and always available.
+
+**Tier 2 — Versioned rules.** [Convention packs](/docs/getting-started/developer/#convention-packs) encode specific coding standards as numbered, classified rules (MUST, SHOULD, MAY per RFC 2119). Each pack targets a domain: Go code, content writing, default project standards. Unlike static documentation, convention packs are portable — `uf init` deploys the same packs to every project, ensuring consistent standards across repositories.
+
+**Tier 3 — Dynamic semantic memory.** [Dewey](/docs/getting-started/knowledge/) provides a searchable knowledge layer over repository content, GitHub issues, web documentation, and stored learnings from prior sessions. Agents query Dewey before starting work, retrieving relevant decisions, patterns, and architectural context. This layer adapts over time as the knowledge base grows.
+
+The three tiers are additive: Tier 1 works alone (any project with an AGENTS.md benefits), Tier 2 adds enforcement (convention packs standardize across projects), and Tier 3 adds memory (Dewey provides cross-session, cross-repo context). A team can adopt one tier and add others as their needs grow.
+
+## Layered Governance Model
+
+Large-scale agent systems need governance — rules that constrain what agents can do, enforced at specific checkpoints. Without governance, agents make incompatible assumptions, skip quality checks, or drift from the project's intent. With too much governance, the system becomes rigid and slow.
+
+Unbound Force layers governance at five levels, from most authoritative to most specific:
+
+1. **[Constitution](/docs/getting-started/constitution/)** — The highest-authority document. Defines core principles (Autonomous Collaboration, Composability First, Observable Quality, Testability) that all work must align with. Constitution violations are automatically CRITICAL severity. Amendments require a pull request with a migration plan.
+
+2. **Convention packs** — Portable rule sets that encode coding standards, security policies, and documentation requirements. Each rule is numbered and classified by severity (MUST/SHOULD/MAY). Convention packs sit below the constitution — they may add specificity but never contradict constitutional principles.
+
+3. **Agent personas** — Individual agent configurations that define each hero's role, capabilities, tool access, and behavioral constraints. Personas are bound by convention packs and the constitution but specialize them for a specific function (development, testing, review, documentation).
+
+4. **Commands** — Slash commands (`/unleash`, `/review-council`, `/speckit.implement`) that orchestrate multi-step workflows. Commands define the sequence of operations, exit points, and handoff protocols. They operate within the constraints set by personas, packs, and the constitution.
+
+5. **CI pipelines** — Automated checks (linters, test suites, vulnerability scanners) that enforce computational constraints. CI is the final enforcement layer — if code passes all higher layers but fails CI, it does not ship.
+
+Each layer constrains the layers below it. An agent persona cannot override a convention pack rule. A command cannot bypass a constitutional principle. This prevents the governance model from being eroded by any single component.
+
+## Control Matrix
+
+How do you classify the different types of controls in an agent system? One useful framework organizes controls along two axes (adapted from ThoughtWorks' agent taxonomy, as described in Liu, "Harness Engineering," *AI Advances*, Apr 2026):
+
+- **Feedforward vs. feedback**: Does the control guide agents *before* they act (feedforward), or evaluate what they produced *after* (feedback)?
+- **Computational vs. inferential**: Is the control deterministic and fast (computational), or does it require judgment and semantic understanding (inferential)?
+
+This produces four quadrants:
+
+|  | Computational | Inferential |
+|---|---|---|
+| **Feedforward** (guides before action) | Type systems, linter rules, convention packs, JSON Schema validation | AGENTS.md, constitution, spec artifacts, agent persona instructions, Dewey knowledge retrieval |
+| **Feedback** (evaluates after action) | Test suites, [Gaze](/docs/team/gaze-tester/) CRAP scores, coverage analysis, vulnerability scanners | [Divisor Council](/docs/team/the-divisor/) reviews, constitution check, retrospective learnings |
+
+Most teams have strong computational controls (tests, linters) but weak inferential ones (relying on human code review as the only semantic check). Unbound Force invests in all four quadrants — Dewey provides inferential feedforward (semantic context before work begins), and the Divisor Council provides inferential feedback (multi-agent semantic review after work completes).
+
+## Doer/Judge Separation
+
+When the same entity both produces and evaluates work, the evaluation is compromised. An agent that wrote code and then reviews its own code is likely to rationalize its choices rather than find genuine issues. This is a well-documented finding across AI agent research: separating the doer from the judge produces higher-quality output (Anthropic's multi-agent architecture, as described in Liu, "Harness Engineering," *AI Advances*, Apr 2026).
+
+Unbound Force enforces this separation structurally, not just procedurally:
+
+- **[Cobalt-Crush](/docs/team/cobalt-crush/)** writes code. It has full tool access: read, write, edit, bash.
+- **[The Divisor](/docs/team/the-divisor/)** reviews code. The Guard agent operates at temperature 0.1 with `write: false`, `edit: false`, `bash: false` — it structurally *cannot* modify files. It can only read and report.
+
+The tool access restriction is the key design choice. A process rule ("don't modify files during review") can be violated. A structural restriction (the agent literally lacks write permissions) cannot. The judge is physically unable to fix what it finds, forcing findings to go through the implementation agent with full visibility.
+
+The Divisor Council extends this further with 5+ specialized review agents running in parallel, each with exclusive ownership boundaries and explicit "Out of Scope" sections to prevent overlap. This is a more granular separation than a single evaluator — each agent focuses on one dimension of quality (drift detection, structural integrity, test coverage, operational readiness, documentation completeness).
+
+## Plan/Execute Separation
+
+Letting an agent plan and execute in the same pass produces unreliable output. Every major AI engineering team has independently discovered this: the planning step must be separate from execution, with its output reviewed before implementation begins (Liu, "Harness Engineering," *AI Advances*, Apr 2026).
+
+Unbound Force implements this as an 8-phase pipeline with hard gates between phases:
+
+```
+constitution → specify → clarify → plan → tasks → analyze → checklist → implement
+```
+
+The phases enforce a strict progression:
+- You cannot plan before you specify
+- You cannot create tasks before you plan
+- You cannot implement before spec review passes
+- All spec artifacts must be committed before implementation begins (Spec Commit Gate)
+
+Phase boundaries are enforced rules, not suggestions. If an agent attempts to make code changes during the planning phase, it triggers a process violation and must stop. The [common workflows page](/docs/getting-started/common-workflows/) describes the full pipeline in detail, including the `/unleash` command that orchestrates all eight phases with six defined exit points where human judgment is required.
+
+This separation applies at two levels: the Speckit pipeline separates planning from execution at the feature level, and [OpenSpec](/docs/getting-started/common-workflows/#bug-fix-tactical) provides a lighter workflow for tactical changes that still separates proposal from implementation.
+
+## Composability
+
+Every component in Unbound Force is designed to be independently useful. You do not need the full system to get value from any single piece:
+
+- **Gaze** analyzes Go code quality without requiring any other Unbound Force tool. Install it, run it, get CRAP scores and coverage analysis.
+- **Dewey** provides semantic search over any Markdown-based knowledge base. It works with any AI coding environment that supports MCP, not just OpenCode.
+- **Convention packs** are portable Markdown files. You can read them as documentation, use them as prompt context, or enforce them through CI — no tooling dependency.
+- **The Speckit pipeline** can be followed manually with any AI assistant. The `/speckit.*` commands automate it, but the underlying workflow is documented and executable without automation.
+
+Graceful degradation is a design principle, not an accident. When Dewey is unavailable, agents fall back to grep and direct file reads — less context, but still functional. When Gaze is not installed, the review council skips the quality analysis phase and proceeds with CI checks and agent reviews. When convention packs are not present, agents still follow AGENTS.md conventions.
+
+This composability means teams can adopt Unbound Force incrementally. Start with one tool that solves an immediate problem. Add others when the need arises. The system gets more powerful as more components are present, but never requires all of them to function.

--- a/openspec/changes/architecture-page/.openspec.yaml
+++ b/openspec/changes/architecture-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-04

--- a/openspec/changes/architecture-page/design.md
+++ b/openspec/changes/architecture-page/design.md
@@ -1,0 +1,39 @@
+## Context
+
+The website has pages for individual tools (Gaze, Dewey), team personas, workflows, and guides, but lacks a page that presents the overall system architecture. Visitors must piece together the design philosophy from scattered references across multiple pages. Issue #88 was unanimously identified by all five content review agents as the highest-impact content gap.
+
+The proposal (proposal.md) established constitution alignment: Content Accuracy (PASS -- sourced from verified upstream repos), Minimal Footprint (PASS -- pure Markdown, no custom templates), Visitor Clarity (PASS -- fills the key missing narrative).
+
+## Goals / Non-Goals
+
+### Goals
+- Present the unified system architecture in a single page that connects existing concepts
+- Cover the six key architectural concepts: three-tier context, layered governance, control matrix, doer/judge separation, plan/execute separation, composability
+- Frame content for a website audience ("why should I care") rather than raw technical detail
+- Use the Liu "Harness Engineering" article as a secondary lens with proper attribution, not as the primary framing
+- Cross-reference existing pages (constitution, developer, knowledge, common-workflows, team pages) where those pages contain deeper detail
+
+### Non-Goals
+- Rebranding around "harness engineering" -- the superhero team identity remains primary
+- Reproducing the full harness engineering analysis -- this is a website page, not an internal document
+- Adding custom HTML, diagrams, or interactive elements -- pure Markdown only
+- Modifying existing pages to link back to this one (can be done in a separate cross-references change)
+- Adding navigation menu entries (the page is discoverable via the existing Getting Started sidebar)
+
+## Decisions
+
+**Page location**: `content/docs/getting-started/architecture.md` with weight 82, placing it after knowledge.md (80) and before constitution.md (85). This positions it as a synthesis page near the end of the getting-started section, after the reader has been introduced to individual components.
+
+**Content structure**: Six sections mapping to the six architectural concepts identified in the issue. Each section explains what the concept is, how Unbound Force implements it, and why it matters. The control matrix section uses a simple Markdown table (no custom HTML).
+
+**Attribution approach**: Liu article findings are cited as "researchers have identified" or "industry analysis shows" with a named citation. Data points from the analysis document are attributed to their sources. The page does not present Liu's framework as Unbound Force's own.
+
+**Cross-reference strategy**: Only link to pages that exist on the current branch (main). Do not link to pages created by other unmerged PRs (e.g., reference section pages from other branches).
+
+## Risks / Trade-offs
+
+**Risk: Content may drift from upstream repos.** The architecture page synthesizes claims about the system's design. If the upstream implementation changes (e.g., the Divisor Council gains or loses agents), this page could become inaccurate. Mitigation: the page describes architectural principles rather than exact counts, reducing drift sensitivity.
+
+**Risk: Overlap with existing pages.** The constitution page, developer page, and knowledge page already describe aspects of the architecture. Mitigation: the architecture page provides a synthesis narrative and links to existing pages for detail, rather than duplicating their content.
+
+**Trade-off: Weight positioning.** Placing the page at weight 82 puts it near the end of getting-started. An argument could be made for placing it earlier (to set context before diving into specifics), but the current ordering assumes readers arrive via quick-start and want practical content first.

--- a/openspec/changes/architecture-page/proposal.md
+++ b/openspec/changes/architecture-page/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+Five content review agents (Curator, Envoy, Herald, Scribe, TechWriter) unanimously identified the absence of an architecture/design philosophy page as the single highest-impact content gap on the website. The site explains what each tool does and how to use it, but never synthesizes why the system is structured the way it is. Visitors who want to understand the overall design -- the three-tier context system, the layered governance model, the doer/judge separation, the 8-phase pipeline -- have to piece it together from scattered references across multiple pages.
+
+GitHub Issue: #88
+
+## What Changes
+
+- Add a new documentation page at `content/docs/getting-started/architecture.md` presenting the unified system architecture and design philosophy
+- The page synthesizes concepts already described across constitution.md, developer.md, knowledge.md, common-workflows.md, and team pages into a single cohesive architecture overview
+- Content draws on the Yanli Liu "Harness Engineering" article (AI Advances, Apr 2026) as a secondary framing lens, with proper attribution
+
+## Capabilities
+
+### New Capabilities
+- `architecture-page`: A documentation page that presents the overall system architecture including the three-tier context system, layered governance model, control matrix, doer/judge separation, plan/execute separation, and composability
+
+### Modified Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- New file: `content/docs/getting-started/architecture.md`
+- Weight positioned between existing getting-started pages (suggested: weight 82, after knowledge.md at 80 and before constitution.md at 85)
+- No changes to existing pages, navigation menus, or styles
+- Cross-references to existing pages (constitution.md, developer.md, knowledge.md, common-workflows.md, the-divisor.md, tester.md) use relative links to pages that already exist on main
+
+## Constitution Alignment
+
+Assessed against the **Unbound Force Website** constitution (.specify/memory/constitution.md).
+
+### I. Content Accuracy
+
+**Assessment**: PASS
+
+The architecture page synthesizes concepts from verified upstream sources: the harness engineering analysis (temp/harness-engineering-analysis.md), the actual AGENTS.md structure, convention pack files, and agent persona files. All claims about the three-tier context system, layered governance, and doer/judge separation are verifiable against the source repositories. The Liu article data points are attributed to their source.
+
+### II. Minimal Footprint
+
+**Assessment**: PASS
+
+The page is pure Markdown content -- no custom HTML, CSS, JavaScript, or template overrides. It uses standard Doks frontmatter and relies entirely on built-in theme rendering. No new dependencies added.
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+This page directly serves visitor clarity by providing the missing "why is the system structured this way" narrative. It connects existing pages into a coherent architecture story, making the overall system design discoverable from a single page rather than requiring visitors to piece it together from scattered references.

--- a/openspec/changes/architecture-page/specs/architecture-page.md
+++ b/openspec/changes/architecture-page/specs/architecture-page.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Architecture Documentation Page
+
+The website MUST include a documentation page at `content/docs/getting-started/architecture.md` that presents the overall system architecture and design philosophy of Unbound Force.
+
+The page MUST cover the following architectural concepts:
+1. Three-tier context system (static docs, versioned rules, dynamic semantic memory)
+2. Layered governance model (constitution > convention packs > agent personas > commands > CI)
+3. Control matrix (feedforward/feedback x computational/inferential)
+4. Doer/judge separation (tool access restrictions on review agents)
+5. Plan/execute separation (8-phase Speckit pipeline with hard gates)
+6. Composability (independently useful components, graceful degradation)
+
+The page MUST use standard Hugo/Doks Markdown with YAML frontmatter. No custom HTML, CSS, or template overrides.
+
+The page SHOULD frame content for a website audience ("why does this matter") rather than reproducing raw technical implementation details.
+
+The page MUST attribute any claims derived from the Yanli Liu "Harness Engineering" article to their source.
+
+The page MUST NOT present "harness engineering" as Unbound Force's primary identity or branding.
+
+#### Scenario: Visitor reads architecture page
+
+- **GIVEN** a visitor navigates to the Getting Started section
+- **WHEN** they click on the Architecture & Design Philosophy page
+- **THEN** they see a page covering all six architectural concepts with cross-references to existing pages for deeper detail
+
+#### Scenario: Architecture page builds without errors
+
+- **GIVEN** the architecture page exists at `content/docs/getting-started/architecture.md`
+- **WHEN** `npm run build` is executed
+- **THEN** the build completes successfully with no errors or warnings related to the new page
+
+### Requirement: Frontmatter Convention
+
+The page MUST include YAML frontmatter with: title, description, lead, date, draft (false), weight (82), and toc (true).
+
+#### Scenario: Page appears in correct sidebar position
+
+- **GIVEN** the architecture page has weight 82
+- **WHEN** the getting-started section renders in the sidebar
+- **THEN** the page appears after knowledge.md (weight 80) and before constitution.md (weight 85)
+
+### Requirement: Cross-Reference Accuracy
+
+The page MUST only link to pages that exist on the current branch. Cross-references SHOULD use relative paths.
+
+#### Scenario: All cross-references resolve
+
+- **GIVEN** the architecture page contains links to other documentation pages
+- **WHEN** a visitor clicks any cross-reference link
+- **THEN** the link resolves to an existing page (no 404 errors)
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/architecture-page/tasks.md
+++ b/openspec/changes/architecture-page/tasks.md
@@ -1,0 +1,17 @@
+## 1. Create Architecture Page
+
+- [x] 1.1 Create `content/docs/getting-started/architecture.md` with YAML frontmatter (title, description, lead, date, draft: false, weight: 82, toc: true)
+- [x] 1.2 Write the three-tier context system section (static docs + versioned rules + dynamic semantic memory)
+- [x] 1.3 Write the layered governance model section (constitution > convention packs > agent personas > commands > CI)
+- [x] 1.4 Write the control matrix section with Markdown table (feedforward/feedback x computational/inferential, all four quadrants populated)
+- [x] 1.5 Write the doer/judge separation section (tool access restrictions, read-only review agents)
+- [x] 1.6 Write the plan/execute separation section (8-phase pipeline, hard gates between phases)
+- [x] 1.7 Write the composability section (independently useful components, graceful degradation)
+- [x] 1.8 Add cross-references to existing pages (constitution.md, developer.md, knowledge.md, common-workflows.md, the-divisor.md, tester.md) — only link to pages that exist on the current branch
+
+## 2. Verification
+
+- [x] 2.1 Run `npm run build` and confirm no errors
+- [x] 2.2 Verify page appears in correct sidebar position (after knowledge.md, before constitution.md)
+- [x] 2.3 Verify all cross-reference links resolve to existing pages
+- [x] 2.4 Verify constitution alignment: Content Accuracy (claims sourced from upstream), Minimal Footprint (pure Markdown, no custom elements), Visitor Clarity (clear architecture narrative for website visitors)


### PR DESCRIPTION
## Summary
- Adds `content/docs/getting-started/architecture.md` covering six core architectural principles
- Three-tier context system, layered governance, control matrix, doer/judge separation, plan/execute separation, composability
- Content sourced from verified upstream repos; Liu article data points attributed to their origin
- Pure Markdown, no custom HTML/CSS/JS — all cross-references verified against existing pages

Closes #88