### PR TITLE
blog: Convention Packs — reusable harness templates

### DIFF
--- a/content/blog/convention-packs.md
+++ b/content/blog/convention-packs.md
@@ -1,0 +1,94 @@
+---
+title: "Convention Packs: Reusable Harness Templates That Travel Between Projects"
+description: "Most teams encode AI agent coding standards as prose in a single file. Convention packs are versioned, numbered, and portable. Here is why that matters."
+lead: "If you maintain AI agent standards as prose in a single file, convention packs show what structured, portable standards look like."
+slug: "convention-packs"
+date: 2026-05-03T00:00:00+00:00
+draft: false
+weight: 43
+toc: true
+categories: ["Engineering"]
+tags: ["agents", "quality", "documentation", "architecture"]
+contributors: ["Unbound Force"]
+---
+
+## The Prose Standards Problem
+
+Every project that uses AI coding agents needs coding standards. The agent needs to know how to format code, name variables, handle errors, structure tests, and manage dependencies. Without explicit standards, the agent guesses — and its guesses are inconsistent across sessions, files, and projects.
+
+Most teams solve this by writing prose in their AGENTS.md or system prompt: "Use camelCase for variables. Write tests for all public functions. Handle errors with wrapped returns." This works for a single project. Then you start a second project. You copy the AGENTS.md, adapt it, and move on.
+
+Six months later, you have five projects with five versions of the same standards. The Go project requires wrapped errors. The TypeScript project forgot to mention it. The content standards evolved in one repo but not the others. Updates drift. Nobody knows which version is canonical.
+
+## What Convention Packs Look Like
+
+Convention packs replace prose standards with structured, numbered, severity-classified rules. Each pack is a Markdown file with YAML frontmatter, deployed to projects via `uf init`.
+
+Here is what a rule looks like in the Go convention pack:
+
+```markdown
+- **CS-001** [MUST] Format all Go source files with `gofmt`.
+  No manual formatting overrides.
+- **CS-006** [MUST] Wrap errors with `fmt.Errorf("context: %w", err)`
+  to preserve the error chain.
+- **CS-010** [SHOULD] Keep functions focused on a single responsibility.
+  Extract helper functions when a function exceeds ~50 lines.
+```
+
+Each rule has three components:
+
+1. **A stable identifier** (CS-001, AP-003, SC-002). The prefix indicates the category: CS for Coding Style, AP for Architectural Patterns, SC for Security Checks, TC for Testing Conventions, DR for Documentation Requirements. The number is sequential within the category and never reused.
+
+2. **A severity level** (MUST, SHOULD, MAY per RFC 2119). MUST rules are non-negotiable — violations are automatic failures. SHOULD rules are expected but can be overridden with justification. MAY rules are suggestions.
+
+3. **The rule itself**. Concrete, actionable, unambiguous. Not "write good tests" but "test observable side effects, not implementation details."
+
+Unbound Force ships with packs for different domains:
+
+| Pack | Domain | Example Rules |
+|------|--------|---------------|
+| `default.md` | All projects | Commit message format, PR conventions, error handling patterns |
+| `go.md` | Go projects | `gofmt`, import organization, `Options`/`Result` pattern, `embed.FS` for assets |
+| `content.md` | Content/docs | Frontmatter requirements, heading structure, link conventions |
+| `typescript.md` | TypeScript projects | Formatting, type safety, module patterns |
+| `severity.md` | Quality gates | CRAP score thresholds, coverage requirements, auto-fix policies |
+
+## The Extension Pattern
+
+Convention packs solve the portability problem — the same `go.md` deploys to every Go project. But projects have different needs. A web API project has different architectural patterns than a CLI tool.
+
+The `-custom.md` pattern handles this. For every pack `<name>.md`, a project can create `<name>-custom.md` with project-specific additions or overrides:
+
+```
+.opencode/uf/packs/
+  go.md              # Standard Go rules (shipped by uf init)
+  go-custom.md       # Project-specific Go rules (you write this)
+  content.md         # Standard content rules
+  content-custom.md  # Project-specific content rules
+```
+
+The custom file can add new rules, tighten existing ones, or document project-specific exceptions. The base pack is never modified directly — it gets updated when you run `uf init` again. Your custom rules persist across updates because they live in a separate file.
+
+This is the same pattern as configuration layering in tools like ESLint or Prettier: a shared base config that extends cleanly with project-specific overrides. The difference is that convention packs are designed for AI agent consumption — structured rules with stable identifiers that agents can reference in their reasoning.
+
+## Why Structure Matters for Agents
+
+Prose instructions work for humans because humans interpret context. An experienced developer reads "handle errors properly" and applies their judgment about what "properly" means in each situation.
+
+AI agents interpret instructions differently. They follow what they are told, but the specificity of the instruction determines the consistency of the output. "Handle errors properly" produces different results on different invocations. "Wrap errors with `fmt.Errorf('context: %w', err)` to preserve the error chain" (rule CS-006, MUST) produces the same result every time.
+
+The structure of convention packs — numbered rules, explicit severity, concrete examples — gives agents three things that prose does not:
+
+**Deterministic reference.** When a review agent flags a violation, it can cite "CS-006 [MUST]" rather than "the part about error handling." The stable identifier makes the reference unambiguous and auditable.
+
+**Severity-based enforcement.** Agents can distinguish between non-negotiable requirements (MUST) and best practices (SHOULD). This prevents the common failure mode of treating every standard as equally important, which leads to either paralysis (everything must be perfect) or nihilism (nothing matters because everything is optional).
+
+**Portable consistency.** The same `go.md` produces the same coding standards across every project. When you update a rule in the canonical pack, every project that runs `uf init` gets the update. No copy-paste, no drift, no "which version are we on."
+
+## Packs as Harness Templates
+
+ThoughtWorks' agent taxonomy includes the concept of "harness templates" — reusable patterns that can be deployed across projects to establish consistent agent behavior (as described in Yanli Liu, "Harness Engineering," *AI Advances*, Apr 2026). Convention packs are a direct implementation of this concept.
+
+The key insight is that coding standards are a property of the organization, not the project. An organization that values error chain preservation values it in every Go project, not just the one where someone wrote it down. Convention packs make organizational standards portable, versioned, and consistently deployed — the same way a CI workflow template ensures every project runs the same quality checks.
+
+If you are maintaining AI agent coding standards as prose in a single AGENTS.md file, convention packs show what the structured alternative looks like. The agent gets explicit rules. The review agent gets stable identifiers to cite. The organization gets portable consistency. And when you start your next project, the standards travel with you.

--- a/openspec/changes/blog-convention-packs/.openspec.yaml
+++ b/openspec/changes/blog-convention-packs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-04

--- a/openspec/changes/blog-convention-packs/design.md
+++ b/openspec/changes/blog-convention-packs/design.md
@@ -1,0 +1,25 @@
+## Context
+
+Convention packs are versioned rule sets deployed via `uf init`. They use numbered rules with MUST/SHOULD/MAY classification. The -custom.md extension pattern allows project-specific overrides. Issue #93 calls for a blog post explaining the concept.
+
+## Goals / Non-Goals
+
+### Goals
+- Explain the problem (prose standards in AGENTS.md that drift across projects)
+- Show pack structure with real examples from go.md
+- Cover the -custom.md extension pattern
+- Connect to the ThoughtWorks "harness templates" concept
+
+### Non-Goals
+- Full pack reference documentation (that's for a dedicated docs page)
+- Modifying existing pages
+
+## Decisions
+
+**File**: `content/blog/convention-packs.md` with slug `convention-packs`.
+
+**Structure**: Problem (prose drifts) → What packs look like → The extension pattern → Why structure matters → CTA.
+
+## Risks / Trade-offs
+
+Minor overlap with developer.md convention packs section. The blog post is narrative-driven (why packs exist, industry context) while the docs page is practical (how to use them).

--- a/openspec/changes/blog-convention-packs/proposal.md
+++ b/openspec/changes/blog-convention-packs/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Convention packs are an undocumented differentiator — portable, versioned, RFC 2119-classified rule sets that travel between projects via `uf init`. No blog post or dedicated page covers them. The developer.md has ~50 lines on packs; this post provides the deep dive on what they are and why they matter.
+
+GitHub Issue: #93
+
+## What Changes
+
+- Add a new blog post at `content/blog/convention-packs.md`
+
+## Capabilities
+
+### New Capabilities
+- `blog-convention-packs`: Blog post on convention packs as reusable harness templates
+
+### Modified Capabilities
+- None
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- New file: `content/blog/convention-packs.md`
+- No changes to existing pages
+
+## Constitution Alignment
+
+Assessed against the **Unbound Force Website** constitution (.specify/memory/constitution.md).
+
+### I. Content Accuracy
+
+**Assessment**: PASS
+
+Pack structure, rule numbering, and -custom.md pattern are verified against actual pack files in `.opencode/uf/packs/`.
+
+### II. Minimal Footprint
+
+**Assessment**: PASS
+
+Pure Markdown blog post.
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+Clear problem/solution/evidence arc for teams managing AI agent coding standards.

--- a/openspec/changes/blog-convention-packs/specs/blog-convention-packs.md
+++ b/openspec/changes/blog-convention-packs/specs/blog-convention-packs.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Convention Packs Blog Post
+
+The website MUST include a blog post explaining convention packs as reusable, portable harness templates for AI agent coding standards.
+
+The post MUST show real examples from actual pack files.
+
+The post MUST cover the -custom.md extension pattern.
+
+#### Scenario: Visitor reads convention packs post
+
+- **GIVEN** a visitor navigates to the blog
+- **WHEN** they read the convention packs post
+- **THEN** they understand what convention packs are, how they are structured, and why they matter
+
+#### Scenario: Build succeeds
+
+- **GIVEN** the blog post exists with proper frontmatter
+- **WHEN** `npm run build` is executed
+- **THEN** the build completes successfully
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/blog-convention-packs/tasks.md
+++ b/openspec/changes/blog-convention-packs/tasks.md
@@ -1,0 +1,13 @@
+## 1. Create Blog Post
+
+- [x] 1.1 Create `content/blog/convention-packs.md` with blog frontmatter
+- [x] 1.2 Write the problem section (prose standards drift across projects)
+- [x] 1.3 Write the pack structure section with real examples
+- [x] 1.4 Write the -custom.md extension pattern section
+- [x] 1.5 Write why structure matters section (agents + deterministic rules)
+- [x] 1.6 Write CTA
+
+## 2. Verification
+
+- [x] 2.1 Run `npm run build` and confirm no errors
+- [x] 2.2 Verify constitution alignment


### PR DESCRIPTION
## Summary
- Adds blog post on convention packs as structured, portable, RFC 2119-classified rule sets
- Covers pack structure with real go.md examples, -custom.md extension pattern
- Connects to ThoughtWorks harness templates concept; pure Markdown

Closes #93