### PR TITLE
chore: propagate skill name frontmatter fix via uf init + replicator init

### DIFF
--- a/.opencode/commands/address-feedback.md
+++ b/.opencode/commands/address-feedback.md
@@ -140,7 +140,7 @@ Load context for evidence-based classification (D10, FR-010):
    - Speckit: `specs/NNN-*/` matching branch pattern
    - OpenSpec: `openspec/changes/*/` matching branch
 5. Linked issues from PR description (`Fixes #N`, `Closes #N`, `Resolves #N`) — load acceptance criteria
-6. If `review-context` convention pack exists, use it for standardized discovery. Otherwise inline the discovery logic above.
+6. Invoke the `skill` tool with name `review-context` to load standardized context discovery (spec artifacts, linked issues, path classification).
 
 ### 2.2 Tiered Assessment
 

--- a/.opencode/commands/review-council.md
+++ b/.opencode/commands/review-council.md
@@ -123,13 +123,13 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 ### Instructions
 
 1. **Run local quality gates before delegating to
-   council agents.** This step has two phases that
-   MUST execute in order. Both phases apply only to
-   Code Review Mode -- Spec Review Mode skips them.
+   council agents.** This step has three phases that
+   MUST execute in order. All three phases apply only
+   to Code Review Mode -- Spec Review Mode skips them.
 
-   #### Phase 1a -- Pre-flight Checks (mandatory, hard gate)
+   #### Phase 1a -- Pre-flight Checks (mandatory, soft gate)
 
-   Load the `pre-flight` skill and run in `hard-gate`
+   Load the `pre-flight` skill and run in `soft-gate`
    mode:
 
    a. Invoke the `skill` tool with name `pre-flight` to
@@ -141,20 +141,32 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
       2. Local Tool Detection — check for config files
          and verify binary availability
       3. CI Coverage Matrix — display the matrix (in
-         hard-gate mode, all tools are marked "Run
+         soft-gate mode, all tools are marked "Run
          locally = Yes")
       4. Execution — run all detected and available
-         tools in hard-gate mode
+         tools in soft-gate mode (do NOT stop on first
+         failure; record all results)
+      5. Baseline Establishment (Phase 4a) — if any
+         tools failed, establish a baseline for `main`
+         using the two-tier strategy (CI API first,
+         worktree fallback)
+      6. Causality Classification (Phase 4b) — classify
+         each failure as branch-caused, pre-existing,
+         or unknown
 
-   c. **If the pre-flight verdict is FAIL**: **STOP
-      immediately.** Report each failure as a CRITICAL
-      finding with the full error output. Do NOT
-      proceed to Phase 1b or to step 2 (Divisor agent
-      delegation). The rationale: reviewing code that
-      doesn't compile or pass tests is wasted work.
+   c. **If the pre-flight verdict is FAIL
+      (branch-caused)**: **STOP immediately.** Report
+      each branch-caused failure as a CRITICAL finding
+      with the full error output. Do NOT proceed to
+      Phase 1b or to step 2 (Divisor agent delegation).
+      The rationale: reviewing code that doesn't compile
+      or pass tests is wasted work.
 
-   d. **If the pre-flight verdict is PASS**: report
-      success and proceed to Phase 1b.
+   d. **If the pre-flight verdict is PASS** (including
+      when pre-existing failures exist): report success.
+      If pre-existing failures were detected, record
+      them for inclusion in the final report (Step 6).
+      Proceed to Phase 1b.
 
    #### Phase 1b -- Gaze Quality Analysis (conditional)
 
@@ -181,6 +193,44 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
       Proceed to step 2 without Gaze data.
 
+   #### Phase 1c -- Discover Review Context (mandatory)
+
+   Load the `review-context` skill for spec artifact
+   discovery, path classification, and walkthrough
+   generation:
+
+   a. Invoke the `skill` tool with name `review-context`
+      to load the shared context discovery instructions.
+
+   b. Execute the skill's protocols in order:
+      1. Protocol 1 (Spec Artifact Discovery) — locate
+         the specification matching the current branch
+         using the branch name from auto-detection and
+         the changed file list.
+      2. Protocol 2 (Issue Linking) — **skip**. This
+         protocol requires a PR body;
+         `/review-council` is a local pre-PR command
+         with no PR body to parse.
+      3. Protocol 3 (Path-Based Focus Heuristics) —
+         classify each changed file from the
+         auto-detection step for review emphasis.
+      4. Protocol 4 (Walkthrough Generation) — generate
+         per-file change summaries from the branch
+         diff (`git diff main...HEAD`).
+
+   c. **Record results**: Use the skill's Review Context
+      output format (Specification, File Classification,
+      Walkthrough). This context is used in step 2
+      (Divisor agent delegation) and step 6 (final
+      report).
+
+   d. **If the skill fails to load**: **STOP
+      immediately.** Report the error as a CRITICAL
+      finding. Do NOT proceed to step 2. The
+      `review-context` skill is a hard dependency,
+      consistent with the `pre-flight` skill
+      consumption pattern — no inline fallback.
+
 2. Delegate the review to all **discovered** reviewer agents in parallel using the Task tool. For each discovered agent, use the focus area from the Known Reviewer Roles reference table to provide targeted context. For any discovered agent not in the table, use a generic prompt: "Review the current changes for quality, correctness, and compliance. Return your verdict (APPROVE or REQUEST CHANGES) along with all findings."
 
    **CRITICAL — Review Scope Rule**: The review scope is
@@ -195,19 +245,30 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
    produces incomplete reviews that miss findings in
    earlier commits on the branch.
 
-   **When Gaze data is available** (from Phase 1b):
-   append a "Quality Context" section to each Divisor
-   agent's review prompt containing the Gaze Report
-   summary. This gives agents -- particularly
-   `divisor-testing` -- access to concrete CRAP
-   scores, coverage percentages, quadrant
-   distributions, and prioritized recommendations.
-   Instruct agents to reference this data in their
-   findings where relevant.
+   **Review context enrichment**: Append the following
+   context sections to each Divisor agent's review
+   prompt:
 
-   **When Gaze data is NOT available**: use the
-   standard prompt without a "Quality Context"
-   section. Agents review based on file reading only.
+   - **Review Context** (from Phase 1c): Include the
+     spec artifact summary, file classifications, and
+     walkthrough from the `review-context` skill output.
+     This gives agents spec alignment context and
+     per-file focus heuristics. Instruct agents to
+     reference spec requirements and file
+     classifications in their findings where relevant.
+
+   - **Quality Context** (from Phase 1b, when Gaze data
+     is available): Include the Gaze Report summary.
+     This gives agents -- particularly
+     `divisor-testing` -- access to concrete CRAP
+     scores, coverage percentages, quadrant
+     distributions, and prioritized recommendations.
+     Instruct agents to reference this data in their
+     findings where relevant.
+
+   **When Gaze data is NOT available**: include only
+   the Review Context section. Agents review based on
+   file reading plus spec/classification context.
 
    For each agent, instruct it to review the full branch diff (all changed files vs `main`) and return its verdict (**APPROVE** or **REQUEST CHANGES**) along with all findings.
 
@@ -239,6 +300,30 @@ Review the current codebase for compliance with the Behavioral Constraints in `A
 
 6. Provide a final report to the user:
    - **Discovery summary**: how many reviewer agents were discovered, which were invoked, and which known reviewer roles were absent (informational, non-blocking)
+   - **Pre-existing CI Failures** (if any were detected
+     in Phase 1a): include an informational section
+     between the discovery summary and the review
+     context summary:
+
+     ```
+     ### Pre-existing CI Failures (informational)
+
+     The following failures exist on `main` and are
+     unrelated to the current branch:
+
+     | Tool | Exit code | Baseline method |
+     |------|-----------|-----------------|
+     | ...  | ...       | ...             |
+
+     These do not block the review verdict.
+     ```
+
+     Omit this section when no pre-existing failures
+     were detected in Phase 1a.
+   - **Review context summary**: specification found
+     (type, path) or "no spec found", and the
+     walkthrough table from Phase 1c (review-context
+     skill, Protocol 4)
    - What was found in each iteration
    - What was fixed
    - If stopped early, the current set of outstanding **REQUEST CHANGES**

--- a/.opencode/commands/review-pr.md
+++ b/.opencode/commands/review-pr.md
@@ -251,71 +251,36 @@ targeting the PR's head ref (`git show`, `git fetch`,
 `git checkout`, `git diff` with remote refs) is
 prohibited.
 
-### 6. Locate Associated Specification
+### 6. Discover Review Context
 
-Search for a specification that matches this PR across all spec directories:
+Load the `review-context` skill for spec artifact
+discovery, issue linking, path classification, and
+walkthrough generation:
 
-- Check if the PR branch name matches a spec directory:
-  - `specs/<branch-name>/spec.md` (Speckit output)
-  - `openspec/specs/<branch-name>/spec.md` (OpenSpec specs)
-  - `openspec/changes/<branch-name>/proposal.md` (OpenSpec changes)
-- Check if the PR description references a spec
-- If not found locally, check the PR's changed file
-  list (from Step 2 metadata) for spec artifacts. The
-  spec may be introduced by the PR itself. If found
-  in the changed file list, read the spec content from
-  the saved diff (Step 5) rather than from the
-  filesystem.
-- If a Speckit spec is found, read only the **Functional Requirements** and **User Stories** sections (not the entire spec) to minimize token usage
-- If an OpenSpec proposal is found, read only the **Capabilities** and **Impact** sections
-- If no spec is found in any directory or in the PR's changed files, note this and use the PR title and description as the intent source
+1. Invoke the `skill` tool with name `review-context`
+   to load the shared context discovery instructions.
 
-#### 6a. Resolve Linked Issues
+2. Execute the skill's protocols in order:
+   a. Protocol 1 (Spec Artifact Discovery) — locate
+      the specification matching this PR using branch
+      name from Step 2 metadata, PR description, and
+      changed file list. If a spec is found in the
+      changed file list, read from the saved diff
+      (Step 5) rather than the filesystem.
+   b. Protocol 2 (Issue Linking) — parse the PR body
+      from Step 2 metadata for linked issues, validate,
+      fetch, sanitize, and extract acceptance criteria.
+   c. Protocol 3 (Path-Based Focus Heuristics) —
+      classify each changed file from the Step 2
+      metadata for review emphasis.
+   d. Protocol 4 (Walkthrough Generation) — generate
+      per-file change summaries while analyzing the
+      diff from Step 5.
 
-Parse the PR body (from Step 2 metadata) for issue
-references using case-insensitive regex:
-- `Fixes #N`, `Closes #N`, `Resolves #N`
-- GitHub URL variants:
-  `Fixes https://github.com/<owner>/<repo>/issues/N`
-
-**Validation and limits**:
-- Validate each parsed issue number as a positive
-  integer (digits only). Discard non-numeric values.
-- URL-format references: validate they belong to the
-  same `{owner}/{repo}` as the PR. List cross-repo
-  references in the output as "cross-repo — not
-  validated" but do NOT fetch them.
-- Limit to 5 linked issues maximum. If more than 5
-  are found, list extras as "listed but not fetched"
-  in the output.
-
-**Fetching**: For each in-scope linked issue:
-
-```bash
-gh issue view <N> --json title,body,labels
-```
-
-**Untrusted input handling**: Issue body content is
-user-controlled. Before incorporating into the review
-context:
-- Truncate to a maximum of 2000 characters.
-
-**Error handling**: If `gh issue view` returns 404,
-403, or times out, log the error, skip that issue, and
-note in the `### Linked Issues` section as "fetch
-failed". The review continues without blocking.
-
-**Acceptance criteria extraction**: From each fetched
-issue body, extract:
-- Checkbox lines (`- [ ]` or `- [x]`)
-- Content under an `## Acceptance Criteria` heading
-
-If neither exists, use the issue title and body as
-general intent context for the alignment check
-(Step 8a).
-
-Record the linked issues and their acceptance criteria
-for use in Step 8a and Step 9.
+3. **Record results**: Use the skill's Review Context
+   output format (Specification, Linked Issues, File
+   Classification, Walkthrough). This context is used
+   in Step 8 (AI review) and Step 9 (output).
 
 ### 7. Load Convention Packs (Optional)
 
@@ -420,38 +385,13 @@ analysis. For each finding:
   have additional context or a different severity
   assessment. Annotate, don't hide.
 
-**Path-based review focus**: Before starting the review,
-classify each changed file against these built-in
-heuristics. Record the focus category for each file
-(used in the Walkthrough output and as additive review
-context):
-
-| Path pattern | Focus category | Additional emphasis |
-|-------------|---------------|-------------------|
-| `*_test.go`, `*_test.py`, `**/__tests__/**`, `**/*_spec.*` | `test-quality` | Edge cases, assertion strength, mock isolation, test naming |
-| `**/cmd/**`, `**/cli/**` | `cli-ux` | Error messages, flag validation, help text |
-| `**/api/**`, `**/handler/**`, `**/middleware/**`, `**/routes/**` | `security` | Auth, input validation, injection |
-| `*.md`, `docs/**` | `documentation` | Clarity, accuracy, broken links |
-| `.github/workflows/**`, `Dockerfile*` | `ci-cd` | Permissions, pinned versions, secrets exposure |
-| `go.mod`, `package.json`, `requirements.txt` | `dependencies` | Maintenance status, license, scope |
-| Everything else | `standard` | Architecture, SOLID, coupling, baseline security |
-
-Path focus is **additive** — it supplements the standard
-review categories (alignment, security, constitution),
-not replaces them. Step 8b (Security Review) applies to
-ALL changed files regardless of path heuristic.
-
-When reviewing each file, append the matched focus
-instruction to the review context for that file.
-
-**Walkthrough generation**: While analyzing each file's
-diff, generate a one-line change summary describing
-what changed (e.g., "Add error handling for null
-inputs"), not how (no code snippets). Record the
-summary and focus category for each file — these are
-used in the `### Walkthrough` output section (Step 9).
-For PRs with 30+ files, generate directory-level
-summaries instead of per-file summaries.
+**Path-based review focus and walkthrough**: Use the
+file classifications and walkthrough summaries from
+Step 6 (review-context skill, Protocols 3 and 4).
+When reviewing each file, apply the matched focus
+instruction as additive review context. Step 8b
+(Security Review) applies to ALL changed files
+regardless of path heuristic.
 
 #### 8a. Alignment Check
 
@@ -461,7 +401,7 @@ Compare the PR intent (title + description + linked spec + linked issues) agains
 - **Requirement coverage**: For each requirement in the spec (if found), verify the code changes address it. Flag uncovered requirements.
 - **Completeness**: Are there partial implementations that could leave the system in an inconsistent state?
 - **Drift detection**: Does the code do anything NOT described in the intent/spec? Flag undocumented behavioral changes.
-- **Issue criteria coverage**: For each acceptance criterion from linked issues (Step 6a), verify the code changes address it. Report uncovered criteria as MEDIUM findings with per-criterion status (COVERED / NOT COVERED / PARTIAL).
+- **Issue criteria coverage**: For each acceptance criterion from linked issues (Step 6, Protocol 2), verify the code changes address it. Report uncovered criteria as MEDIUM findings with per-criterion status (COVERED / NOT COVERED / PARTIAL).
 - **Issue suggestion gap detection**: After checking
   acceptance criteria, scan each linked issue body for
   explicit code suggestions — fenced code blocks
@@ -641,7 +581,7 @@ Present findings in this structured format:
 | `internal/gateway/` | 3 | Token refresh and provider detection | security |
 
 ### Linked Issues
-<Only include this section if Step 6a found linked issues>
+<Only include this section if Step 6 found linked issues>
 | Issue | Title | Criteria |
 |-------|-------|----------|
 | #38 | Export metrics to CSV | 3/4 COVERED |

--- a/.opencode/commands/uf-init.md
+++ b/.opencode/commands/uf-init.md
@@ -101,19 +101,27 @@ completes to review all changes before committing.
 ### Step 2: Apply Branch Enforcement
 
 For each target file listed below, apply the branch enforcement
-customization. For each file:
+customization. Each enforcement category has **independent**
+idempotency checks -- presence of one variant MUST NOT cause
+other variants to be skipped. For each file:
 
 1. **Read** the file content
-2. **Check** if branch enforcement is already present. Look for
-   the concept semantically -- does the file already describe
-   creating, validating, or cleaning up an `opsx/<name>` branch?
-   Check for phrases like `git checkout -b opsx/`, `opsx/<name>`,
-   `opsx/<change-name>`, or equivalent branch management
-   instructions.
-3. **If already present**: Report `⊘ <filename>: already present (skipped)`
-4. **If not present**: Read the file structure, find the correct
-   insertion point, and insert the customization. Report
-   `✅ <filename>: inserted`
+2. **Check** each applicable variant independently:
+   - **Basic branch check**: Look for `opsx/<name>`,
+     `opsx/<change-name>`, or `git checkout -b opsx/`
+   - **Dirty tree check** (propose only): Look for
+     `git status --short` in a pre-branch-creation
+     context
+   - **Commit-before-archive** (archive-change only):
+     Look for `git add` and `git commit` appearing
+     before the archive move step
+   - **Branch-switch confirmation** (explore only): Look
+     for `uncommitted changes` or `switch branches` in
+     the guardrails section
+3. **For each variant**: If present, report
+   `⊘ <filename>: [variant] already present (skipped)`.
+   If not present, insert it and report
+   `✅ <filename>: [variant] inserted`
 
 #### Branch Enforcement: Propose (Skills + Commands)
 
@@ -121,8 +129,13 @@ customization. For each file:
 - `.opencode/skills/openspec-propose/SKILL.md`
 - `.opencode/commands/opsx-propose.md`
 
-**What to insert**: After the step that creates the change
-directory (`openspec new change "<name>"`), insert a new step:
+**Two independent checks**:
+
+**A. Basic branch check** -- idempotency marker:
+`opsx/<name>` or `git checkout -b opsx/`
+
+If not present, insert after the step that creates the
+change directory (`openspec new change "<name>"`):
 
 > **Create and checkout a branch**
 >
@@ -138,6 +151,32 @@ directory (`openspec new change "<name>"`), insert a new step:
 **Where**: After the change directory creation step, before the
 artifact creation steps. Insert as a new numbered step; do NOT
 renumber existing steps (to avoid accidental content loss).
+
+**B. Dirty tree check** -- idempotency marker:
+`git status --short` in a pre-branch-creation context
+
+If not present, insert before the branch creation guard
+(part A above), or immediately before the existing branch
+check if part A is already present:
+
+> **Check for uncommitted changes**
+>
+> Before creating or switching branches, run
+> `git status --short`. If there are uncommitted changes
+> (staged, unstaged, or untracked files that appear
+> related to work):
+> - **STOP** and ask the user for confirmation before
+>   switching branches. Show what uncommitted changes
+>   exist and warn that switching branches with a dirty
+>   working tree may cause changes to be applied to the
+>   wrong branch.
+> - If the user confirms, proceed. If not, abort.
+> - Exception: if the user explicitly requested a new
+>   change, this still requires confirmation -- never
+>   silently switch branches with uncommitted work.
+
+**Where**: Before the branch creation guard. Insert as a
+sub-step or preceding step.
 
 #### Branch Enforcement: Apply (Skills + Commands)
 
@@ -167,8 +206,12 @@ existing steps.
 - `.opencode/skills/openspec-archive-change/SKILL.md`
 - `.opencode/commands/opsx-archive.md`
 
-**What to insert**: After the archive move completes, insert a
-branch cleanup step:
+**Two independent checks**:
+
+**A. Return to main branch** -- idempotency marker:
+`git checkout main` after the archive move
+
+If not present, insert after the archive move completes:
 
 > **Return to main branch**
 >
@@ -185,10 +228,66 @@ branch cleanup step:
 the archive, before the display summary step. Insert as a new
 numbered step; do NOT renumber existing steps.
 
-**Note**: `openspec-explore` and `opsx-explore.md` are
-intentionally excluded from branch enforcement -- explore mode
-does not create or modify changes, so branch management does
-not apply.
+**B. Commit-before-archive** -- idempotency markers:
+`git add` and `git commit` appearing before the archive
+move step
+
+If not present, insert before the archive move step
+(the step that moves the change directory to the archive):
+
+> **Commit and push all changes**
+>
+> Before archiving, ensure all work is committed:
+>
+> 1. Run `git status --short` to check for uncommitted
+>    changes.
+> 2. If uncommitted changes exist:
+>    - Stage the change directory and implementation
+>      files explicitly:
+>      `git add openspec/changes/<name>/ .opencode/`
+>      and any other modified files shown by
+>      `git status --short`
+>    - Commit with a descriptive message:
+>      `git commit -m "feat(<name>): complete implementation"`
+>    - Push to remote: `git push`
+> 3. Verify the working tree is clean after push.
+>
+> **CRITICAL**: Do NOT move to the archive step with
+> uncommitted changes. All work must be committed and
+> pushed before the change directory is moved to the
+> archive.
+
+**Where**: Before the step that moves the change directory
+to the archive. Insert as a new numbered step; do NOT
+renumber existing steps.
+
+#### Branch Enforcement: Explore (Guardrail Only)
+
+**Target file**:
+- `.opencode/skills/openspec-explore/SKILL.md`
+
+**Note**: Explore mode does not create or modify changes, so
+full branch management does not apply. However, explore may
+lead to creating a proposal, which requires a branch switch.
+
+**Single check** -- idempotency marker: `uncommitted changes`
+or `switch branches` in the guardrails section
+
+If not present, append this bullet to the explore SKILL.md
+guardrails section:
+
+> - Don't switch branches without confirmation -- If
+>   exploration leads to creating a proposal (which
+>   requires a new `opsx/` branch), check for uncommitted
+>   changes first and ask the user before switching.
+>   Never silently leave uncommitted work behind.
+
+**Where**: Append to the existing guardrails bullet list
+at the end of the file.
+
+Report: `✅ openspec-explore/SKILL.md: branch-switch
+confirmation inserted` or `⊘ openspec-explore/SKILL.md:
+branch-switch confirmation already present (skipped)`
 
 ### Step 3: Apply Dewey Context
 
@@ -447,18 +546,66 @@ step: run `.specify/scripts/bash/check-prerequisites.sh
 ### Step 6: Speckit Command Guardrails
 
 Inject a `## Guardrails` section into ALL 9
-`.opencode/commands/speckit.*.md` files. For each file:
+`.opencode/commands/speckit.*.md` files. Use two
+variants depending on the command type.
+
+**Spec-phase commands** (get Guardrails WITH
+review-rationale sentence):
+- `speckit.specify.md`
+- `speckit.clarify.md`
+- `speckit.plan.md`
+- `speckit.tasks.md`
+- `speckit.analyze.md`
+- `speckit.checklist.md`
+
+**Execution/utility commands** (get Guardrails WITHOUT
+review-rationale sentence):
+- `speckit.implement.md`
+- `speckit.constitution.md`
+- `speckit.taskstoissues.md`
+
+For each file:
 
 1. **Read** the file content
 2. **Check** if a `## Guardrails` section already exists
    (search for the heading text `## Guardrails`)
-3. **If already present**: Report
-   `⊘ <filename>: guardrails already present (skipped)`
-4. **If not present**: Append the following block at the
-   very end of the file. Report
+3. **If NOT present**: Append the appropriate guardrails
+   variant at the very end of the file. Report
    `✅ <filename>: guardrails injected`
+4. **If already present**: Perform a secondary check
+   for spec-phase commands only -- search for the phrase
+   "review defeats the purpose". If the Guardrails
+   heading exists but the review-rationale sentence is
+   missing, append the sentence to the existing
+   Guardrails section. Report
+   `✅ <filename>: review-rationale added`.
+   If the sentence is already present, report
+   `⊘ <filename>: guardrails already present (skipped)`
 
-The guardrails block to append:
+**Spec-phase guardrails block** (with review-rationale):
+
+```markdown
+
+## Guardrails
+
+- **NEVER modify source code** — this command updates
+  spec artifacts ONLY. Implementation changes belong in
+  `/speckit.implement`, `/unleash`, or `/cobalt-crush`.
+- **NEVER modify test files, Go source, Markdown agents,
+  convention packs, or config files** outside the
+  `specs/NNN-*/` feature directory.
+- The ONLY files this command may write are:
+  - `FEATURE_SPEC` (the spec.md file)
+  - Files within `FEATURE_DIR` (spec artifacts:
+    plan.md, tasks.md, research.md, data-model.md,
+    quickstart.md, contracts/, checklists/)
+- The user needs to review the plan before
+  implementation begins. Implementing without review
+  defeats the purpose of the spec-first workflow.
+```
+
+**Execution/utility guardrails block** (no
+review-rationale):
 
 ```markdown
 
@@ -476,17 +623,6 @@ The guardrails block to append:
     plan.md, tasks.md, research.md, data-model.md,
     quickstart.md, contracts/, checklists/)
 ```
-
-The 9 target files are:
-- `speckit.specify.md`
-- `speckit.clarify.md`
-- `speckit.plan.md`
-- `speckit.tasks.md`
-- `speckit.analyze.md`
-- `speckit.checklist.md`
-- `speckit.implement.md`
-- `speckit.constitution.md`
-- `speckit.taskstoissues.md`
 
 **Note**: `speckit.implement.md` is an exception — it IS
 allowed to modify source code. However, the guardrails
@@ -595,6 +731,18 @@ After processing all customizations, display a summary:
   [status] [filename]: [action]
   ...
 
+### STOP HERE Blocks
+  [status] [filename]: [action]
+  ...
+
+### Scaffold Comment Deduplication
+  [status] [filename]: [action]
+  ...
+
+### Legacy Directory Cleanup
+  [status] [item]: [action]
+  ...
+
 ### Summary
 Applied: N | Already present: N | Errors: N
 ```
@@ -603,6 +751,121 @@ Use these status indicators:
 - `✅` -- customization was inserted
 - `⊘` -- customization already present (skipped)
 - `❌` -- file not found or error (with fix suggestion)
+
+### Step 10: STOP HERE Blocks
+
+Inject a STOP HERE block into each spec-phase speckit
+command file. The block prevents premature advancement
+to implementation by instructing the LLM to stop and
+prompt the user.
+
+**Target files** (spec-phase commands only):
+- `speckit.specify.md`
+- `speckit.plan.md`
+- `speckit.tasks.md`
+- `speckit.analyze.md`
+- `speckit.checklist.md`
+- `speckit.clarify.md`
+
+**Excluded** (execution/utility commands -- no STOP HERE):
+- `speckit.implement.md`
+- `speckit.constitution.md`
+- `speckit.taskstoissues.md`
+
+For each target file:
+
+1. **Read** the file content
+2. **Check** if "STOP HERE" (case-sensitive) is already
+   present in the file
+3. **If already present**: Report
+   `⊘ <filename>: STOP HERE already present (skipped)`
+4. **If not present**: Insert the STOP HERE block. Report
+   `✅ <filename>: STOP HERE inserted`
+
+**What to insert**:
+
+```markdown
+
+**STOP HERE. Do NOT proceed to implementation.**
+
+Your job is done. Report the results and prompt the
+user. The user will invoke a separate command
+(`/speckit.implement`, `/unleash`, or `/cobalt-crush`)
+when they are ready to implement.
+```
+
+**Where**: After the main workflow instructions, before
+the `## Guardrails` section. If no `## Guardrails`
+section exists, insert at the end of the file.
+
+### Step 11: Scaffold Comment Deduplication
+
+Deduplicate scaffold comments in all files processed by
+`/uf-init`. Repeated runs of `uf init` across versions
+can accumulate multiple `<!-- scaffolded by uf ... -->`
+comments in the same file.
+
+**Target scope**: All files processed by `/uf-init`:
+- The 4 OpenSpec skill files (Step 2-4 targets)
+- The 3 OpenSpec command files (Step 2-3 targets)
+- The 9 speckit command files (Step 5-6 targets)
+
+For each file:
+
+1. **Read** the file content
+2. **Count** lines matching the pattern
+   `<!-- scaffolded by uf` (any version string after "uf")
+3. **If 0 or 1 matches**: No action needed. Report
+   `⊘ <filename>: scaffold comments clean`
+4. **If 2+ matches**: Keep only the LAST occurrence,
+   remove all earlier occurrences. Report
+   `✅ <filename>: deduplicated scaffold comments
+   (N removed)`
+
+**Important**: This step runs AFTER all other insertion
+steps to catch any duplicates introduced by earlier steps.
+
+### Step 12: Legacy Directory Cleanup
+
+Clean up legacy directory artifacts from older versions
+of `uf init`.
+
+Set `LEGACY_PACKS = .opencode/` + `unbound/packs/`
+(the pre-Spec-025 convention pack location).
+
+#### Sub-task A: Legacy Packs Removal
+
+1. Check if `LEGACY_PACKS` exists
+2. **If it does NOT exist**: Report
+   `⊘ legacy packs: not present`
+3. **If it exists**: Verify pre-conditions:
+   - `.opencode/uf/packs/default.md` MUST exist
+   - `.opencode/uf/packs/severity.md` MUST exist
+4. **If pre-conditions met**: Remove `LEGACY_PACKS`
+   recursively (NOT its parent directory). Then check
+   if the parent directory is empty -- if so, remove it
+   too. If the parent still contains other files or
+   directories, leave it and report a warning:
+   `⚠️ legacy parent dir: packs/ removed but directory
+   contains other content -- leaving in place`.
+   Report `✅ legacy packs: removed (migrated to
+   uf/packs/)`
+5. **If pre-conditions NOT met**: Report
+   `❌ legacy packs: uf/packs/ missing core files,
+   skipped`
+
+#### Sub-task B: `command/` Migration Hardening
+
+After Step 0 runs (command directory migration), verify
+the migration was effective:
+
+1. Check if any `speckit.*.md` files remain in
+   `.opencode/command/` (singular)
+2. **If found**: Report
+   `⚠️ command/: speckit commands still in singular
+   directory after migration -- check Step 0 output`
+3. **If not found**: Report
+   `⊘ command/: migration verified (or not needed)`
 
 ### Post-Write Verification
 

--- a/.opencode/skills/always-on-guidance/SKILL.md
+++ b/.opencode/skills/always-on-guidance/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: always-on-guidance
 description: Global coding rules and tool usage discipline
 tags: [always-on, coding, quality]
 ---

--- a/.opencode/skills/forge-coordination/SKILL.md
+++ b/.opencode/skills/forge-coordination/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: forge-coordination
 description: Multi-agent coordination patterns for forge sessions
 tags: [forge, coordination, multi-agent]
 ---

--- a/.opencode/skills/forge-global/SKILL.md
+++ b/.opencode/skills/forge-global/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: forge-global
 description: Cross-project forge coordination patterns
 tags: [forge, global, coordination]
 ---

--- a/.opencode/skills/learning-systems/SKILL.md
+++ b/.opencode/skills/learning-systems/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: learning-systems
 description: How the forge learns from outcomes
 tags: [learning, forge, insights]
 ---

--- a/.opencode/skills/pre-flight/SKILL.md
+++ b/.opencode/skills/pre-flight/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate and ci-aware execution policies."
+name: pre-flight
+description: "Shared pre-flight skill for CI detection and local tool execution. Supports hard-gate, ci-aware, and soft-gate execution policies."
 ---
 <!-- scaffolded by uf vdev -->
 # Skill: Pre-flight Checks
@@ -13,8 +14,9 @@ an execution policy.
 
 | Mode | Behavior | Typical consumer |
 |------|----------|-----------------|
-| `hard-gate` | Run all detected tools. Stop on first failure. | `/review-council`, `/unleash` |
+| `hard-gate` | Run all detected tools. Stop on first failure. | `/unleash` (phase checkpoints) |
 | `ci-aware` | Build CI coverage matrix against PR check results. Skip tools CI already verified. Run the rest. | `/review-pr` |
+| `soft-gate` | Run all detected tools. Classify failures as branch-caused vs pre-existing. Gate only on branch-caused failures. | `/review-council` |
 
 The consuming command specifies which mode to use.
 
@@ -191,11 +193,174 @@ Record all exit codes and output.
 If no tools are marked "Yes" (all covered by CI): report
 "All tools covered by CI — no local execution needed."
 
+### soft-gate mode
+
+Execute ALL detected and available tools (same as
+hard-gate). Do NOT stop on first failure — record all
+exit codes and output for every tool.
+
+- If ALL tools pass: verdict is PASS. No baseline
+  establishment is needed. Skip Phase 4a and 4b.
+- If ANY tools fail: proceed to Phase 4a (Baseline
+  Establishment) to classify each failure.
+
+---
+
+## Phase 4a: Baseline Establishment (soft-gate only)
+
+This phase runs only in `soft-gate` mode, and only when
+at least one tool failed during Phase 4 execution.
+
+Establish a baseline for the default branch to determine
+which failures are branch-caused vs pre-existing. Use a
+two-tier strategy: CI API first, local worktree fallback.
+
+### Detect the default branch
+
+Before establishing a baseline, detect the repository's
+default branch. Do NOT hardcode `main` — repositories
+may use `master` or another default branch name.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref \
+  refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's|refs/remotes/origin/||')
+```
+
+If that fails (remote HEAD not set, which happens after
+a fresh clone without
+`git remote set-head origin --auto`), fall back to
+checking for common names:
+
+```bash
+if [ -z "${DEFAULT_BRANCH}" ]; then
+  if git rev-parse --verify origin/main \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git rev-parse --verify origin/master \
+    >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+```
+
+If neither resolves, treat the baseline as unavailable
+and fall through to the conservative fallback (all
+failures classified as `unknown` = branch-caused).
+
+### Tier 1 — CI API baseline
+
+Check if the `gh` CLI is available:
+
+```bash
+which gh
+```
+
+If `gh` is available, query the latest check-run results
+for the default branch:
+
+```bash
+gh api \
+  repos/{owner}/{repo}/commits/${DEFAULT_BRANCH}/check-runs \
+  --jq '.check_runs[] | {name, conclusion}'
+```
+
+Use `--arg` for any dynamic values to prevent injection
+(consistent with `/review-pr` Step 3a).
+
+Map CI check names to local tool names using the same
+coverage matrix logic from Phase 3. For each failing
+tool from Phase 4, look up the corresponding CI check
+conclusion on `${DEFAULT_BRANCH}`:
+
+- `conclusion: "success"` → baseline PASS
+- `conclusion: "failure"` → baseline FAIL
+- No matching check → baseline NO DATA
+
+If `gh` is not available, or the API call returns no
+data, or the API call fails: proceed to Tier 2.
+
+### Tier 2 — Local worktree baseline
+
+Create a temporary detached worktree of the default
+branch:
+
+```bash
+SHORT_SHA=$(git rev-parse --short=8 ${DEFAULT_BRANCH})
+git worktree add /tmp/preflight-baseline-${SHORT_SHA} \
+  ${DEFAULT_BRANCH} --detach
+```
+
+Run ONLY the tools that failed on the branch in the
+worktree directory. Tools that passed on the branch
+MUST NOT be run against the baseline — they are not
+branch-caused by definition.
+
+```bash
+# For each failing tool, run it in the worktree:
+cd /tmp/preflight-baseline-${SHORT_SHA}
+<tool-command>
+# Record exit code
+```
+
+After running all failing tools, clean up the worktree:
+
+```bash
+git worktree remove \
+  /tmp/preflight-baseline-${SHORT_SHA} --force
+```
+
+Compare exit codes:
+- Tool fails in worktree → baseline FAIL
+- Tool passes in worktree → baseline PASS
+
+### Fallback — conservative classification
+
+If both Tier 1 and Tier 2 fail (e.g., `gh` unavailable
+AND worktree creation fails due to disk space or dirty
+state), or the default branch could not be detected,
+classify ALL failures as `unknown`. The `unknown`
+classification is treated as branch-caused
+(conservative), matching `/review-pr` behavior.
+
+Record which baseline method was used: `CI API`,
+`worktree`, or `unavailable`.
+
+---
+
+## Phase 4b: Causality Classification (soft-gate only)
+
+This phase runs only in `soft-gate` mode, after Phase 4a
+has established a baseline.
+
+For each failing tool from Phase 4, classify it using
+the baseline result from Phase 4a:
+
+| Baseline status | Branch status | Classification |
+|-----------------|---------------|----------------|
+| Pass            | Fail          | **branch-caused** |
+| Fail            | Fail          | **pre-existing** |
+| No data         | Fail          | **unknown** (treat as branch-caused) |
+
+### Gate decision
+
+After classifying all failures:
+
+- If ANY failures are `branch-caused` or `unknown`:
+  verdict is **FAIL (branch-caused)**. The consuming
+  command MUST NOT proceed past the pre-flight gate.
+- If ALL failures are `pre-existing`: verdict is
+  **PASS**. The consuming command MAY proceed, with
+  pre-existing failures reported as informational
+  findings.
+
 ---
 
 ## Phase 5: Result Format
 
-Present results in a standardized format:
+Present results in a standardized format.
+
+### hard-gate and ci-aware modes
 
 ```
 ## Pre-flight Results
@@ -216,7 +381,42 @@ Present results in a standardized format:
 - **Failures**: [list if any]
 ```
 
+### soft-gate mode
+
+```
+## Pre-flight Results
+
+### CI Coverage Matrix
+| Local tool | CI check | CI status | Run locally? |
+|------------|----------|-----------|--------------|
+| ...        | ...      | ...       | ...          |
+
+### Execution Results
+| Tool | Command | Exit code | Status | Causality |
+|------|---------|-----------|--------|-----------|
+| ...  | ...     | ...       | ...    | ...       |
+
+### Verdict
+- **Mode**: soft-gate
+- **Result**: PASS | FAIL (branch-caused)
+- **Branch-caused failures**: [list if any]
+- **Pre-existing failures**: [list if any]
+- **Baseline method**: CI API | worktree | unavailable
+```
+
+The `Causality` column in the Execution Results table
+contains one of: `branch-caused`, `pre-existing`,
+`unknown`, or `—` (for tools that passed).
+
+The `Result` field is:
+- `PASS` if no branch-caused or unknown failures exist
+  (even if pre-existing failures exist)
+- `FAIL (branch-caused)` if any branch-caused or unknown
+  failures exist
+
 The consuming command uses this result to decide whether
-to proceed (hard-gate: stop on FAIL) or to include
-failure context in AI review (ci-aware: continue with
-context).
+to proceed:
+- `hard-gate`: stop on FAIL
+- `ci-aware`: continue with failure context for AI review
+- `soft-gate`: stop on FAIL (branch-caused), continue
+  with pre-existing failures as informational findings

--- a/.opencode/skills/replicator-cli/SKILL.md
+++ b/.opencode/skills/replicator-cli/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: replicator-cli
 description: Replicator CLI quick reference
 tags: [cli, reference, replicator]
 ---

--- a/.opencode/skills/review-context/SKILL.md
+++ b/.opencode/skills/review-context/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: review-context
+description: "Shared review context discovery for spec artifacts, linked issues, path classification, and walkthrough generation."
+---
+<!-- scaffolded by uf vdev -->
+# Skill: Review Context Discovery
+
+Shared logic for discovering and loading review context
+before a review command begins its analysis. Consuming
+commands load this skill to standardize how spec
+artifacts, linked issues, path classifications, and
+walkthrough summaries are discovered and formatted.
+
+## Consumers
+
+| Command | How it loads | Notes |
+|---------|-------------|-------|
+| `/review-pr` | Skill tool | Replaces inline Steps 6-8 logic |
+| `/review-council` | Skill tool | Phase 1c — Protocols 1, 3, 4 (skips Protocol 2: no PR body) |
+| `/address-feedback` | Skill tool | Replaces inline fallback (line 143) |
+
+The consuming command specifies which protocols to
+execute based on the available inputs (e.g., a local
+review has no PR body to parse for issue links).
+
+---
+
+## Protocol 1: Spec Artifact Discovery
+
+Locate the specification associated with the current
+change. The discovery order is deterministic — stop at
+the first match.
+
+### Step 1: Branch name matching
+
+Derive the spec directory from the current branch name
+or PR branch name:
+
+| Branch pattern | Spec location |
+|---------------|---------------|
+| `NNN-<name>` (digits then dash) | `specs/<branch-name>/spec.md` (Speckit) |
+| `opsx/<name>` | `openspec/changes/<name>/proposal.md` (OpenSpec changes) |
+| `opsx/<name>` | `openspec/specs/<name>/spec.md` (OpenSpec specs) |
+
+### Step 2: PR description parsing
+
+If no spec is found via branch name and a PR description
+is available, scan for explicit spec references (e.g.,
+"See spec 012" or "Implements specs/012-swarm/spec.md").
+
+### Step 3: Changed-file detection
+
+If no spec is found via branch name or PR description,
+check the changed file list for spec artifacts. The spec
+may be introduced by the change itself. If found in
+changed files, read the spec content from the diff
+rather than from the filesystem.
+
+### Step 4: Read relevant sections
+
+When a spec is found, read only the sections relevant
+to review to minimize token usage:
+
+| Spec type | Sections to read |
+|-----------|-----------------|
+| Speckit | Functional Requirements, User Stories |
+| OpenSpec proposal | Capabilities, Impact |
+| OpenSpec spec | Requirements, Acceptance Criteria |
+
+### Step 5: No spec found
+
+If no spec is found in any directory or in the changed
+files, note this and use the PR title/description or
+branch name as the intent source. No error or warning
+needed — not every change has a spec.
+
+---
+
+## Protocol 2: Issue Linking
+
+Parse and fetch linked issues to extract acceptance
+criteria for alignment checking. This protocol applies
+when a PR body is available. For local reviews without
+a PR, skip this protocol.
+
+### Step 1: Parse issue references
+
+Parse the PR body for issue references using
+case-insensitive matching:
+
+- `Fixes #N`, `Closes #N`, `Resolves #N`
+- GitHub URL variants:
+  `Fixes https://github.com/<owner>/<repo>/issues/N`
+
+### Step 2: Validate references
+
+Apply all of the following validation controls:
+
+- **Digits-only validation**: Each parsed issue number
+  MUST be a positive integer (digits only). Discard
+  non-numeric values.
+- **Same-repo URL scoping**: URL-format references MUST
+  belong to the same `{owner}/{repo}` as the PR. List
+  cross-repo references in the output as "cross-repo —
+  not validated" but do NOT fetch them.
+- **Fetch limit**: Maximum 5 linked issues. If more
+  than 5 are found, list extras as "listed but not
+  fetched" in the output.
+
+### Step 3: Fetch linked issues
+
+For each validated, in-scope linked issue:
+
+```bash
+gh issue view <N> --json title,body,labels
+```
+
+### Step 4: Sanitize fetched content
+
+Issue body content is user-controlled and untrusted.
+Before incorporating into the review context:
+
+- **Body truncation**: Truncate to a maximum of 2000
+  characters.
+
+### Step 5: Extract acceptance criteria
+
+From each fetched issue body, extract:
+
+- Checkbox lines (`- [ ]` or `- [x]`)
+- Content under an `## Acceptance Criteria` heading
+
+If neither exists, use the issue title and body as
+general intent context.
+
+### Step 6: Error handling
+
+If `gh issue view` returns 404, 403, or times out:
+
+- Log the error
+- Skip that issue
+- Note in the output as "fetch failed"
+- Continue without blocking — the review proceeds
+  with available data
+
+Record the linked issues and their acceptance criteria
+for use by the consuming command.
+
+---
+
+## Protocol 3: Path-Based Focus Heuristics
+
+Classify each changed file against built-in heuristics
+to guide review emphasis. The classification is additive
+— it supplements standard review categories, not
+replaces them.
+
+### Classification table
+
+| Path pattern | Focus category | Additional emphasis |
+|-------------|---------------|-------------------|
+| `*_test.go`, `*_test.py`, `**/__tests__/**`, `**/*_spec.*` | `test-quality` | Edge cases, assertion strength, mock isolation, test naming |
+| `**/cmd/**`, `**/cli/**` | `cli-ux` | Error messages, flag validation, help text |
+| `**/api/**`, `**/handler/**`, `**/middleware/**`, `**/routes/**` | `security` | Auth, input validation, injection |
+| `*.md`, `docs/**` | `documentation` | Clarity, accuracy, broken links |
+| `.github/workflows/**`, `Dockerfile*` | `ci-cd` | Permissions, pinned versions, secrets exposure |
+| `go.mod`, `package.json`, `requirements.txt` | `dependencies` | Maintenance status, license, scope |
+| Everything else | `standard` | Architecture, SOLID, coupling, baseline security |
+
+### Application
+
+For each changed file:
+
+1. Match the file path against the table (first match
+   wins for multi-match paths).
+2. Record the focus category.
+3. When reviewing the file, append the matched focus
+   instruction to the review context for that file.
+
+Security review (auth, input validation, injection)
+applies to ALL changed files regardless of path
+heuristic — the `security` focus category adds
+additional emphasis, not exclusive coverage.
+
+---
+
+## Protocol 4: Walkthrough Generation
+
+Generate a per-file change summary table while
+analyzing each file's diff. The walkthrough is produced
+alongside the review, not as a separate pass.
+
+### Standard format (< 30 files)
+
+```markdown
+### Walkthrough
+| File | Change | Focus |
+|------|--------|-------|
+| `internal/gateway/provider.go` | Add token expiry tracking | security |
+| `internal/gateway/gateway_test.go` | Add regression test for stale tokens | test-quality |
+| `cmd/unbound-force/gateway.go` | Register --provider flag | cli-ux |
+```
+
+### Directory-level format (>= 30 files)
+
+For PRs with 30 or more changed files, generate
+directory-level summaries instead of per-file
+summaries:
+
+```markdown
+### Walkthrough
+| Directory | Files | Summary | Focus |
+|-----------|-------|---------|-------|
+| `internal/gateway/` | 4 | Token refresh and provider abstraction | security |
+| `cmd/unbound-force/` | 2 | CLI flag registration | cli-ux |
+```
+
+### Change descriptions
+
+Each change summary describes **what** changed (e.g.,
+"Add error handling for null inputs"), not **how** (no
+code snippets). Keep summaries to one line.
+
+---
+
+## Result Format
+
+Present the discovered context in a standardized
+format that consuming commands can reference:
+
+```
+## Review Context
+
+### Specification
+- Type: Speckit | OpenSpec | None
+- Path: specs/012-swarm/spec.md
+- Sections loaded: Functional Requirements, User Stories
+
+### Linked Issues
+| Issue | Title | Criteria |
+|-------|-------|----------|
+| #42 | Add auth endpoint | 3 checkboxes extracted |
+| #43 | Fix token refresh | Acceptance Criteria section |
+
+### File Classification
+| File | Focus |
+|------|-------|
+| ... | ... |
+
+### Walkthrough
+| File | Change | Focus |
+|------|--------|-------|
+| ... | ... | ... |
+```
+
+The consuming command uses this context to inform its
+review analysis and output formatting.

--- a/.opencode/skills/system-design/SKILL.md
+++ b/.opencode/skills/system-design/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: system-design
 description: System design principles for clean architecture
 tags: [design, architecture, principles]
 ---

--- a/.opencode/skills/testing-patterns/SKILL.md
+++ b/.opencode/skills/testing-patterns/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: testing-patterns
 description: Go testing patterns for the replicator project
 tags: [testing, go, patterns]
 ---


### PR DESCRIPTION
## Summary

Re-run `uf init` and `replicator init --force` to propagate the`name` field fix from unbound-force/unbound-force#309 and
unbound-force/replicator#28. All skills now have the required `name` field in YAML frontmatter, making them discoverable by OpenCode's `skill` tool.

Without this fix, `/review-council`, `/review-pr`, and `/unleash` fail with "Skill not found" when attempting to load `pre-flight`.

## Changes

### Skills — `name` field added (via `replicator init --force`)

| Skill | Added field |
|-------|------------|
| `always-on-guidance/SKILL.md` | `name: always-on-guidance` |
| `forge-coordination/SKILL.md` | `name: forge-coordination` |
| `forge-global/SKILL.md` | `name: forge-global` |
| `learning-systems/SKILL.md` | `name: learning-systems` |
| `replicator-cli/SKILL.md` | `name: replicator-cli` |
| `system-design/SKILL.md` | `name: system-design` |
| `testing-patterns/SKILL.md` | `name: testing-patterns` |

### New files (from `uf init`)

- Skills: `review-context/SKILL.md`

### Updated files (from `uf init`)

- Skills: `pre-flight/SKILL.md` (`name` field + latest content)
- Commands: `address-feedback.md`, `review-council.md`, `review-pr.md`, `uf-init.md`

## No production code changes

This PR only touches agent tooling, skill files, and command files.

## Verification

- All 14 skills have `name` field matching directory name
- No Go test packages in this repo

## Context

Issue pre-existing for other skills but discovered via  [unbound-force/unbound-force#309](https://github.com/unbound-force/unbound-force/issues/309).
Scaffold sources fixed in [unbound-force/unbound-force#317](https://github.com/unbound-force/unbound-force/pull/317)
and [unbound-force/replicator#30](https://github.com/unbound-force/replicator/pull/30).

Ref: unbound-force/unbound-force#316
