### PR TITLE
blog: Why Your AI Code Reviewer Cannot Have Write Access

### DIFF
--- a/content/blog/why-your-ai-code-reviewer-cannot-have-write-access.md
+++ b/content/blog/why-your-ai-code-reviewer-cannot-have-write-access.md
@@ -1,0 +1,72 @@
+---
+title: "Why Your AI Code Reviewer Cannot Have Write Access"
+description: "Telling an AI agent 'do not modify files during review' is behavioral. Removing write access entirely is structural. The difference matters."
+lead: "Telling an AI agent 'do not modify files during review' is like telling an auditor 'please do not adjust the books.' The enforcement must be structural, not behavioral."
+slug: "ai-code-reviewer-write-access"
+date: 2026-05-03T00:00:00+00:00
+draft: false
+weight: 45
+toc: true
+categories: ["Engineering"]
+tags: ["code-review", "agents", "divisor", "quality", "architecture"]
+contributors: ["Unbound Force"]
+---
+
+## The Feedback Loop That Eats Itself
+
+When the same AI agent writes code and reviews it, the review is compromised. The agent has context about why it made each decision. It remembers the trade-offs it considered. It is, in the most literal sense, reviewing its own homework.
+
+Anthropic discovered this when building their multi-agent systems: agents tasked with both producing and evaluating work would "confidently praise broken implementations" (as described in Yanli Liu, "Harness Engineering," *AI Advances*, Apr 2026). The agent was not lying — it genuinely believed the code was correct because it had rationalized each decision during implementation.
+
+The obvious fix is to use a separate agent for review. But separation is not enough if the review agent can modify what it reviews. A reviewer with write access is not a reviewer — it is a second developer. The moment the reviewer can "fix" an issue instead of reporting it, two things happen: the fix bypasses the normal implementation pipeline (no tests, no spec alignment check), and the reviewer loses objectivity because it is now invested in the code it touched.
+
+## Behavioral vs. Structural Enforcement
+
+There are two ways to prevent a review agent from modifying code:
+
+**Behavioral**: Add an instruction to the agent's prompt — "Do not modify files during review." This works until it does not. Models interpret instructions probabilistically. A sufficiently compelling reason ("this is a one-line fix, it would be more efficient to just change it") can override the instruction. The more capable the model, the more creative it gets at justifying exceptions.
+
+**Structural**: Remove the tools. If the agent does not have write, edit, or bash access, it cannot modify files regardless of what it wants to do. There is no prompt injection, no reasoning chain, no "just this once" exception that can override a missing capability. The constraint is architectural, not behavioral.
+
+In Unbound Force, [the Divisor Council's](/docs/team/the-divisor/) Guard agent operates at temperature 0.1 with explicit tool restrictions:
+
+```
+tools:
+  write: false
+  edit: false
+  bash: false
+```
+
+The Guard can read files, search code, and reason about what it finds. But it physically cannot change a single character. Every finding must be reported as a review comment, routed back through the implementation agent, and subjected to the normal quality pipeline before it reaches the codebase.
+
+This is not a minor implementation detail. It is the difference between a review process and a second pass at implementation.
+
+## The Layered Feedback Stack
+
+Structural doer/judge separation is one part of a larger feedback architecture. The review pipeline in Unbound Force runs in layers, from cheapest to most expensive:
+
+**Layer 1 — Computational feedback.** Tests, linters, vulnerability scanners, and [Gaze](/docs/team/gaze-tester/) static analysis (CRAP scores, coverage analysis, testability classification). These checks are deterministic, fast, and cheap. If a test fails or a linter reports an error, there is no ambiguity — the code does not meet the standard. This layer runs first because there is no point spending cycles on semantic review if the code does not compile or fails its tests.
+
+**Layer 2 — Inferential feedback.** The Divisor Council — five or more specialized review agents running in parallel. Each agent evaluates from a different perspective: the Guard checks for intent drift, the Architect reviews structural integrity, the Adversary stress-tests for security and edge cases, the Tester evaluates test quality, and the SRE assesses operational readiness. Each agent has explicit "Out of Scope" sections to prevent overlap.
+
+This layering follows a principle identified independently by multiple teams building AI agent systems: use computational feedback first, then inferential feedback (ThoughtWorks' terminology, as described in Liu, "Harness Engineering," *AI Advances*, Apr 2026). Deterministic checks are cheaper and more reliable; inferential review is powerful but expensive. Running them in order maximizes the value of each layer.
+
+## The Three-Iteration Cap
+
+What happens when the reviewer finds issues? The implementation agent fixes them and resubmits. The reviewer runs again. If it finds more issues, the cycle repeats — but only three times.
+
+The 3-iteration review cap is a pragmatic constraint: if a piece of code cannot pass review in three attempts, the problem is not a typo or a missed edge case. It is a design issue that requires human judgment. Continuing to iterate would waste compute on a problem the agents are not equipped to resolve.
+
+This cap also prevents a subtle failure mode: the implementation agent and review agent entering an infinite loop where each fix introduces a new issue that the previous fix was avoiding. Three iterations is enough to catch genuine oversights while avoiding oscillation.
+
+## What This Means for Your Review Pipeline
+
+If you are building AI code review into your workflow, the enforcement model matters more than the review prompt. A sophisticated review prompt with full write access produces worse outcomes than a simple review prompt with structural separation.
+
+The checklist:
+- **Separate the agents.** The agent that writes code and the agent that reviews code must be different instances with different context.
+- **Remove write access from reviewers.** Not "do not write" — actually remove the tools. No write, no edit, no bash.
+- **Layer your feedback.** Run deterministic checks first, semantic review second. Do not waste inferential review on code that fails to compile.
+- **Cap the iterations.** If it is not fixed in three passes, escalate to a human. The agents are circling.
+
+If your AI review agent can edit files, it is not a reviewer. It is a second developer with a different prompt.

--- a/openspec/changes/blog-doer-judge/.openspec.yaml
+++ b/openspec/changes/blog-doer-judge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-04

--- a/openspec/changes/blog-doer-judge/design.md
+++ b/openspec/changes/blog-doer-judge/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The Divisor Council enforces doer/judge separation structurally — the Guard agent cannot modify files. No blog post explains this rationale. Issue #91 calls for a post covering structural vs behavioral enforcement.
+
+## Goals / Non-Goals
+
+### Goals
+- Explain why structural enforcement (tool access restrictions) is superior to behavioral instructions
+- Describe the layered feedback stack (CI → Gaze → Divisor agents)
+- Cover the 3-iteration review cap as a pragmatic constraint
+- Attribute Anthropic findings to Liu article
+
+### Non-Goals
+- Detailed Divisor agent persona documentation (that belongs in team pages)
+- Modifying existing pages
+- Adding diagrams or custom HTML
+
+## Decisions
+
+**File**: `content/blog/why-your-ai-code-reviewer-cannot-have-write-access.md` with slug `ai-code-reviewer-write-access`.
+
+**Structure**: Problem (collapsed doer/judge) → Structural vs behavioral → The layered feedback stack → The 3-iteration cap → CTA.
+
+**Cross-references**: Link to the-divisor.md and gaze-tester.md team pages; common-workflows.md for the review pipeline.
+
+## Risks / Trade-offs
+
+**Risk**: Overlap with the five-principles post (#89) which also covers doer/judge separation. Mitigation: this post goes deeper on the specific mechanism (tool access restrictions, review iteration limits) while the principles post covers it at the conceptual level.

--- a/openspec/changes/blog-doer-judge/proposal.md
+++ b/openspec/changes/blog-doer-judge/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+No existing blog post covers the architectural rationale behind the Divisor Council's structural doer/judge separation — why review agents are physically prevented from modifying files rather than behaviorally instructed not to. This is a distinctive architectural decision that maps directly to Anthropic's finding about agents "confidently praising broken work" when doer and judge roles collapse.
+
+GitHub Issue: #91
+
+## What Changes
+
+- Add a new blog post at `content/blog/why-your-ai-code-reviewer-cannot-have-write-access.md`
+- Covers structural vs behavioral enforcement, layered feedback stack, tool access restrictions, the 3-iteration review cap
+- Attributes Anthropic findings to their source (Liu article)
+
+## Capabilities
+
+### New Capabilities
+- `blog-doer-judge`: Blog post on structural doer/judge separation in AI code review
+
+### Modified Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- New file: `content/blog/why-your-ai-code-reviewer-cannot-have-write-access.md`
+- No changes to existing pages
+
+## Constitution Alignment
+
+Assessed against the **Unbound Force Website** constitution (.specify/memory/constitution.md).
+
+### I. Content Accuracy
+
+**Assessment**: PASS
+
+The Guard agent's tool restrictions (write: false, edit: false, bash: false) are verifiable against the agent persona file. The 3-iteration review cap is verifiable against the review-council command. Anthropic findings attributed to Liu article.
+
+### II. Minimal Footprint
+
+**Assessment**: PASS
+
+Pure Markdown blog post, no custom elements.
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+The post serves visitors building AI review workflows by providing a clear architectural rationale with a memorable CTA.

--- a/openspec/changes/blog-doer-judge/specs/blog-doer-judge.md
+++ b/openspec/changes/blog-doer-judge/specs/blog-doer-judge.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Doer/Judge Blog Post
+
+The website MUST include a blog post explaining the structural doer/judge separation in the Divisor Council.
+
+The post MUST cover structural vs behavioral enforcement of review boundaries.
+
+The post MUST attribute Anthropic findings to their source (Liu article).
+
+The post MUST describe the layered feedback stack and the 3-iteration review cap.
+
+#### Scenario: Visitor reads doer/judge post
+
+- **GIVEN** a visitor navigates to the blog
+- **WHEN** they read the doer/judge separation post
+- **THEN** they understand why review agents are structurally prevented from modifying files
+
+#### Scenario: Build succeeds
+
+- **GIVEN** the blog post exists with proper frontmatter
+- **WHEN** `npm run build` is executed
+- **THEN** the build completes successfully
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/blog-doer-judge/tasks.md
+++ b/openspec/changes/blog-doer-judge/tasks.md
@@ -1,0 +1,14 @@
+## 1. Create Blog Post
+
+- [x] 1.1 Create `content/blog/why-your-ai-code-reviewer-cannot-have-write-access.md` with blog frontmatter
+- [x] 1.2 Write the problem section (collapsed doer/judge, agents praising broken work)
+- [x] 1.3 Write structural vs behavioral enforcement section
+- [x] 1.4 Write the layered feedback stack section (CI → Gaze → Divisor agents)
+- [x] 1.5 Write the 3-iteration review cap section
+- [x] 1.6 Write CTA ("If your AI review agent can edit files...")
+- [x] 1.7 Add cross-references to existing pages only
+
+## 2. Verification
+
+- [x] 2.1 Run `npm run build` and confirm no errors
+- [x] 2.2 Verify constitution alignment


### PR DESCRIPTION
## Summary
- Adds blog post on structural doer/judge separation in AI code review
- Covers behavioral vs structural enforcement, layered feedback stack (CI → Gaze → Divisor), 3-iteration review cap
- Anthropic findings attributed to Liu article; pure Markdown

Closes #91