### PR TITLE
docs: reframe homepage and getting-started with harness engineering context

### DIFF
--- a/content/docs/getting-started/_index.md
+++ b/content/docs/getting-started/_index.md
@@ -50,3 +50,11 @@ Ready to dive in? Start with the [Quick Start](/docs/getting-started/quick-start
 - **[Hero Artifacts](/docs/getting-started/artifacts/)** -- Inter-hero communication: envelope format, artifact types, and lifecycle data flow
 - **[Knowledge Retrieval with Dewey](/docs/getting-started/knowledge/)** -- Install and configure Dewey for semantic search across your repositories
 - **[Constitution](/docs/getting-started/constitution/)** -- The 4 core principles that govern all heroes and the governance model
+
+## Design Philosophy
+
+An AI agent is a model plus a harness — the surrounding system of context, controls, and feedback loops that shapes what the model produces. The model provides capability; the harness provides direction. Unbound Force invests heavily in the harness because the same model with a better harness consistently outperforms a better model with a weaker harness.
+
+The system delivers context to agents through three tiers. Static documentation (AGENTS.md) provides project structure and conventions at session start. Versioned rules ([convention packs](/docs/getting-started/developer/#convention-packs)) encode coding standards as numbered, severity-classified rules that are portable across projects. Dynamic semantic memory ([Dewey](/docs/getting-started/knowledge/)) provides searchable context from prior sessions, GitHub issues, and web documentation — adapting over time as the knowledge base grows.
+
+Quality is enforced through layered feedback: computational checks first (tests, linters, [Gaze](/docs/team/gaze-tester/) static analysis), then inferential review ([the Divisor Council](/docs/team/the-divisor/) — multiple specialized agents evaluating from distinct quality dimensions). The doer and the judge are structurally separated — review agents cannot modify files, so findings must go through the implementation path with full visibility. This layered approach means fast, cheap, deterministic checks catch the obvious issues before slower, semantic review agents spend cycles on deeper analysis.

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -251,6 +251,35 @@
           </p>
         </div>
       </div>
+      <div class="col-lg-4 col-md-6">
+        <div class="feature-card p-4 rounded-4 h-100">
+          <div class="feature-icon mb-3">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M3 7v6h6" />
+              <path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13" />
+              <path d="M21 7v6h-6" />
+              <path d="M3 17a9 9 0 0 0 9 9 9 9 0 0 0 6-2.3l3-2.7" />
+            </svg>
+          </div>
+          <h3 class="h5 fw-semibold">Built as a Harness, Not a Wrapper</h3>
+          <p class="text-body-secondary mb-0">
+            Feedforward controls — convention packs, specs, semantic context —
+            guide agents before they write code. Feedback controls — tests,
+            static analysis, multi-agent review — catch what slips through.
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/openspec/changes/messaging-reframe/.openspec.yaml
+++ b/openspec/changes/messaging-reframe/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-04

--- a/openspec/changes/messaging-reframe/design.md
+++ b/openspec/changes/messaging-reframe/design.md
@@ -1,0 +1,33 @@
+## Context
+
+The homepage has a "Why Unbound Force?" section with one featured card and three supporting cards. The getting-started index has sections for the stack table, heroes, and a "Get Started" link list. Neither speaks to visitors familiar with harness engineering concepts. Issue #90 calls for adding a feature card and a design philosophy section.
+
+The proposal (proposal.md) established constitution alignment: Content Accuracy (PASS), Minimal Footprint (PASS), Visitor Clarity (PASS).
+
+## Goals / Non-Goals
+
+### Goals
+- Add one feature card to the homepage "Why Unbound Force?" section
+- Add a "Design Philosophy" section to the getting-started index page
+- Use harness engineering as secondary framing, superhero identity stays primary
+- Attribute any Liu article data points to their source
+
+### Non-Goals
+- Rebranding the homepage or site around harness engineering
+- Adding custom CSS or new visual elements
+- Modifying the hero section, project cards, or other existing content
+- Citing specific numbers from the Liu article (the card should convey the concept, not reproduce data)
+
+## Decisions
+
+**Homepage card placement**: Add as a fourth supporting card in the "Why Unbound Force?" grid, after "Open Source". This maintains the existing 3-column grid layout (the fourth card wraps naturally on large screens and stacks on mobile).
+
+**Card content**: "Built as a Harness, Not a Wrapper" — feedforward controls guide agents before they write code, feedback controls catch what slips through. This conveys the core architectural concept without requiring knowledge of Liu's article.
+
+**Design philosophy section**: Add after the "Get Started" section in _index.md. Three paragraphs: the Agent = Model + Harness equation, the three-tier context system, and layered feedback. Link to the architecture page only if it exists on this branch (it won't — #88 is a separate PR).
+
+## Risks / Trade-offs
+
+**Risk**: Fourth feature card may look unbalanced in the 3-column grid on large screens. Mitigation: Bootstrap handles this gracefully — the fourth card appears centered below, or can be part of a 2+2 grid.
+
+**Trade-off**: Not citing specific numbers from Liu (52.8% → 66.5%, $9 → $125). The issue suggested this, but the numbers require significant context to be meaningful and might confuse visitors unfamiliar with the article. The card conveys the concept instead.

--- a/openspec/changes/messaging-reframe/proposal.md
+++ b/openspec/changes/messaging-reframe/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The website's messaging doesn't speak to the harness engineering audience — engineers who have read Liu's article and are looking for concrete implementations. The homepage feature cards describe tools but don't explain the architectural principles that make the system work. The getting-started index describes what the heroes do but not the design philosophy behind the system. With Liu's article actively circulating (1.7K claps), there is a time-sensitive positioning opportunity.
+
+GitHub Issue: #90
+
+## What Changes
+
+- Add a new feature card to the homepage (`layouts/home.html`) addressing the harness engineering audience — "Built as a Harness, Not a Wrapper" with feedforward/feedback control framing
+- Add a "Design Philosophy" section to the getting-started index (`content/docs/getting-started/_index.md`) after the existing content, framing in terms the harness engineering community recognizes
+- Harness engineering is a secondary framing lens, not a rebrand — superhero team identity remains primary
+
+## Capabilities
+
+### New Capabilities
+- `homepage-harness-card`: A feature card on the homepage that speaks to the harness engineering audience
+- `getting-started-design-philosophy`: A section on the getting-started index page explaining the design philosophy
+
+### Modified Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- Modified file: `layouts/home.html` (add one feature card)
+- Modified file: `content/docs/getting-started/_index.md` (add design philosophy section)
+- No new files, no changes to navigation or styles
+
+## Constitution Alignment
+
+Assessed against the **Unbound Force Website** constitution (.specify/memory/constitution.md).
+
+### I. Content Accuracy
+
+**Assessment**: PASS
+
+The homepage card describes real architectural features (feedforward/feedback controls). Any cited data points from the Liu article are attributed to their source. The design philosophy section describes the three-tier context system and layered feedback — both verifiable against the upstream repository.
+
+### II. Minimal Footprint
+
+**Assessment**: PASS
+
+The homepage card follows the existing feature card HTML pattern — no new CSS, templates, or JavaScript. The getting-started section is pure Markdown. No new dependencies.
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+Both changes improve visitor clarity by connecting Unbound Force to a recognized industry framework. The homepage card gives visitors from the harness engineering community an immediate recognition point. The design philosophy section provides the "why" context missing from the current page.

--- a/openspec/changes/messaging-reframe/specs/messaging-reframe.md
+++ b/openspec/changes/messaging-reframe/specs/messaging-reframe.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Homepage Harness Engineering Feature Card
+
+The homepage MUST include a feature card in the "Why Unbound Force?" section that speaks to the harness engineering audience.
+
+The card MUST convey the feedforward/feedback control concept without requiring knowledge of the Liu article.
+
+The card MUST NOT rebrand Unbound Force around harness engineering.
+
+The card MUST follow the existing feature card HTML pattern (no new CSS or JavaScript).
+
+#### Scenario: Visitor sees harness engineering card
+
+- **GIVEN** a visitor navigates to the homepage
+- **WHEN** they scroll to the "Why Unbound Force?" section
+- **THEN** they see a feature card describing the harness architecture (feedforward + feedback controls)
+
+### Requirement: Getting-Started Design Philosophy Section
+
+The getting-started index page MUST include a "Design Philosophy" section explaining the architectural principles behind Unbound Force.
+
+The section SHOULD cover: the Agent = Model + Harness concept, the three-tier context system, and layered feedback.
+
+The section MUST be pure Markdown (no custom HTML).
+
+#### Scenario: Visitor reads design philosophy
+
+- **GIVEN** a visitor navigates to the "What is Unbound Force?" page
+- **WHEN** they scroll past the heroes and get started sections
+- **THEN** they see a design philosophy section explaining the architectural principles
+
+#### Scenario: Build succeeds with changes
+
+- **GIVEN** the homepage and getting-started index are modified
+- **WHEN** `npm run build` is executed
+- **THEN** the build completes successfully
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/messaging-reframe/tasks.md
+++ b/openspec/changes/messaging-reframe/tasks.md
@@ -1,0 +1,15 @@
+## 1. Homepage Feature Card
+
+- [x] 1.1 Add a fourth feature card to the "Why Unbound Force?" section in `layouts/home.html` — "Built as a Harness, Not a Wrapper" with feedforward/feedback description
+- [x] 1.2 Use the existing feature card HTML pattern (same classes, SVG icon style)
+
+## 2. Getting-Started Design Philosophy
+
+- [x] 2.1 Add a "Design Philosophy" section to `content/docs/getting-started/_index.md` after the "Get Started" section
+- [x] 2.2 Cover the Agent = Model + Harness concept, three-tier context system, and layered feedback
+- [x] 2.3 Only cross-reference pages that exist on the current branch
+
+## 3. Verification
+
+- [x] 3.1 Run `npm run build` and confirm no errors
+- [x] 3.2 Verify constitution alignment: Content Accuracy (factual claims), Minimal Footprint (no new CSS/JS), Visitor Clarity (clear messaging)


### PR DESCRIPTION
## Summary
- Adds "Built as a Harness, Not a Wrapper" feature card to homepage "Why Unbound Force?" section
- Adds "Design Philosophy" section to getting-started index (agent=model+harness, three-tier context, layered feedback)
- Harness engineering as secondary framing lens, superhero identity stays primary

Closes #90