### PR TITLE
fix: add slug frontmatter to resolve broken internal links across docs

### DIFF
--- a/content/docs/getting-started/artifacts.md
+++ b/content/docs/getting-started/artifacts.md
@@ -1,5 +1,6 @@
 ---
 title: "Hero Artifacts"
+slug: "artifacts"
 description: "The 7 inter-hero artifact types, the standard envelope format, and how artifacts flow through the hero lifecycle."
 lead: "How heroes communicate — structured artifacts with a standard envelope format that enables autonomous, auditable collaboration."
 date: 2026-03-29T00:00:00+00:00

--- a/content/docs/getting-started/developer.md
+++ b/content/docs/getting-started/developer.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started: Developer"
+slug: "developer"
 description: "Set up your environment, learn the daily workflow, and start building with the Unbound Force AI agent swarm as a developer."
 lead: "Install the tools, learn the workflows, and start shipping code with Cobalt-Crush, Speckit, and Replicator."
 date: 2026-03-22T00:00:00+00:00

--- a/content/docs/getting-started/knowledge.md
+++ b/content/docs/getting-started/knowledge.md
@@ -1,5 +1,6 @@
 ---
 title: "Knowledge Retrieval with Dewey"
+slug: "knowledge"
 description: "Set up Dewey for semantic knowledge retrieval — install, configure content sources, and give your AI agents cross-repo context."
 lead: "Give your AI agents the context they need. Install Dewey, configure your knowledge sources, and enable semantic search across your entire organization."
 date: 2026-03-25T00:00:00+00:00

--- a/content/docs/getting-started/product-manager.md
+++ b/content/docs/getting-started/product-manager.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started: Product Manager"
+slug: "product-manager"
 description: "Use Mx F for sprint management, metrics dashboards, impediment tracking, coaching, and retrospectives in the Unbound Force workflow."
 lead: "Monitor team health, facilitate retrospectives, and drive continuous improvement with Mx F."
 date: 2026-03-22T00:00:00+00:00

--- a/content/docs/getting-started/product-owner.md
+++ b/content/docs/getting-started/product-owner.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started: Product Owner"
+slug: "product-owner"
 description: "Use Muti-Mind for backlog management, priority scoring, and acceptance decisions in the Unbound Force hero workflow."
 lead: "Manage the product backlog, score priorities, sync with GitHub Issues, and make acceptance decisions."
 date: 2026-03-22T00:00:00+00:00

--- a/content/docs/getting-started/tester.md
+++ b/content/docs/getting-started/tester.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started: Tester"
+slug: "tester"
 description: "Use Gaze for quality analysis, understand contract coverage and CRAP scores, and integrate quality checks into your CI pipeline."
 lead: "Analyze code quality with Gaze, run the review council, and enforce coverage ratchets in CI."
 date: 2026-03-22T00:00:00+00:00

--- a/content/docs/team/gaze-tester.md
+++ b/content/docs/team/gaze-tester.md
@@ -1,5 +1,6 @@
 ---
 title: "Gaze"
+slug: "gaze-tester"
 description: "Gaze is the Tester of the Unbound Force swarm — a quality analysis tool for Go that measures test quality through side effect detection and contract coverage."
 lead: "The Quality Sentinel — Test Quality Analysis for Go"
 date: 2026-02-23T00:00:00+00:00


### PR DESCRIPTION
## Summary

- Adds explicit `slug:` frontmatter to 7 docs pages where Hugo's title-derived URL didn't match the filename-based paths used in internal links
- Fixes 20+ broken internal links across the site that were returning 404

Closes #126

## Root Cause

Hugo's permalink config (`/docs/:sections[1:]/:slug/`) generates URLs from page titles, not filenames. Pages with multi-word titles like `"Getting Started: Developer"` resolved to `/docs/getting-started/getting-started-developer/`, but all internal links used the filename-based path `/docs/getting-started/developer/`.

## Pages Fixed

| File | slug added | Broken URL fixed |
|------|-----------|-----------------|
| `content/docs/getting-started/developer.md` | `"developer"` | `/docs/getting-started/developer/` |
| `content/docs/getting-started/knowledge.md` | `"knowledge"` | `/docs/getting-started/knowledge/` |
| `content/docs/getting-started/artifacts.md` | `"artifacts"` | `/docs/getting-started/artifacts/` |
| `content/docs/getting-started/product-manager.md` | `"product-manager"` | `/docs/getting-started/product-manager/` |
| `content/docs/getting-started/product-owner.md` | `"product-owner"` | `/docs/getting-started/product-owner/` |
| `content/docs/getting-started/tester.md` | `"tester"` | `/docs/getting-started/tester/` |
| `content/docs/team/gaze-tester.md` | `"gaze-tester"` | `/docs/team/gaze-tester/` |

## Note

PR #73 (`opsx/cli-reference-and-positioning`) introduces `content/docs/reference/cli.md` with the same issue — it will also need `slug: "cli"` added to its frontmatter. That fix should be applied on the PR #73 branch after this lands.

## Verification

```bash
npm run build   # passes — 101 pages, no errors
npm run dev     # all 7 URLs verified returning 200
```