### PR TITLE
docs: add cross-reference links between existing pages

### DIFF
--- a/content/docs/contributing/_index.md
+++ b/content/docs/contributing/_index.md
@@ -30,7 +30,7 @@ We follow the standard GitHub pull request workflow:
 4. Submit a pull request against the `main` branch
 5. Address any review feedback from The Divisor council
 
-All pull requests are reviewed by The Divisor — a council of nine sub-personas. Six review personas (The Guard, The Architect, The Adversary, The Operator (SRE), The Tester, and The Curator) evaluate intent, structure, resilience, operational readiness, and test quality. Three content personas (The Scribe, The Herald, and The Envoy) ensure documentation, blog posts, and public communications meet quality standards. Collective approval from all active personas is required before merge.
+All pull requests are reviewed by The Divisor — a council of nine sub-personas. Six review personas (The Guard, The Architect, The Adversary, The Operator (SRE), The Tester, and The Curator) evaluate intent, structure, resilience, operational readiness, and test quality. Three content personas (The Scribe, The Herald, and The Envoy) ensure documentation, blog posts, and public communications meet quality standards. Collective approval from all active personas is required before merge. See [convention packs](/docs/getting-started/developer/#convention-packs) for the specific coding standards your contributions will be reviewed against.
 
 ## Conventional Commits
 

--- a/content/docs/getting-started/artifacts.md
+++ b/content/docs/getting-started/artifacts.md
@@ -37,7 +37,7 @@ The swarm defines 7 artifact types. Each has a designated producer hero and one 
 | Type                  | Producer            | Consumers                     | Description                                                                                      |
 | --------------------- | ------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------ |
 | `quality-report`      | Gaze                | Mx F, Muti-Mind, Cobalt-Crush | Test results, contract coverage data, CRAP scores, and risk analysis from quality validation     |
-| `review-verdict`      | The Divisor         | Mx F, Cobalt-Crush, Muti-Mind | APPROVE or REQUEST CHANGES verdict with per-persona findings from the review council             |
+| `review-verdict`      | [The Divisor](/docs/team/the-divisor/) | Mx F, Cobalt-Crush, Muti-Mind | APPROVE or REQUEST CHANGES verdict with per-persona findings from the review council             |
 | `backlog-item`        | Muti-Mind           | Mx F, Cobalt-Crush            | Feature or bug descriptions with priority scores (5-dimension composite) and acceptance criteria |
 | `acceptance-decision` | Muti-Mind           | Mx F, Cobalt-Crush            | ACCEPT, REJECT, or CONDITIONAL decision with rationale after reviewing the completed increment   |
 | `metrics-snapshot`    | Mx F                | Muti-Mind                     | Velocity, quality trends, review efficiency, and CI health metrics for the current period        |

--- a/content/docs/getting-started/common-workflows.md
+++ b/content/docs/getting-started/common-workflows.md
@@ -351,7 +351,7 @@ Moves the change to `openspec/changes/archive/` with a date prefix for historica
 
 ## Code Review
 
-The review council brings multiple specialized perspectives to every code review.
+The review council brings multiple specialized perspectives to every code review. Each persona has [exclusive ownership boundaries](/docs/team/the-divisor/#exclusive-ownership-boundaries) — a finding like "missing error handling" is raised by exactly one persona, not duplicated across multiple reviewers.
 
 ### Invoking the Council
 

--- a/content/docs/getting-started/constitution.md
+++ b/content/docs/getting-started/constitution.md
@@ -138,4 +138,5 @@ The constitution is versioned (currently v1.1.0) and the check validates against
 
 - Read [Hero Artifacts](/docs/getting-started/artifacts/) to understand the envelope format and artifact types referenced in Principle I
 - See [Common Workflows](/docs/getting-started/common-workflows/) for how the constitution gates the specification pipeline
+- Read about [convention packs](/docs/getting-started/developer/#convention-packs/) — the constitution sets the floor; convention packs raise the bar with specific, severity-classified coding standards
 - Explore the [Team](/docs/team/) pages to see how each hero implements these principles

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -269,7 +269,7 @@ The eight categories of protected values are:
 7. Review iteration limits and worker concurrency caps
 8. Workflow gate markers (e.g., `<!-- spec-review: passed -->`)
 
-The Guard checks for "Gatekeeping Integrity" during code review and the Adversary checks for "Gate Tampering" — both will flag unauthorized modifications to these values.
+The [Guard](/docs/team/the-divisor/#the-guard--intent-and-cohesion) checks for "Gatekeeping Integrity" during code review and the [Adversary](/docs/team/the-divisor/#the-adversary--resilience-and-security) checks for "Gate Tampering" — both will flag unauthorized modifications to these values.
 
 ## Project Scaffolding with `uf init`
 

--- a/content/docs/getting-started/quick-start.md
+++ b/content/docs/getting-started/quick-start.md
@@ -77,6 +77,7 @@ Each tool is independently useful, but they compose into the full Unbound Force 
 
 ## Next Steps
 
+- **[Constitution](/docs/getting-started/constitution/)** -- The core principles that govern all heroes. The constitution must exist before running `/speckit.specify`
 - **[Developer Guide](/docs/getting-started/developer/)** -- Daily workflow, Speckit pipeline, Replicator coordination, convention packs
 - **[Tester Guide](/docs/getting-started/tester/)** -- Gaze quality analysis, CRAP scores, coverage ratchets, CI integration
 - **[Product Owner Guide](/docs/getting-started/product-owner/)** -- Muti-Mind backlog management, priority scoring, acceptance decisions

--- a/content/docs/team/the-divisor.md
+++ b/content/docs/team/the-divisor.md
@@ -175,7 +175,7 @@ This structure ensures that only code which passes all nine lenses — intent, a
 
 **For Developers (Cobalt-Crush):** Cobalt-Crush relies on The Divisor for the final technical sign-off. The multi-faceted feedback from the nine personas provides a holistic critique covering intent, structure, security, operational readiness, test quality, documentation governance, and content accuracy. Clear architectural standards minimize uncertainty, allowing Cobalt-Crush to code with confidence.
 
-**For the Tester (Gaze):** Gaze relies on The Divisor to establish the architectural and non-functional requirements against which testability must be measured. Gaze's green light on functional tests is the entry criterion for The Divisor's review, ensuring review time is spent on high-level risk and structure rather than defect finding.
+**For the Tester ([Gaze](/docs/team/gaze-tester/)):** Gaze relies on The Divisor to establish the architectural and non-functional requirements against which testability must be measured. Gaze's green light on functional tests is the entry criterion for The Divisor's review, ensuring review time is spent on high-level risk and structure rather than defect finding.
 
 **For the Product Owner and Manager (Muti-Mind and Mx F):** Muti-Mind and Mx F are assured that every merged feature is technically sound, secure, and scalable. The Divisor acts as the ultimate guarantor of technical quality, ensuring that the velocity gained through prioritization and execution is sustainable and does not accrue crippling technical debt.
 

--- a/openspec/changes/cross-references/.openspec.yaml
+++ b/openspec/changes/cross-references/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-05-04

--- a/openspec/changes/cross-references/design.md
+++ b/openspec/changes/cross-references/design.md
@@ -1,0 +1,21 @@
+## Context
+
+Seven cross-reference links missing between existing pages. Issue #96 specifies each pair.
+
+## Goals / Non-Goals
+
+### Goals
+- Add all 7 cross-reference links specified in the issue
+- Keep additions minimal and contextually appropriate
+
+### Non-Goals
+- Restructuring any page
+- Adding links to pages from other unmerged branches
+
+## Decisions
+
+Each link is added as a sentence or clause within existing prose, or as an item in an existing "Next Steps" list. The additions are minimal — typically one sentence each.
+
+## Risks / Trade-offs
+
+Minimal risk. The main consideration is finding natural insertion points that don't disrupt reading flow.

--- a/openspec/changes/cross-references/proposal.md
+++ b/openspec/changes/cross-references/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Navigation dead-ends exist where pages should link to each other but currently do not. Adding cross-references improves discoverability and helps visitors navigate between related concepts.
+
+GitHub Issue: #96
+
+## What Changes
+
+- Add cross-reference links between 7 existing page pairs as specified in the issue
+- All links point to pages that exist on main
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- Enhanced navigation between constitution.md, the-divisor.md, developer.md, common-workflows.md, contributing/_index.md, artifacts.md, and quick-start.md
+
+### Removed Capabilities
+- None
+
+## Impact
+
+- Small text additions to 7 existing pages
+- No new files, no style changes
+
+## Constitution Alignment
+
+Assessed against the **Unbound Force Website** constitution (.specify/memory/constitution.md).
+
+### I. Content Accuracy
+
+**Assessment**: PASS
+
+All links point to existing pages with accurate context descriptions.
+
+### II. Minimal Footprint
+
+**Assessment**: PASS
+
+Small text additions only, no custom elements.
+
+### III. Visitor Clarity
+
+**Assessment**: PASS
+
+Cross-references directly improve navigation and discoverability, fulfilling the "within two clicks from homepage" requirement.

--- a/openspec/changes/cross-references/specs/cross-references.md
+++ b/openspec/changes/cross-references/specs/cross-references.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+None (modifications only).
+
+## MODIFIED Requirements
+
+### Requirement: Cross-Reference Links
+
+Seven page pairs MUST have cross-reference links added as specified in issue #96.
+
+All links MUST point to pages that exist on the current branch.
+
+#### Scenario: All cross-references resolve
+
+- **GIVEN** the cross-reference links are added
+- **WHEN** a visitor clicks any of the new links
+- **THEN** the link resolves to an existing page
+
+#### Scenario: Build succeeds
+
+- **GIVEN** all pages are modified with cross-reference additions
+- **WHEN** `npm run build` is executed
+- **THEN** the build completes successfully
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/cross-references/tasks.md
+++ b/openspec/changes/cross-references/tasks.md
@@ -1,0 +1,14 @@
+## 1. Add Cross-References
+
+- [x] 1.1 constitution.md → developer.md (convention packs): "Convention packs raise the bar"
+- [x] 1.2 the-divisor.md → tester.md (Gaze): link in "Gaze's green light" context
+- [x] 1.3 developer.md (gatekeeping) → the-divisor.md (Guard, Adversary): link personas that enforce
+- [x] 1.4 common-workflows.md (code review) → the-divisor.md (ownership): link to ownership table
+- [x] 1.5 contributing/_index.md → developer.md (convention packs): standards contributors face
+- [x] 1.6 artifacts.md → the-divisor.md (review-verdict): link artifact type to producer
+- [x] 1.7 quick-start.md → constitution.md: mention constitution prerequisite
+
+## 2. Verification
+
+- [x] 2.1 Run `npm run build` and confirm no errors
+- [x] 2.2 Verify all new links resolve


### PR DESCRIPTION
## Summary
- Adds 7 cross-reference links between existing pages to eliminate navigation dead-ends
- constitution→convention packs, divisor→Gaze, gatekeeping→Guard/Adversary, code review→ownership, contributing→convention packs, artifacts→Divisor, quick-start→constitution
- All links verified to resolve to existing pages

Closes #96