### PR TITLE
docs: update CLI docs for multi-package analyze and quality commands

### DIFF
--- a/content/blog/gaze-in-practice.md
+++ b/content/blog/gaze-in-practice.md
@@ -100,6 +100,8 @@ This warning means the module-level quality scan did not find test files at the 
 
 The fix is straightforward: run `/gaze quality ./internal/store` or `/gaze quality ./internal/organizer` to get per-package contract coverage breakdowns. This is not a bug — it is the tool telling you to scope your query more narrowly for detailed results.
 
+> **Update** ([gaze#159](https://github.com/unbound-force/gaze/pull/159)): `gaze quality` accepts multiple package patterns including `./...` wildcards. Running `gaze quality ./...` processes all packages in the module, skipping packages without tests (with a warning). The per-package scoping shown above is still useful for targeted analysis but is no longer required.
+
 ## 🏷️ Classification Summary
 
 The classification analysis identifies the side effects of each function and classifies them as contractual, incidental, or ambiguous.

--- a/content/docs/getting-started/tester.md
+++ b/content/docs/getting-started/tester.md
@@ -18,11 +18,14 @@ Gaze detects every observable side effect a function produces, classifies each a
 ### Core Commands
 
 ```bash
-# Detect all observable side effects in a package
-gaze analyze --classify ./pkg
+# Detect all observable side effects across the module
+gaze analyze --classify ./...
+
+# Analyze specific packages
+gaze analyze --classify ./internal/loader ./internal/crap
 
 # Assess test quality (contract coverage, over-specification)
-gaze quality ./pkg
+gaze quality ./...
 
 # Compute CRAP and GazeCRAP risk scores
 gaze crap ./...

--- a/content/docs/projects/gaze.md
+++ b/content/docs/projects/gaze.md
@@ -136,10 +136,12 @@ Both `--ai=opencode` and `--ai=claude` are fully supported AI backends for `gaze
 
 | Flag                   | Commands             | Description                                                                                                                                                    |
 | ---------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--include-unexported` | `analyze`, `quality` | Include unexported functions in the analysis. Auto-detected for `package main` — CLI tools and entry points are analyzed by default without needing this flag. |
-| `--ai-mapper`          | `quality`, `crap`    | Enable AI-assisted assertion mapping as a 5th pass (confidence 50). Uses the configured AI adapter to evaluate structurally disconnected assertions.           |
-| `--max-gaze-crapload`  | `report`             | Fail if more than N functions exceed the GazeCRAP threshold. Similar to `--max-crapload` but uses contract coverage instead of line coverage.                  |
-| `--coverprofile`       | `report`             | Pass a pre-generated `go test -coverprofile` to skip Gaze's internal test run. See the [Tester guide](/docs/getting-started/tester/) for the CI pattern.       |
+| `--include-unexported` | `analyze`, `quality` | Include unexported functions in the analysis. Auto-detected per-package for `package main` (see note below). |
+| `--ai-mapper`          | `quality`, `crap`    | Enable AI-assisted assertion mapping as a 5th pass (confidence 50). Uses the configured AI adapter to evaluate structurally disconnected assertions. |
+| `--max-gaze-crapload`  | `report`             | Fail if more than N functions exceed the GazeCRAP threshold. Similar to `--max-crapload` but uses contract coverage instead of line coverage. |
+| `--coverprofile`       | `report`             | Pass a pre-generated `go test -coverprofile` to skip Gaze's internal test run. See the [Tester guide](/docs/getting-started/tester/) for the CI pattern. |
+
+**`--include-unexported` auto-detection**: When analyzing multiple packages, each package is checked individually for `package main`. CLI entry points are included automatically without needing this flag.
 
 ### The `/gaze fix` Command
 
@@ -229,7 +231,7 @@ Gaze is actively developed. The current scope has known boundaries:
 - **P3-P4 side effects not yet detected.** P0 through P2 are fully implemented — covering return values, error returns, mutations, I/O, channel operations, file system operations, database writes, goroutine spawns, panics, and context cancellation. P3-P4 side effects (stdout/stderr, environment mutations, mutex operations, reflection, unsafe) are not yet detected.
 - **Assertion mapping accuracy is ~84.7%** (83/98 mapped assertions, ratchet floor 84.0%). The target is 90%. Accuracy is primarily limited by helper function assertions and testify field-access patterns (tracked as [GitHub Issue #6](https://github.com/unbound-force/gaze/issues/6)).
 - **No CGo or unsafe analysis.** Functions using `cgo` or `unsafe.Pointer` are not analyzed for their specific side effects.
-- **Single package loading.** The `analyze` and `quality` commands process one package at a time. The `crap` and `report` commands process the entire module (`./...`).
+- **No transitive multi-module analysis.** All four commands (`analyze`, `quality`, `crap`, `report`) accept multiple package patterns including `./...` wildcards, but analysis is scoped to the current module. Cross-module dependency analysis is out of scope for v1.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
Updates website documentation to reflect multi-package support added to gaze analyze and gaze quality in unbound-force/gaze#159 (https://github.com/unbound-force/gaze/pull/159) (closes unbound-force/gaze#107 (https://github.com/unbound-force/gaze/issues/107)).
Both commands now accept multiple package patterns including ./... wildcards. The website previously documented a "Single package loading" limitation and showed single-package examples that understated the tool's capabilities.

## Changes
content/docs/projects/gaze.md — Gaze project page
- Current Limitations: replaced "Single package loading" bullet with "No transitive multi-module analysis" — accurately reflects that all four commands accept multi-package patterns while noting the remaining actual limitation (single-module scope)
- CLI Flags table: updated --include-unexported description to note per-package auto-detection when analyzing multiple packages
content/docs/getting-started/tester.md — Tester getting started guide
- Core Commands: updated examples from single-package (./pkg) to module-wide (./...) and added a multi-package example (gaze analyze --classify ./internal/loader ./internal/crap)
content/blog/gaze-in-practice.md — Blog walkthrough
- Quality Summary: added editorial update note after the per-package workaround advice, informing readers that gaze quality ./... now works across all packages while preserving the historical walkthrough context
## Not changed (intentionally)
- content/blog/why-contract-coverage.md — examples use single-package paths with threshold flags, which remain valid
- content/docs/getting-started/common-workflows.md — already uses ./... patterns
 ## Verification
- hugo --minify --gc --baseURL "https://unboundforce.dev/" builds successfully (140 pages, 0 errors)
- All warnings are pre-existing (description length on tags/categories)
 ## Reference
- Upstream PR: unbound-force/gaze#159 (https://github.com/unbound-force/gaze/pull/159)
- Upstream issue: unbound-force/gaze#107 (https://github.com/unbound-force/gaze/issues/107)

Closes #163

Signed-off-by: Yvonne Devlin <ydevlin@redhat.com>
Assisted-by: OpenCode (claude-opus-4-6)