### PR TITLE
docs: add harness engineering framing to existing pages

### DIFF
--- a/content/docs/getting-started/constitution.md
+++ b/content/docs/getting-started/constitution.md
@@ -134,6 +134,18 @@ The `/constitution-check` command automates this assessment. OpenSpec proposals 
 
 The constitution is versioned (currently v1.1.0) and the check validates against the version referenced in the project's `parent_constitution` field. See the [contributing guide](/docs/contributing/) for how this fits into the specification pipeline.
 
+## Governance Hierarchy
+
+The constitution sits at the top of a layered governance model. Each layer constrains the layers below it:
+
+1. **Constitution** — core principles (this document)
+2. **Convention packs** — portable coding standards (MUST/SHOULD/MAY rules)
+3. **Agent personas** — individual hero configurations and behavioral constraints
+4. **Commands** — workflow orchestration (`/unleash`, `/review-council`, `/speckit.*`)
+5. **CI pipelines** — automated deterministic checks
+
+A convention pack cannot override a constitutional principle. A command cannot bypass a convention pack rule. This layered model ensures that organizational intent flows consistently from principles to implementation. The constitution and governance model are decay-resistant — they encode organizational values and process rules that persist regardless of how AI model capabilities evolve.
+
 ## Next Steps
 
 - Read [Hero Artifacts](/docs/getting-started/artifacts/) to understand the envelope format and artifact types referenced in Principle I

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -194,7 +194,7 @@ Every session follows this ritual:
 
 ### Convention Packs
 
-Convention packs are shared coding standards files stored in `.opencode/uf/packs/`. Cobalt-Crush follows these conventions during implementation, and The Divisor enforces them during review. Every rule in a pack has a severity tag that determines how violations are handled.
+Convention packs are shared coding standards files stored in `.opencode/uf/packs/`. They function as feedforward controls — portable harness templates that guide agents before they write code, rather than correcting output after. Cobalt-Crush follows these conventions during implementation, and The Divisor enforces them during review. Every rule in a pack has a severity tag that determines how violations are handled.
 
 #### Pack Files
 

--- a/content/docs/getting-started/knowledge.md
+++ b/content/docs/getting-started/knowledge.md
@@ -8,6 +8,10 @@ weight: 80
 toc: true
 ---
 
+## Why Semantic Memory?
+
+AI agents perform best when given concrete context — real file paths, real decisions, real patterns from prior work. Unbound Force delivers context through three tiers: static documentation (AGENTS.md), versioned rules ([convention packs](/docs/getting-started/developer/#convention-packs)), and dynamic semantic memory. Dewey is the third tier — a searchable knowledge layer that provides agents with cross-repo context, prior learnings, and architectural decisions before they start work. In harness engineering terms, Dewey is a feedforward control: it shapes agent behavior by providing context before action, rather than correcting output after.
+
 ## What Dewey Does
 
 Dewey is a semantic knowledge layer that gives AI agents rich, cross-repository context. It combines a structured knowledge graph (page traversal, tag queries, wikilink navigation) with vector-based semantic search — so agents can find conceptually related content even when different terminology is used. A search for "authentication timeout" finds an issue titled "login session expiry" because Dewey understands meaning, not just keywords.

--- a/content/docs/team/the-divisor.md
+++ b/content/docs/team/the-divisor.md
@@ -16,6 +16,14 @@ The Divisor is the PR Reviewer of the Unbound Force swarm — the architectural 
 
 The Divisor acts as the final technical gate before integration, translating high-level architectural standards into actionable review criteria. What makes The Divisor unique is its structure: it operates as a **council of nine dynamically discovered personas** -- nine canonical roles ship by default (six review, three content creation), with users able to add or remove personas freely. Each provides a different lens on every code submission.
 
+## Why a Council?
+
+A single AI agent reviewing its own code — or even a single separate agent reviewing another's code — misses issues that only become visible from a different perspective. Security experts catch vulnerabilities that architects overlook. Test quality specialists identify coverage gaps that SREs miss. The council model exists because no single evaluative lens is sufficient for production-quality code.
+
+The Divisor's architecture reflects two design principles. First, **doer/judge separation**: the Guard agent operates at temperature 0.1 with tool access restrictions (`write: false`, `edit: false`, `bash: false`), making it structurally unable to modify code. This is not a behavioral instruction — it is an architectural constraint. The judge physically cannot fix what it finds, forcing all findings through the normal implementation pipeline with full visibility.
+
+Second, **layered feedback ordering**: computational checks (CI pipeline, [Gaze](/docs/team/gaze-tester/) static analysis) run before the Divisor Council reviews. Fast, deterministic, cheap checks filter out obvious issues before slower, more expensive semantic review begins. The council's time is spent on judgment calls, not compilation errors.
+
 ## The Council
 
 ### The Guard — Intent and Cohesion

--- a/openspec/changes/framing-enhancements/.openspec.yaml
+++ b/openspec/changes/framing-enhancements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-04

--- a/openspec/changes/framing-enhancements/design.md
+++ b/openspec/changes/framing-enhancements/design.md
@@ -1,0 +1,29 @@
+## Context
+
+Four existing pages need small enhancements to connect them to the harness engineering framework. Issue #95 specifies the exact additions for each page.
+
+## Goals / Non-Goals
+
+### Goals
+- Add targeted sections/sentences to 4 pages
+- Use harness engineering as secondary framing, keep existing vocabulary primary
+- Keep additions concise and high-signal
+
+### Non-Goals
+- Rebranding any page
+- Adding decay warnings to feature pages
+- Custom HTML or styling
+
+## Decisions
+
+**Divisor page**: Add a "Why a Council?" section after "The Code Integrity Guardian" paragraph, before "The Council". Covers multi-perspective evaluation, structural doer/judge separation, layered feedback ordering.
+
+**Constitution page**: Add a governance hierarchy paragraph in the "Next Steps" area or after "Constitution Check". Brief note about decay resistance.
+
+**Knowledge page**: Add a "Why Semantic Memory?" paragraph after "What Dewey Does" to frame the three-tier context system.
+
+**Developer page**: Add one sentence to the convention packs intro paragraph noting they are feedforward controls and portable harness templates.
+
+## Risks / Trade-offs
+
+Minimal risk — all additions are small Markdown sections. The main concern is tone consistency: the harness engineering vocabulary should complement, not replace, the existing superhero team framing.

--- a/openspec/changes/framing-enhancements/proposal.md
+++ b/openspec/changes/framing-enhancements/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+All 5 content review agents agreed that existing pages should be enhanced with harness engineering vocabulary where it adds clarity — without replacing the project's existing terminology. This is low-effort, high-signal: adding a few sentences to four existing pages to connect them to the broader harness engineering framework.
+
+GitHub Issue: #95
+
+## What Changes
+
+- Add "Why a Council?" section to `content/docs/team/the-divisor.md` explaining architectural rationale
+- Add governance hierarchy note to `content/docs/getting-started/constitution.md`
+- Add "Why Semantic Memory?" context to `content/docs/getting-started/knowledge.md`
+- Add feedforward framing sentence to convention packs section in `content/docs/getting-started/developer.md`
+
+## Capabilities
+
+### New Capabilities
+- None (enhancements to existing pages)
+
+### Modified Capabilities
+- `divisor-page`: Enhanced with architectural rationale section
+- `constitution-page`: Enhanced with governance hierarchy context
+- `knowledge-page`: Enhanced with three-tier context framing
+- `developer-page`: Enhanced with feedforward framing for convention packs
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- Modified files: 4 existing Markdown pages
+- No new files, no navigation changes, no style changes
+
+## Constitution Alignment
+
+Assessed against the **Unbound Force Website** constitution (.specify/memory/constitution.md).
+
+### I. Content Accuracy
+
+**Assessment**: PASS
+
+All additions describe real architectural features verifiable against the upstream repository. No new claims fabricated.
+
+### II. Minimal Footprint
+
+**Assessment**: PASS
+
+Small Markdown additions to existing pages. No custom elements.
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+Connects existing pages to a recognized industry framework, improving discoverability and context for visitors familiar with harness engineering concepts.

--- a/openspec/changes/framing-enhancements/specs/framing-enhancements.md
+++ b/openspec/changes/framing-enhancements/specs/framing-enhancements.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+None (modifications only).
+
+## MODIFIED Requirements
+
+### Requirement: Divisor Page Enhancement
+
+The Divisor page MUST include a "Why a Council?" section explaining the architectural rationale for multi-perspective evaluation, structural doer/judge separation, and layered feedback.
+
+### Requirement: Constitution Page Enhancement
+
+The Constitution page SHOULD include a note on the governance hierarchy (constitution > convention packs > agent personas > commands > CI) and decay resistance.
+
+### Requirement: Knowledge Page Enhancement
+
+The Knowledge page SHOULD include context framing Dewey as part of the three-tier context system and as a feedforward control.
+
+### Requirement: Developer Page Enhancement
+
+The convention packs section SHOULD note that convention packs function as feedforward controls and portable harness templates.
+
+#### Scenario: All pages build successfully
+
+- **GIVEN** the four pages are modified with small additions
+- **WHEN** `npm run build` is executed
+- **THEN** the build completes successfully
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/framing-enhancements/tasks.md
+++ b/openspec/changes/framing-enhancements/tasks.md
@@ -1,0 +1,11 @@
+## 1. Page Enhancements
+
+- [x] 1.1 Add "Why a Council?" section to the-divisor.md (architectural rationale, doer/judge separation, layered feedback)
+- [x] 1.2 Add governance hierarchy note to constitution.md
+- [x] 1.3 Add "Why Semantic Memory?" paragraph to knowledge.md
+- [x] 1.4 Add feedforward framing sentence to convention packs intro in developer.md
+
+## 2. Verification
+
+- [x] 2.1 Run `npm run build` and confirm no errors
+- [x] 2.2 Verify constitution alignment


### PR DESCRIPTION
## Summary
- Adds "Why a Council?" section to the-divisor.md (doer/judge separation, layered feedback ordering)
- Adds governance hierarchy section to constitution.md (decay-resistant organizational intent)
- Adds "Why Semantic Memory?" section to knowledge.md (three-tier context, feedforward control)
- Adds feedforward framing sentence to convention packs in developer.md
- Harness engineering as secondary lens; superhero identity stays primary

Closes #95